### PR TITLE
Revert d667863 and instead use a shared error handler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sentry-raven (2.4.0)
+    sentry-raven (2.6.3)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include ErrorHandler
+
   if Rails.application.secrets[:basic_auth_user] && Rails.application.secrets[:basic_auth_password]
     http_basic_authenticate_with(
       name: Rails.application.secrets[:basic_auth_user],

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -210,8 +210,7 @@ class PublishersController < ApplicationController
     end
   rescue PublisherVerifier::VerificationIdMismatch
     redirect_to(publisher_last_verification_method_path(@publisher), alert: t("activerecord.errors.models.publisher.attributes.brave_publisher_id.taken"))
-  rescue Faraday::Error => e
-    Raven.capture_exception(e)
+  rescue Faraday::Error
     redirect_to(publisher_last_verification_method_path(@publisher), alert: t("shared.api_error"))
   end
 

--- a/app/jobs/enqueue_publisher_verifications.rb
+++ b/app/jobs/enqueue_publisher_verifications.rb
@@ -1,6 +1,6 @@
 # For Publishers created recently, enqueue jobs to verify each unique
 # brave_publisher_id.
-class EnqueuePublisherVerifications < ActiveJob::Base
+class EnqueuePublisherVerifications < ApplicationJob
   MAX_AGE = 6.weeks
 
   queue_as :scheduler

--- a/app/jobs/verify_publisher.rb
+++ b/app/jobs/verify_publisher.rb
@@ -1,5 +1,5 @@
 # Verify all Publishers created in past 2 weeks with brave_publisher_id
-class VerifyPublisher < ActiveJob::Base
+class VerifyPublisher < ApplicationJob
   queue_as :default
 
   require "faraday"

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -120,8 +120,7 @@ class Publisher < ApplicationRecord
     )
   rescue PublisherDomainNormalizer::OfflineNormalizationError => e
     errors.add(:brave_publisher_id, e.message)
-  rescue Faraday::Error => e
-    Raven.capture_exception(e)
+  rescue Faraday::Error
     errors.add(
       :brave_publisher_id,
       I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.api_error_cant_normalize")

--- a/app/services/base_api_client.rb
+++ b/app/services/base_api_client.rb
@@ -1,4 +1,6 @@
-class BaseApiClient
+class BaseApiClient < BaseService
+  include ErrorHandler
+
   private
 
   def api_base_uri

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -1,0 +1,11 @@
+class BaseService
+  require "error_handler_delegator"
+
+  def self.new(*args, &block)
+    ErrorHandlerDelegator.new(super)
+  end
+
+  def self.instance
+    @__instance__ ||= new
+  end
+end

--- a/app/services/publisher_balance_getter.rb
+++ b/app/services/publisher_balance_getter.rb
@@ -21,7 +21,6 @@ class PublisherBalanceGetter < BaseApiClient
     # {"amount"=>42, "currency"=>"USD", "satoshis"=>0}
     Balance.new(response_hash["amount"], response_hash["currency"], response_hash["satoshis"])
   rescue Faraday::Error => e
-    Raven.capture_exception(e)
     Rails.logger.warn("PublisherBalanceGetter #perform error: #{e}")
     nil
   end

--- a/app/services/publisher_dns_record_generator.rb
+++ b/app/services/publisher_dns_record_generator.rb
@@ -1,6 +1,6 @@
 # An option for domain verification.
 
-class PublisherDnsRecordGenerator
+class PublisherDnsRecordGenerator < BaseService
   attr_reader :publisher
 
   def initialize(publisher:)

--- a/app/services/publisher_host_inspector.rb
+++ b/app/services/publisher_host_inspector.rb
@@ -1,7 +1,7 @@
 require 'publishers/fetch'
 
 # Inspect a brave_publisher_id's host for web_host and HTTPS support
-class PublisherHostInspector
+class PublisherHostInspector < BaseService
   include Publishers::Fetch
 
   attr_reader :brave_publisher_id, :follow_local_redirects, :follow_all_redirects, :require_https, :check_web_host

--- a/app/services/publisher_login_link_emailer.rb
+++ b/app/services/publisher_login_link_emailer.rb
@@ -1,5 +1,5 @@
 # "Magic sign in link" / One time sign-in token via email
-class PublisherLoginLinkEmailer
+class PublisherLoginLinkEmailer < BaseService
   attr_accessor :error
   attr_reader :brave_publisher_id, :normal_publisher_id, :email, :publisher
 
@@ -21,8 +21,7 @@ class PublisherLoginLinkEmailer
     @normal_publisher_id = PublisherDomainNormalizer.new(
       domain: brave_publisher_id
     ).perform
-  rescue PublisherDomainNormalizer::DomainExclusionError, Faraday::Error => e
-    Raven.capture_exception(e)
+  rescue PublisherDomainNormalizer::DomainExclusionError, Faraday::Error
     @error = I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.api_error_cant_normalize")
     false
   rescue URI::InvalidURIError

--- a/app/services/publisher_notifier.rb
+++ b/app/services/publisher_notifier.rb
@@ -1,5 +1,5 @@
 # TODO: Generalized Notifier service class
-class PublisherNotifier
+class PublisherNotifier < BaseService
   attr_reader :notification_params, :notification_type, :publisher
 
   # Should match methods in NotificationMailer starting with #publisher_*

--- a/app/services/publisher_token_authenticator.rb
+++ b/app/services/publisher_token_authenticator.rb
@@ -1,6 +1,6 @@
 # Authenticate a Publisher by #authentication_token, which are consumed on use
 # and expires after 3 hours. New ones can be sent to your email.
-class PublisherTokenAuthenticator
+class PublisherTokenAuthenticator < BaseService
   attr_reader :publisher, :token, :confirm_email
 
   def initialize(publisher:, token:, confirm_email:)

--- a/app/services/publisher_token_generator.rb
+++ b/app/services/publisher_token_generator.rb
@@ -1,7 +1,7 @@
 # Generate a Publisher #authentication_token, which is a one time use token
 # for creating a login session. They expire after 3 hours.
 # @returns new authentication_token
-class PublisherTokenGenerator
+class PublisherTokenGenerator < BaseService
   TOKEN_TTL = 3.hours
 
   attr_reader :publisher

--- a/app/services/publisher_verification_file_generator.rb
+++ b/app/services/publisher_verification_file_generator.rb
@@ -1,6 +1,6 @@
 # An option for domain verification.
 
-class PublisherVerificationFileGenerator
+class PublisherVerificationFileGenerator < BaseService
   attr_reader :publisher
 
   def initialize(publisher:)

--- a/app/services/uphold_request_access_parameters.rb
+++ b/app/services/uphold_request_access_parameters.rb
@@ -1,6 +1,6 @@
 require "faraday"
 
-class UpholdRequestAccessParameters
+class UpholdRequestAccessParameters < BaseService
   class InvalidGrantError < StandardError; end
 
   attr_reader :publisher
@@ -44,7 +44,6 @@ class UpholdRequestAccessParameters
       nil
     end
   rescue Faraday::Error => e
-    Raven.capture_exception(e)
     Rails.logger.warn("UpholdRequestAccessParameters #perform error: #{e}")
     nil
   end

--- a/config/initializers/init_notifier.rb
+++ b/config/initializers/init_notifier.rb
@@ -8,7 +8,6 @@ if Rails.env.production?
       message: message
     ).perform
   rescue Faraday::Error => e
