### PR TITLE
Introduce dynamic Uphold status display and connection options to the Dashboard

### DIFF
--- a/app/assets/javascripts/dynamic_ellipsis.js
+++ b/app/assets/javascripts/dynamic_ellipsis.js
@@ -1,0 +1,27 @@
+(function() {
+
+  var ellipsisIntervals = {};
+
+  this.dynamicEllipsis = {
+    start: function(elementId, durationBetween, maxEllipsis) {
+      var element = document.getElementById(elementId);
+      var text = element.innerText;
+      var count = 0;
+      var max = maxEllipsis || 5;
+      var duration = durationBetween || 200;
+
+      ellipsisIntervals[elementId] = setInterval(function() {
+        var displayText = text;
+        count++;
+        if (count > max) count = 0;
+        for (i = 0; i < count; i++) displayText += '.';
+        element.innerText = displayText;
+      }, duration);
+    },
+
+    stop: function(elementId) {
+      clearInterval(ellipsisIntervals[elementId]);
+    }
+  };
+
+}).call(window);

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -41,6 +41,7 @@ class PublishersController < ApplicationController
              home
              verification_done
              update
+             uphold_status
              uphold_verified)
   before_action :update_publisher_verification_method,
     only: %i(verification_dns_record
@@ -283,6 +284,18 @@ class PublishersController < ApplicationController
     respond_to do |format|
       format.json {
         render(json: { reportURL: report_url }, status: 200)
+      }
+    end
+  end
+
+  def uphold_status
+    publisher = current_publisher
+    respond_to do |format|
+      format.json {
+        render(json: {
+          status: publisher.uphold_status.to_s,
+          description: uphold_status_description(publisher)
+        }, status: 200)
       }
     end
   end

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -224,7 +224,6 @@ class PublishersController < ApplicationController
   # payment information.
   def verification_done
     @publisher = current_publisher
-    @publisher.prepare_uphold_state_token
   end
 
   def uphold_verified

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -3,6 +3,23 @@ module PublishersHelper
     publisher.uphold_status == :verified
   end
 
+  def uphold_status_description(publisher)
+    case publisher.uphold_status
+    when :verified
+      t("publishers.uphold_status_verified")
+    when :access_parameters_acquired
+      t("publishers.uphold_status_access_parameters_acquired")
+    when :code_acquired
+      t("publishers.uphold_status_code_acquired")
+    when :unconnected
+      t("publishers.uphold_status_unconnected")
+    end
+  end
+
+  def show_uphold_connect(publisher)
+    publisher.uphold_status == :unconnected || publisher.uphold_status == :code_acquired
+  end
+
   # balance: Instance of PublisherBalanceGetter::Balance
   def publisher_humanize_balance(publisher)
     if balance = publisher.balance

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -39,6 +39,8 @@ module PublishersHelper
   end
 
   def uphold_authorization_endpoint(publisher)
+    publisher.prepare_uphold_state_token
+
     Rails.application.secrets[:uphold_authorization_endpoint]
         .gsub('<UPHOLD_CLIENT_ID>', Rails.application.secrets[:uphold_client_id])
         .gsub('<UPHOLD_SCOPE>', Rails.application.secrets[:uphold_scope])

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -16,8 +16,12 @@ module PublishersHelper
     end
   end
 
-  def show_uphold_connect(publisher)
+  def show_uphold_connect?(publisher)
     publisher.uphold_status == :unconnected || publisher.uphold_status == :code_acquired
+  end
+
+  def poll_uphold_status?(publisher)
+    publisher.uphold_status == :access_parameters_acquired
   end
 
   # balance: Instance of PublisherBalanceGetter::Balance

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -49,9 +49,6 @@ class Publisher < ApplicationRecord
   def prepare_uphold_state_token
     if self.uphold_state_token.nil?
       self.uphold_state_token = SecureRandom.hex(64)
-      self.uphold_code = nil
-      self.uphold_access_parameters = nil
-      self.uphold_verified = false
       save!
     end
   end

--- a/app/services/publisher_verifier.rb
+++ b/app/services/publisher_verifier.rb
@@ -68,7 +68,6 @@ class PublisherVerifier < BaseApiClient
     if PublisherMailer.should_send_internal_emails?
       PublisherMailer.verification_done_internal(verified_publisher).deliver_later
     end
-    verified_publisher.prepare_uphold_state_token
     SlackMessenger.new(message: "*#{verified_publisher}* verified by #{verified_publisher.name} (#{verified_publisher.email}); id=#{verified_publisher.id}").perform
   end
 

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -148,7 +148,7 @@ javascript:
 
       generateStatement.addEventListener('click', function(event) {
         event.preventDefault();
-        showSpinner();
+
         submitForm('statement_generator', 'PATCH', false)
           .then(function(response) {
             return response.json();
@@ -156,20 +156,21 @@ javascript:
           .then(function(json) {
             generateStatement.style.display = 'none';
             generateStatementResult.style.display = 'inline-block';
-            generateStatementResult.innerText = 'Generating ...';
+            generateStatementResult.innerText = 'Generating';
+
+            dynamicEllipsis.start('generate_statement_result');
 
             return waitForReport(json.reportURL, 3000, 2000, 4);
           })
           .then(function(reportURL) {
-            hideSpinner();
+            dynamicEllipsis.stop('generate_statement_result');
             generateStatementResult.innerHTML = '<a href="' + reportURL + '">View report</a>';
           })
           .catch(function() {
-            hideSpinner();
+            dynamicEllipsis.stop('generate_statement_result');
             generateStatementResult.innerText = 'We will email you a link when your report is ready.'
           });
       }, false);
-
     }, false);
   })();
 

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -174,6 +174,41 @@ javascript:
     }, false);
   })();
 
