### PR TITLE
Verify offline using .well-known public files

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -195,6 +195,7 @@ class PublishersController < ApplicationController
   # TODO: Rate limit
   # TODO: Support XHR
   def verify
+    @publisher = current_publisher
     require "faraday"
     PublisherVerifier.new(
       brave_publisher_id: current_publisher.brave_publisher_id,

--- a/app/services/publisher_host_inspector.rb
+++ b/app/services/publisher_host_inspector.rb
@@ -1,9 +1,8 @@
-require 'net/http'
+require 'publishers/fetch'
 
 # Inspect a brave_publisher_id's host for web_host and HTTPS support
 class PublisherHostInspector
-  class RedirectError < StandardError; end
-  class ConnectionFailedError < StandardError; end
+  include Publishers::Fetch
 
   attr_reader :brave_publisher_id, :follow_local_redirects, :follow_all_redirects, :require_https, :check_web_host
 
@@ -19,45 +18,12 @@ class PublisherHostInspector
     @require_https = require_https
   end
 
-  # Fetch URI, following redirects per options
-  def fetch(uri, limit = 10)
-    raise RedirectError.new('too many HTTP redirects') if limit == 0
-
-    begin
-      response = Net::HTTP.get_response(uri)
-
-      case response
-        when Net::HTTPSuccess then
-          response
-        when Net::HTTPRedirection then
-          raise RedirectError.new('redirects prohibited') unless follow_all_redirects || follow_local_redirects
-
-          location = response['location']
-          new_uri = URI.parse(location)
-
-          # Tests if redirect is relative or if it's to a new host or page in the same domain
-          local_redirect = new_uri.relative? || new_uri.host.end_with?(uri.host)
-
-          if local_redirect && follow_local_redirects
-            new_uri = URI(uri + location)
-          elsif !follow_all_redirects
-            raise RedirectError.new('non local redirects prohibited')
-          end
-
-          fetch(new_uri, limit - 1)
-        else
-          response.value
-      end
-
-    rescue => e
-      raise ConnectionFailedError.new(e)
-    end
-  end
-
   # ToDo: github pages can be hosted at custom domains. We should detect them, if possible.
   # ToDo: perform better https test than just raising when the connection is refused?
   def inspect_uri(uri)
-    response = fetch(uri)
+    response = fetch(uri: uri,
+                     follow_all_redirects: follow_all_redirects,
+                     follow_local_redirects: follow_local_redirects)
 
     if check_web_host
       web_host = if brave_publisher_id.include?(".github.io")
@@ -70,7 +36,7 @@ class PublisherHostInspector
     end
 
     { response: response, web_host: web_host }
-  rescue RedirectError, ConnectionFailedError => e
+  rescue Publishers::Fetch::RedirectError, Publishers::Fetch::ConnectionFailedError => e
     { response: e }
   end
 

--- a/app/services/publisher_verifier.rb
+++ b/app/services/publisher_verifier.rb
@@ -1,7 +1,11 @@
+require 'publishers/fetch'
+
 # Request verification from Eyeshade. Sets the matching
 # If the publisher previously has been verified, you can't reverify (for now)
 # TODO: Rate limit
 class PublisherVerifier < BaseApiClient
+  include Publishers::Fetch
+
   attr_reader :attended, :brave_publisher_id, :publisher, :verified_publisher, :verified_publisher_id
 
   # publisher is optional. If given, service will raise errors if the provided publisher's verification token
@@ -73,6 +77,30 @@ class PublisherVerifier < BaseApiClient
   end
 
   def verify_offline_publisher_id
+    Rails.logger.info("PublisherVerifier offline by #{publisher.verification_method}")
+
+    case publisher.verification_method
+      when "dns_record"
+        verify_offline_publisher_id_dns
+      when "public_file"
+        verify_offline_publisher_id_public_file
+      when "github"
+        verify_offline_publisher_id_public_file
+      when "wordpress"
+        verify_offline_publisher_id_public_file
+      when "support_queue"
+        verify_offline_publisher_id_support_queue
+      else
+        Rails.logger.info("PublisherVerifier unknown verification_method: #{publisher.verification_method}")
+        nil
+    end
+  end
+
+  def verify_offline_publisher_id_support_queue
+    nil
+  end
+
+  def verify_offline_publisher_id_dns
     require "dnsruby"
     resolver = Dnsruby::Resolver.new
     message = resolver.query(brave_publisher_id, "TXT")
@@ -96,6 +124,28 @@ class PublisherVerifier < BaseApiClient
     nil
   rescue Dnsruby::NXDomain
     Rails.logger.warn("Dnsruby::NXDomain")
+    nil
+  end
+
+  def verify_offline_publisher_id_public_file
+    generator = PublisherVerificationFileGenerator.new(publisher: publisher)
+    uri = URI("https://#{brave_publisher_id}/.well-known/#{generator.filename}")
+    response = fetch(uri: uri)
+    if response.code == "200"
+      token_match = /#{publisher.verification_token}/.match(response.body)
+      if token_match
+        Rails.logger.warn("verify_offline_publisher_id_public_file: Token Found")
+        publisher.id
+      else
+        Rails.logger.warn("verify_offline_publisher_id_public_file: Token Mismatch")
+        nil
+      end
+    else
+      Rails.logger.warn("verify_offline_publisher_id_public_file: Not Net::HTTPSuccess")
+      nil
+    end
+  rescue Publishers::Fetch::RedirectError, Publishers::Fetch::ConnectionFailedError => e
+    Rails.logger.warn("verify_offline_publisher_id_public_file: #{e.message}")
     nil
   end
 

--- a/lib/publishers/fetch.rb
+++ b/lib/publishers/fetch.rb
@@ -1,0 +1,46 @@
+require 'net/http'
+
+module Publishers
+  module Fetch
+    class RedirectError < StandardError; end
+    class ConnectionFailedError < StandardError; end
+
+    # Fetch URI, following redirects per options
+    def fetch(uri:, limit: 10, follow_all_redirects: false, follow_local_redirects: true)
+      raise RedirectError.new('too many HTTP redirects') if limit == 0
+
+      begin
+        response = Net::HTTP.get_response(uri)
+
+        case response
+          when Net::HTTPSuccess then
+            response
+          when Net::HTTPRedirection then
+            raise RedirectError.new('redirects prohibited') unless follow_all_redirects || follow_local_redirects
+
+            location = response['location']
+            new_uri = URI.parse(location)
+
+            # Tests if redirect is relative or if it's to a new host or page in the same domain
+            local_redirect = new_uri.relative? || new_uri.host.end_with?(uri.host)
+
+            if local_redirect && follow_local_redirects
+              new_uri = URI(uri + location)
+            elsif !follow_all_redirects
+              raise RedirectError.new('non local redirects prohibited')
+            end
+
+            fetch(uri: new_uri,
+                  limit: limit - 1,
+                  follow_all_redirects: follow_all_redirects,
+                  follow_local_redirects: follow_local_redirects)
+          else
+            response.value
+        end
+
+      rescue => e
+        raise ConnectionFailedError.new(e)
+      end
+    end
+  end
+end

--- a/test/services/publisher_host_inspector_test.rb
+++ b/test/services/publisher_host_inspector_test.rb
@@ -75,7 +75,7 @@ class PublisherHostInspectorTest < ActiveJob::TestCase
     refute result[:host_connection_verified]
     refute result[:https]
     assert_nil result[:web_host]
-    assert result[:response].is_a?(PublisherHostInspector::ConnectionFailedError)
+    assert result[:response].is_a?(Publishers::Fetch::ConnectionFailedError)
   end
 
   test "connection to site fails when https fails and http is require_https is true" do
@@ -86,7 +86,7 @@ class PublisherHostInspectorTest < ActiveJob::TestCase
     refute result[:host_connection_verified]
     refute result[:https]
     assert_nil result[:web_host]
-    assert result[:response].is_a?(PublisherHostInspector::ConnectionFailedError)
+    assert result[:response].is_a?(Publishers::Fetch::ConnectionFailedError)
   end
 
   test "follows local redirects" do
@@ -126,7 +126,7 @@ class PublisherHostInspectorTest < ActiveJob::TestCase
     refute result[:host_connection_verified]
     refute result[:https]
     assert_nil result[:web_host]
-    assert result[:response].is_a?(PublisherHostInspector::ConnectionFailedError)
+    assert result[:response].is_a?(Publishers::Fetch::ConnectionFailedError)
     assert_equal "non local redirects prohibited", result[:response].to_s
   end
 


### PR DESCRIPTION
Fix #127

Separates the HTTP fetch logic form the PublisherHostInspector to its
own module to share with the PublisherVerifier.