### PR TITLE
Update github verification instructions, rework file upload page

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -48,13 +48,6 @@ body[data-controller="publishers"]
       font-size: $font-size-small
       color: $gray
       line-height: $line-height-computed * 1.5
-    .verification-file
-      .file-content
-        height: $font-size-base * $line-height-base * 4
-        font-family: monospace
-        font-size: $font-size-base * 0.6
-        color: $braveOrange
-        outline: #888 solid thin
     .verification_code
       font-family: monospace
       font-size: $font-size-base * 0.6
@@ -86,15 +79,51 @@ body[data-controller="publishers"]
     .ol-flush
       padding-left: 20px
       list-style-position: outside
-    .li-text
-      padding-left: 0px
-      padding-right: 0px
-      margin-top: 0px
     .brave-logo-large
       background: url(asset-path("brave_icon_512x.png")) 0 0 / 128px 128px no-repeat
       margin: 0 auto
       height: 128px
       width: 128px
+
+  &[data-action="verification_github"],
+  &[data-action="verification_public_file"]
+    .img-right
+      float: right
+      width: 30%
+
+    @media (max-width: 991px)
+      $li-max-width: 100%
+      .verification-file
+        .file-content
+          height: $font-size-base * $line-height-base * 4
+          font-family: monospace
+          font-size: $font-size-base * 0.6
+          color: $braveOrange
+          outline: #888 solid thin
+          max-width: $li-max-width
+
+      .li-text
+        padding-left: 0px
+        padding-right: 0px
+        margin-top: 0px
+        max-width: $li-max-width
+
+    @media (min-width: 992px)
+      $li-max-width: 65%
+      .verification-file
+        .file-content
+          height: $font-size-base * $line-height-base * 4
+          font-family: monospace
+          font-size: $font-size-base * 0.6
+          color: $braveOrange
+          outline: #888 solid thin
+          max-width: $li-max-width
+
+      .li-text
+        padding-left: 0px
+        padding-right: 0px
+        margin-top: 0px
+        max-width: $li-max-width
 
   &[data-action="verification_done"]
     h2

--- a/app/views/publishers/verification_github.html.slim
+++ b/app/views/publishers/verification_github.html.slim
@@ -2,36 +2,37 @@
   = render :partial => 'progress', :locals => { progress: { info: 100, verify: 50, wallet: 0 }, publisher: current_publisher }
 
 .row
-  .col-no-pad.col-center.col-xs-10.col-md-10
+  .col-center.col-sm-10
     legend= t("publishers.verification_option_github")
 
 .row
-  .col-no-pad.col-center.col-xs-10.col-md-10
+  .col-center.col-sm-10
     = render :partial => 'https_check', :locals => { publisher: current_publisher }
 
 div class=(current_publisher.supports_https? ? "row" : "row dimmed")
-  .col-no-pad.col-center.col-xs-10.col-md-10
+  .col-center.col-sm-10
     .form-group
       ol.ol-flush
         li
-          .help-block.col-xs-10.col-md-8.li-text= t("publishers.verification_option_github_help_download")
-          .col-xs-10.visible-sm.visible-xs
-            = image_tag("download.png")
-          .row
-            .col-xs-10.col-md-8
-              strong= t("publishers.verification_option_github_file_contents")
-              .verification-file
-                .file-content= simple_format h publisher_filter_public_file_content(current_publisher, @public_file_content)
-                = link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path, class: "button btn btn-xs btn-default btn-download")
-            .col-xs-4.col-md-4.visible-md.visible-lg
-              = image_tag("download.png")
+          .help-block.li-text= t("publishers.verification_option_github_nojekyll")
         li
-          .help-block.col-xs-10.col-md-8.li-text= t("publishers.verification_option_github_help_upload_html")
-          .col-sm-12.col-xs-10.visible-sm.visible-xs
-            = image_tag("upload-well-known.png")
-          .row
-            .col-xs-10.col-md-8
-              = form_for(current_publisher, method: :patch, url: verify_publishers_path) do |f|
-                = f.submit(t("publishers.verify_button"), class: "btn btn-primary btn-sm")
-            .col-xs-4.col-md-4.visible-md.visible-lg
+          .help-block.li-text= t("publishers.verification_option_github_help_download")
+          .visible-sm.visible-xs
+            = image_tag("download.png")
+          strong= t("publishers.verification_option_github_file_contents")
+
+          .visible-md.visible-lg
+            .img-right
+              = image_tag("download.png")
+          .verification-file
+            .file-content= simple_format h publisher_filter_public_file_content(current_publisher, @public_file_content)
+            = link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path, class: "button btn btn-xs btn-default btn-download")
+        li
+          .visible-md.visible-lg
+            .img-right
               = image_tag("upload-well-known.png")
+          .help-block.li-text= t("publishers.verification_option_github_help_upload_html")
+          .visible-sm.visible-xs
+            = image_tag("upload-well-known.png")
+          = form_for(current_publisher, method: :patch, url: verify_publishers_path) do |f|
+            = f.submit(t("publishers.verify_button"), class: "btn btn-primary btn-sm")