+- if poll_uphold_status?(current_publisher)
+  javascript:
+    (function() {
+      var checkUpholdStatusInterval;
+
+      function checkUpholdStatus() {
+        var options = {
+          headers: {
+            'Accept': 'application/json'
+          },
+          credentials: 'same-origin',
+          method: 'GET'
+        };
+
+        return window.fetch('./uphold_status', options)
+          .then(function(response) {
+            if (response.status === 200) {
+              return response.json();
+            }
+          })
+          .then(function(body) {
+            if (body.status === 'verified') {
+              document.getElementById('uphold_status').innerText = body.description;
+              dynamicEllipsis.stop('uphold_status');
+              clearInterval(checkUpholdStatusInterval);
+            }
+          });
+      }
+
+      window.addEventListener('load', function() {
+        dynamicEllipsis.start('uphold_status');
+        checkUpholdStatusInterval = setInterval(checkUpholdStatus, 2000);
+      });
+    })();
+
 noscript
   div.noscript-warning = t("publishers.dashboard_noscript")
 
@@ -201,7 +236,7 @@ div#cssload-pgloading style="display: none"
       h4= I18n.t("publishers.uphold_status")
       .attribute-value.status
         p#uphold_status= uphold_status_description(current_publisher)
-        - if show_uphold_connect(current_publisher)
+        - if show_uphold_connect?(current_publisher)
           div#uphold_connect
             p.help-block= t("publishers.verification_done_submit_payment_info_body")
             p= link_to(image_tag("uphold-connect-white@1x.png"), uphold_authorization_endpoint(current_publisher))

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -197,15 +197,13 @@ div#cssload-pgloading style="display: none"
         - if !current_publisher.verified?
           span.link-hint.publisher-verified-status= I18n.t("publishers.not_verified")
 
-      h4= I18n.t("publishers.status")
+      h4= I18n.t("publishers.uphold_status")
       .attribute-value.status
-        - if publisher_can_receive_funds?(current_publisher)
-          div= I18n.t("publishers.status_can_receive_funds")
-        - else
-          div= I18n.t("publishers.status_to_receive_payments")
-          ul
-            - if current_publisher.uphold_status != :verified #ToDo: Further breakdown
-              li= I18n.t("publishers.status_connect_to_uphold_required")
+        p#uphold_status= uphold_status_description(current_publisher)
+        - if show_uphold_connect(current_publisher)
+          div#uphold_connect
+            p.help-block= t("publishers.verification_done_submit_payment_info_body")
+            p= link_to(image_tag("uphold-connect-white@1x.png"), uphold_authorization_endpoint(current_publisher))
 
       h4= I18n.t("publishers.balance_pending")
       .attribute-value.balance

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,6 @@ en:
     complete_irs_w_9_hint: "United States taxpayers"
     complete_irs_w_8ben: "Complete IRS W-8BEN"
     complete_irs_w_8ben_hint: "Individuals outside the States"
