### PR TITLE
Adds i8n-tasks development gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,9 @@ group :development do
   gem "rubocop", require: false
   # gem "spring"
   # gem "spring-watcher-listen", "~> 2.0.0"
+
+  # i18n-tasks helps you find and manage missing and unused translations.
+  gem 'i18n-tasks', '~> 0.9.12'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,10 @@ GEM
     dnsruby (1.59.3)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
+    easy_translate (0.5.0)
+      json
+      thread
+      thread_safe
     email_validator (1.6.0)
       activemodel
     encryptor (3.0.0)
@@ -99,8 +103,19 @@ GEM
       activesupport (>= 4.2.0)
     hashdiff (0.3.5)
     hashie (3.5.5)
+    highline (1.7.8)
     htmlentities (4.3.4)
     i18n (0.8.6)
+    i18n-tasks (0.9.12)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      easy_translate (>= 0.5.0)
+      erubis
+      highline (>= 1.7.3)
+      i18n
+      parser (>= 2.2.3.0)
+      term-ansicolor (>= 1.3.2)
+      terminal-table (>= 1.5.1)
     jmespath (1.3.1)
     json (2.0.2)
     jsonapi (0.1.1.beta6)
@@ -260,9 +275,15 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     temple (0.7.7)
+    term-ansicolor (1.6.0)
+      tins (~> 1.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.0)
+    thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.0.7)
+    tins (1.15.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.0.2)
@@ -303,6 +324,7 @@ DEPENDENCIES
   domain_name
   email_validator (~> 1.6)
   faraday (~> 0.9.2)
+  i18n-tasks (~> 0.9.12)
   listen (~> 3.0.5)
   lograge (~> 0.4)
   newrelic_rpm (~> 3.16)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,123 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
+# locales: [es, fr]
+## Reporting locale, default: en. Available: en, ru.
+# internal_locale: en
+
+# Read and write translations.
+data:
+  ## Translations are read from the file system. Supported format: YAML, JSON.
+  ## Provide a custom adapter:
+  # adapter: I18n::Tasks::Data::FileSystem
+
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    # Default:
+     - config/locales/%{locale}.yml
+
+    ## More files:
+    # - config/locales/**/*.%{locale}.yml
+    # Another gem (replace %#= with %=):
+     - "<%= %x[bundle show recaptcha].chomp %>/templates/locales/%{locale}.yml"
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    # For example, write devise and simple form keys to their respective files:
+     - ['{devise}.*', 'config/locales/\1.%{locale}.yml']
+
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  # router: convervative_router
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+  ## Pretty-print JSON:
+  # json:
+  #   write:
+  #     indent: '  '
+  #     space: ' '
+  #     object_nl: "\n"
+  #     array_nl: "\n"
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  # paths:
+  #  - app/
+
+  ## Root directories for relative keys resolution.
+  # relative_roots:
+  #   - app/controllers
+  #   - app/helpers
+  #   - app/mailers
+  #   - app/presenters
+  #   - app/views
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos
+
+  ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
+  ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
+  # only: ["*.rb", "*.html.slim"]
+
+  ## If `strict` is `false`, guess usages such as t("categories.#{category}.title"). The default is `true`.
+  # strict: true
+
+  ## Multiple scanners can be used. Their results are merged.
+  ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.
+  ## See this example of a custom scanner: https://github.com/glebm/i18n-tasks/wiki/A-custom-scanner-example
+
+## Google Translate
+# translation:
+#   # Get an API key and set billing info at https://code.google.com/apis/console to use Google Translate
+#   api_key: "AbC-dEf5"
+
+## Do not consider these keys missing:
+# ignore_missing:
+# - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
+# - '{devise,simple_form}.*'
+
+## Consider these keys used:
+  ignore_unused:
+   - 'activerecord.attributes.*'
+# - '{devise,kaminari,will_paginate}.*'
+# - 'simple_form.{yes,no}'
+# - 'simple_form.{placeholders,hints,labels}.*'
+# - 'simple_form.{error_notification,required}.:'
+
+## Exclude these keys from the `i18n-tasks eq-base' report:
+# ignore_eq_base:
+#   all:
+#     - common.ok
+#   fr,es:
+#     - common.brand
+
+## Ignore these keys completely:
+# ignore:
+#  - kaminari.*
+
+## Sometimes, it isn't possible for i18n-tasks to match the key correctly,
+## e.g. in case of a relative key defined in a helper method.
+## In these cases you can use the built-in PatternMapper to map patterns to keys, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       only: %w(*.html.haml *.html.slim),
+#       patterns: [['= title\b', '.page_title']] %>
+#
+# The PatternMapper can also match key literals via a special %{key} interpolation, e.g.:
+#
+# <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+#       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>


### PR DESCRIPTION
Will allow management of localizations
Uses the default setup, which may need some customization for a best fit

Documentation can be found at https://glebm.github.io/i18n-tasks/
Along with a host of useful features, it can be used to find unused and missing keys:

```bash
i18n-tasks health
```

Might be useful to integrate with travis to ensure we don't launch with missing strings. This is TBD.