### PR TITLE
Ensure publisher's status is set correctly on the dashboard

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -134,13 +134,21 @@ body[data-controller="publishers"]
       .attribute-value
         margin-bottom: 24px
       .publisher-domain-summary
+        margin-bottom: 12px
+      .publisher-domain-name
         font-size: $font-size-h3
-        img.verified-icon
-          margin-right: 12px
-          height: 30px
-        .publisher-verified-status
-          font-size: $font-size-base
-          vertical-align: middle
+        margin-bottom: 12px
+      #publisher_status
+        font-size: $font-size-base
+        vertical-align: middle
+        padding: 5px 0 5px 35px
+        background-position: center left
+        background-repeat: no-repeat
+        background-size: 25px
+        &.complete
+          background-image: url(asset-path("verified-icon.png"))
+        &.incomplete
+          background-image: url(asset-path("unverified-icon.png"))
       .balance
         font-size: $font-size-base
         .approximate-hint

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -293,13 +293,15 @@ class PublishersController < ApplicationController
     end
   end
 
-  def uphold_status
+  def status
     publisher = current_publisher
     respond_to do |format|
       format.json {
         render(json: {
-          status: publisher.uphold_status.to_s,
-          description: uphold_status_description(publisher)
+          status: publisher_status(publisher),
+          status_description: publisher_status_description(publisher),
+          uphold_status: publisher.uphold_status.to_s,
+          uphold_status_description: uphold_status_description(publisher)
         }, status: 200)
       }
     end

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -227,12 +227,8 @@ div#cssload-pgloading style="display: none"
     .publisher-status
       .publisher-domain-summary
         .publisher-domain-name= current_publisher.brave_publisher_id
-        - if current_publisher.uphold_verified?
-          = image_tag("verified-icon.png", alt: t("publishers.verified"), class: "verified-icon")
-          span.publisher-verified-status= t("publishers.verified_publisher_uphold_connected")
-        - else
-          = image_tag("unverified-icon.png", alt: t("publishers.verified"), class: "verified-icon")
-          span.publisher-verified-status= t("publishers.verified_publisher_not_uphold_connected")
+        #publisher_status class=(publisher_status(current_publisher) == :complete ? 'complete' : 'incomplete')
+          = publisher_status_description(current_publisher)
 
 .row
   .col.col-details.col-md-4.col-xs-8.col-xs-center.col-sm-center

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -188,15 +188,18 @@ javascript:
           method: 'GET'
         };
 
-        return window.fetch('./uphold_status', options)
+        return window.fetch('./status', options)
           .then(function(response) {
             if (response.status === 200) {
               return response.json();
             }
           })
           .then(function(body) {
-            if (body.status === 'verified') {
-              document.getElementById('uphold_status').innerText = body.description;
+            if (body.uphold_status === 'verified') {
+              document.getElementById('uphold_status').innerText = body.uphold_status_description;
+              var publisherStatus = document.getElementById('publisher_status');
+              publisherStatus.innerText = body.status_description;
+              publisherStatus.className = body.status === 'complete' ? 'complete' : 'incomplete';
               dynamicEllipsis.stop('uphold_status');
               clearInterval(checkUpholdStatusInterval);
             }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,14 +91,16 @@ en:
       create_wallet: "Create Your Wallet"
     publisher_statements: "Statements"
     email_verified_phone: "Phone (optional)"
+    status_complete: "Verified Publisher"
+    status_uphold_processing: "Your Uphold wallet is being connected to your account"
+    status_uphold_unconnected: "Wallet not found, please Connect with Uphold to create one"
+    status_unverified: "Your account has not been verified"
     uphold_status: "Status"
     uphold_status_verified: "Your Uphold wallet is ready to receive Brave Payments."
     uphold_status_access_parameters_acquired: "Connecting your Uphold account."
     uphold_status_code_acquired: "A problem was experienced connecting your Uphold account."
     uphold_status_unconnected: "Not connected to Uphold."
     verified: "Verified publisher"
-    verified_publisher_uphold_connected: "Verified Publisher"
-    verified_publisher_uphold_not_connected: "Wallet not found, please Connect with Uphold to create one."
     verified_publisher_connect_to_uphold_html: |
       <p>Check your wallet with Uphold</p>
       <p>Update your tax or BAT info</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       get :verification_github
       get :verification_wordpress
       get :verification_support_queue
-      get :uphold_status
+      get :status
       get :uphold_verified
       patch :verify
       patch :check_for_https

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -373,7 +373,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_match("{\"reportURL\":\"/publishers/home\"}", response.body)
   end
   
-  test "a publisher's uphold_status can be polled via ajax" do
+  test "a publisher's status can be polled via ajax" do
     perform_enqueued_jobs do
       post(publishers_path, params: SIGNUP_PARAMS)
     end
@@ -391,11 +391,16 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal false, publisher.show_verification_status
 
-    url = uphold_status_publishers_path
+    url = status_publishers_path
     get(url,
         headers: { 'HTTP_ACCEPT' => "application/json" })
 
     assert_response 200
-    assert_match("{\"status\":\"unconnected\",\"description\":\"Not connected to Uphold.\"}", response.body)
+    assert_match(
+      '{"status":"uphold_unconnected",' +
+       '"status_description":"Wallet not found, please Connect with Uphold to create one",' +
+       '"uphold_status":"unconnected",' +
+       '"uphold_status_description":"Not connected to Uphold."}',
+      response.body)
   end
 end


### PR DESCRIPTION
The helpers used to determine the publisher's status have been refactored to DRY up the logic and ensure that the descriptions match those given in #137 

The publisher's status is now updated both statically and dynamically (when the uphold status is polled). The `publishers/uphold_status` route has been replaced with `publishers/status`. This more general route now includes both the publishers general status and description, as well as the uphold status and description.