-    connect_with_uphold: "Create BAT Wallet"
     contact_person: "Contact person"
     create_done_header: "We're excited that you want to be in on Brave Bounty!"
     create_done_body_html: |
@@ -95,11 +94,12 @@ en:
       verify_site: "Verify Your Site"
       create_wallet: "Create Your Wallet"
     publisher_statements: "Publisher statements"
-    status: "Status"
-    status_to_receive_payments: "To receive payments you need to:"
-    status_can_receive_funds: "You are fully setup to receive Brave Payments."
-    status_connect_to_uphold_required: "Connect to an Uphold account."
     email_verified_phone: "Phone (optional)"
+    uphold_status: "Status"
+    uphold_status_verified: "Your Uphold wallet is ready to receive Brave Payments."
+    uphold_status_access_parameters_acquired: "Connecting your Uphold account."
+    uphold_status_code_acquired: "A problem was experienced connecting your Uphold account."
+    uphold_status_unconnected: "Not connected to Uphold."
     verified: "Verified publisher"
     verification_dns_record_help: "To verify ownership of your site, you'll need to add a new DNS record for "
     verification_dns_record_help_2: " using the account for your DNS host."
@@ -115,7 +115,7 @@ en:
     verification_done_balance_html: |
       <p>%{bat_balance}</p>
     verification_done_submit_payment_info: "Ready to claim your funds now?"
-    verification_done_submit_payment_info_body: "To claim your funds, you will needs to create a wallet via Uphold. Please click on the Connect button."
+    verification_done_submit_payment_info_body: "To claim your funds, you'll need to create a wallet via Uphold. Please click the Connect button."
     verification_form_legend: "Verify website ownership"
 
     verification_choose_header: "Verify your Site: Choose a method"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       get :verification_github
       get :verification_wordpress
       get :verification_support_queue
+      get :uphold_status
       get :uphold_verified
       patch :verify
       patch :check_for_https

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -373,4 +373,30 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_response 200
     assert_match("{\"reportURL\":\"/publishers/home\"}", response.body)
   end
+  
+  test "a publisher's uphold_status can be polled via ajax" do
+    perform_enqueued_jobs do
+      post(publishers_path, params: SIGNUP_PARAMS)
+    end
+    publisher = Publisher.order(created_at: :asc).last
+    url = publisher_url(publisher, token: publisher.authentication_token)
+    get(url)
+    follow_redirect!
+    perform_enqueued_jobs do
+      patch(update_unverified_publishers_path, params: PUBLISHER_PARAMS)
+    end
+
+    publisher.show_verification_status = false
+    publisher.verified = true
+    publisher.save!
+
+    assert_equal false, publisher.show_verification_status
+
+    url = uphold_status_publishers_path
+    get(url,
+        headers: { 'HTTP_ACCEPT' => "application/json" })
+
+    assert_response 200
+    assert_match("{\"status\":\"unconnected\",\"description\":\"Not connected to Uphold.\"}", response.body)
+  end
 end

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -33,16 +33,12 @@ class PublisherTest < ActiveSupport::TestCase
     assert_equal [:uphold_access_parameters], publisher.errors.keys
   end
 
-  test "prepare_uphold_state_token generates a new uphold_state_token and clears other uphold fields" do
+  test "prepare_uphold_state_token generates a new uphold_state_token if one does not already exist" do
     publisher = publishers(:verified)
-    publisher.uphold_code = "foo"
-    publisher.uphold_access_parameters = "bar"
-    publisher.uphold_verified = false
+    publisher.uphold_state_token = nil
     publisher.prepare_uphold_state_token
 
     assert publisher.uphold_state_token
-    assert_nil publisher.uphold_code
-    assert_nil publisher.uphold_access_parameters
     assert publisher.valid?
 
     uphold_state_token = publisher.uphold_state_token


### PR DESCRIPTION
The Uphold status is now displayed on a publisher's dashboard. If appropriate, the publisher is given the opportunity to connect with Uphold. Furthermore, if the Uphold data is still being processed in the background, the user is shown a processing message which dynamically changes the number of dots in a trailing ellipsis. This gives the impression of progress without taking over the UI like the current spinner we've been using. Obviously, this can all be tweaked if we decide to show progress in another way.

[Resolves #112]