### PR TITLE
Landing page cleanup

### DIFF
--- a/app/assets/stylesheets/application/static.sass
+++ b/app/assets/stylesheets/application/static.sass
@@ -21,7 +21,7 @@ body[data-controller="static"]
     letter-spacing: 0.02em
 
   .logo
-    margin-top: 45px
+    margin-top: 20px
 
   .main-heading
     h2
@@ -61,9 +61,10 @@ body[data-controller="static"]
     width: 100%
     margin-left: 0px
 
+  .welcome
+    margin-top: 25px
+
   @media (max-width: 767px)
-    .welcome
-      margin-top: 25px
     .col-centered
       float: none
       margin: 0 auto
@@ -71,8 +72,6 @@ body[data-controller="static"]
       padding-right: 30px
 
   @media (max-width: 991px)
-    .welcome
-      margin-top: 25px
     .col-centered
       float: none
       margin: 0 auto
@@ -80,8 +79,6 @@ body[data-controller="static"]
       padding-right: 40px
 
   @media (min-width: 992px)
-    .welcome
-      margin-top: 65px
     .col-left
       padding-left: 70px
       padding-right: 30px
@@ -90,8 +87,6 @@ body[data-controller="static"]
       padding-right: 70px
 
   @media (min-width: 1200px)
-    .welcome
-      margin-top: 65px
     .col-left
       padding-left: 120px
       padding-right: 30px

--- a/app/assets/stylesheets/application/static.sass
+++ b/app/assets/stylesheets/application/static.sass
@@ -9,7 +9,6 @@ body[data-controller="static"]
   background-position: top right
 
   color: white
-  font-family: 'Open Sans', sans-serif
   font-size: 16px
   font-weight: 300
   letter-spacing: 0.02em
@@ -17,7 +16,6 @@ body[data-controller="static"]
   p
     padding-bottom: 15px
     color: white
-    font-family: 'Open Sans', sans-serif
     font-size: 16px
     font-weight: 300
     letter-spacing: 0.02em
@@ -45,7 +43,6 @@ body[data-controller="static"]
 
   .alt-path-copy
     color: rgba(white, 0.85)
-    font-family: 'Open Sans', sans-serif
     font-size: 15px
     font-weight: 200
     letter-spacing: 0.02em

--- a/app/assets/stylesheets/variables/fonts.scss
+++ b/app/assets/stylesheets/variables/fonts.scss
@@ -6,8 +6,8 @@
   font-weight: normal;
   src: font-url("open-sans-regular/open-sans-v14-latin-regular.eot");
   src: font-url("open-sans-regular/open-sans-v14-latin-regular.eot?iefix") format("embedded-opentype"),
-    font-url("open-sans-regular/open-sans-v14-latin-regular.ttf") format("truetype")
-    font-url("open-sans-regular/open-sans-v14-latin-regular.woff") format("woff")
+    font-url("open-sans-regular/open-sans-v14-latin-regular.ttf") format("truetype"),
+    font-url("open-sans-regular/open-sans-v14-latin-regular.woff") format("woff"),
     font-url("open-sans-regular/open-sans-v14-latin-regular.svg") format("svg");
 }
 
@@ -17,8 +17,8 @@
   font-weight: bold;
   src: font-url("open-sans-bold/open-sans-v14-latin-700.eot");
   src: font-url("open-sans-bold/open-sans-v14-latin-700.eot?iefix") format("embedded-opentype"),
-    font-url("open-sans-bold/open-sans-v14-latin-700.ttf") format("truetype")
-    font-url("open-sans-bold/open-sans-v14-latin-700.woff") format("woff")
+    font-url("open-sans-bold/open-sans-v14-latin-700.ttf") format("truetype"),
+    font-url("open-sans-bold/open-sans-v14-latin-700.woff") format("woff"),
     font-url("open-sans-bold/open-sans-v14-latin-700.svg") format("svg");
 }
 


### PR DESCRIPTION
Fixes loading the new local fonts (missing commas). Reverts the landing page to using the default font.

Reduces the amount of empty space above and below the logo.