--- a/app/views/publishers/verification_public_file.html.slim
+++ b/app/views/publishers/verification_public_file.html.slim
@@ -2,38 +2,37 @@
   = render :partial => 'progress', :locals => { progress: { info: 100, verify: 50, wallet: 0 }, publisher: current_publisher }
 
 .row
-  .col-no-pad.col-center.col-xs-10.col-md-10
+  .col-center.col-sm-10
     fieldset
       legend= t("publishers.verification_option_public_file")
 .row
-  .col-no-pad.col-center.col-xs-10.col-md-10
+  .col-center.col-sm-10
     = render :partial => 'https_check', :locals => { publisher: current_publisher }
 
 div class=(current_publisher.supports_https? ? "row" : "row dimmed")
-  .col-no-pad.col-center.col-xs-10.col-md-10
+  .col-center.col-sm-10
     .form-group
       ol.ol-flush
         li
-          .help-block.col-xs-10.col-md-8.li-text= t("publishers.verification_option_public_file_help_download")
-          .col-xs-10.visible-sm.visible-xs
+          .help-block.li-text= t("publishers.verification_option_public_file_help_download")
+          .visible-sm.visible-xs
             = image_tag("download.png")
-          .row
-            .col-xs-10.col-md-8
-              strong= t("publishers.verification_option_public_file_file_contents")
-              .verification-file
-                .file-content= simple_format h publisher_filter_public_file_content(current_publisher, @public_file_content)
-                = link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path, class: "button btn btn-xs btn-default btn-download")
-            .col-xs-4.col-md-4.visible-md.visible-lg
+          strong= t("publishers.verification_option_public_file_file_contents")
+
+          .visible-md.visible-lg
+            .img-right
               = image_tag("download.png")
+          .verification-file
+            .file-content= simple_format h publisher_filter_public_file_content(current_publisher, @public_file_content)
+            = link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path, class: "button btn btn-xs btn-default btn-download")
         li
-          .help-block.col-xs-10.col-md-8.li-text= t("publishers.verification_option_public_file_help_upload_html")
-          .col-sm-12.col-xs-10.visible-sm.visible-xs
-            = image_tag("upload-well-known.png")
-          .row
-            .col-xs-10.col-md-8
-              = form_for(current_publisher, method: :patch, url: verify_publishers_path) do |f|
-                = f.submit(t("publishers.verify_button"), class: "btn btn-primary btn-sm")
-              br
-              .help-block= t("publishers.verification_option_public_file_verify_note")
-            .col-xs-4.col-md-4.visible-md.visible-lg
+          .visible-md.visible-lg
+            .img-right
               = image_tag("upload-well-known.png")
+          .help-block.li-text= t("publishers.verification_option_public_file_help_upload_html")
+          .visible-sm.visible-xs
+            = image_tag("upload-well-known.png")
+          = form_for(current_publisher, method: :patch, url: verify_publishers_path) do |f|
+            = f.submit(t("publishers.verify_button"), class: "btn btn-primary btn-sm")
+          br
+          .help-block.li-text= t("publishers.verification_option_public_file_verify_note")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,6 +192,7 @@ en:
     verification_option_wordpress_help_verify: "Finally, let us know you are ready to check for the verification code."
     verification_option_wordpress_verify_button: "Check for the verification code"
     verification_option_github_use: "Verify Your Site: Upload a trusted file"
+    verification_option_github_nojekyll: "Please make sure to add an empty file named '.nojekyll' to the root of your repo."
     verification_option_github_help_download: "Download the verification file below:"
     verification_option_github_help_directory: "Find or create the directory: %{directory}"
     verification_option_github_help_upload_html: |
@@ -199,11 +200,6 @@ en:
       be sure to create it. Make sure the file is in the .well-known folder and click verify.
     verification_option_github_file_contents: "File contents:"
     verification_option_github: "Hello! It looks like you are using GitHub."
-    verification_option_github_help_intro: ""
-    verification_option_github_help_1_html: ""
-    verification_option_github_help_2_html: ""
-    verification_option_github_token: "Verication code:"
-    verification_option_github_help_verify: ""
     verification_option_github_verify_button: "Check for the verification code."
     verification_required: "To continue please verify ownership of your domain."
     verification_helper_dns_title: "Need help with adding a TXT record in your DNS account?"


### PR DESCRIPTION
Updates the github instructions per #142

Reworks layout of public file and github verification pages for better flow.

![screen shot 2017-10-06 at 6 30 37 pm](https://user-images.githubusercontent.com/29154/31300933-938a1952-aac4-11e7-8a2b-287ac96410b2.png)
![screen shot 2017-10-06 at 6 31 09 pm](https://user-images.githubusercontent.com/29154/31300934-93908814-aac4-11e7-8ab5-0192931b23ca.png)