-    Raven.capture_exception(e)
     Rails.logger.warn("Couldn't notify Slack in notify_boot.rb: #{e}\n#{message} -- falling back to logger")
   end
 end

--- a/lib/error_handler.rb
+++ b/lib/error_handler.rb
@@ -1,0 +1,29 @@
+# A module with global error handling logic (to send to Sentry)
+# In your class:
+#   include ErrorHandler
+# Then proceed to rescue things normally.
+module ErrorHandler
+  extend ActiveSupport::Concern
+
+  included do
+    include ActiveSupport::Rescuable
+    rescue_from StandardError, with: :handle_standard_error
+  end
+
+  def handle_known_exceptions
+    yield
+  rescue => exception
+    rescue_with_handler(exception)
+    # reraise to run normal exception handling
+    raise
+  end
+
+  def handle_standard_error(exception)
+    if %w(production staging).include?(Rails.env)
+      require "sentry-raven"
+      Raven.capture_exception(exception)
+    else
+      Rails.logger.warn(exception)
+    end
+  end
+end

--- a/lib/error_handler_delegator.rb
+++ b/lib/error_handler_delegator.rb
@@ -1,0 +1,14 @@
+class ErrorHandlerDelegator
+  require "error_handler"
+  include ErrorHandler
+
+  def initialize(target)
+    @target = target
+  end
+
+  def method_missing(*args, &block)
+    handle_known_exceptions do
+      @target.send(*args, &block)
+    end
+  end
+end


### PR DESCRIPTION
@evq has been staging the new BAT website and expressed the desire for more comprehensive exception logging, especially API errors.
Currently only unhandled exceptions are sent to our reporting service Sentry; and we handle most exceptions to ensure a good UX (e.g. prevent API 500s from reaching the user instead saying "API Error").

Rather than doing `Raven.capture_exception` everywhere we handle exceptions, I've instead added some metaprogramming to `BaseService` and `ApplicationJob`. I know this is a controversial Ruby style, but weighing the complexity downsides vs quality of life improvements for our ops team I think this is the most pragmatic way.

(Also upgrades Sentry to 2.6.3.)

Auditors: @dgeb @lgebhardt @bsclifton 