### PR TITLE
Remove `transactions` from UPHOLD_SCOPE

### DIFF
--- a/docs/publishers-secrets.example.sh
+++ b/docs/publishers-secrets.example.sh
@@ -27,4 +27,4 @@ export UPHOLD_CLIENT_ID="" # Client ID for registered Uphold application
 export UPHOLD_CLIENT_SECRET="" # Client secret for registered Uphold application
 export UPHOLD_AUTHORIZATION_ENDPOINT="https://sandbox.uphold.com/authorize/<UPHOLD_CLIENT_ID>?scope=<UPHOLD_SCOPE>&intention=signup&state=<STATE>"
 export UPHOLD_API_URI="https://api-sandbox.uphold.com" # the API endpoint for Uphold.
-export UPHOLD_SCOPE="cards:read,user:read,transactions:transfer:others"
+export UPHOLD_SCOPE="cards:read,cards:write,user:read"


### PR DESCRIPTION
According to @mrose17, the `transactions` param is not needed.

Note: this change only affects the _documentation_. The `transactions` param should also be removed from env vars.