### PR TITLE
Add a noscript warning to the dashboard

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -104,3 +104,10 @@ body[data-controller="publishers"]
     padding: 10px
     color: #666
 
+  .noscript-warning
+    text-align: center
+    background: #f0f0f0
+    border: 1px solid #ccc
+    padding: 10px
+    margin-bottom: 20px
+    color: #333

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -173,6 +173,9 @@ javascript:
     }, false);
   })();
 
+noscript
+  div.noscript-warning = t("publishers.dashboard_noscript")
+
 - content_for(:navbar_content) do
   span= I18n.t("publishers.dashboard")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
     create_auth_token_body: "Please check your email for the login link."
     domain: "Domain"
     dashboard: "Dashboard"
+    dashboard_noscript: "Please enable JavaScript in your browser if you wish to interact with the dashboard."
     email_confirmed: "Your updated email address %{email} has been confirmed."
     finished_header: "Thank you for registering with Brave Payments!"
     finished_intro: "You will see an initial transfer to your Uphold account as soon as we process payments, which happens on the last day of every month. If you'd prefer a different payment schedule please contact us."


### PR DESCRIPTION
The dashboard requires JavaScript for much of its functionality.

[Fixes #111]

<img width="1028" alt="screen shot 2017-09-22 at 8 30 59 am" src="https://user-images.githubusercontent.com/29122/30744781-a573beba-9f71-11e7-8f15-489983898aaa.png">
