### PR TITLE
Clean up publishers/create_done page

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -225,9 +225,9 @@ body[data-controller="publishers"]
       width: 128px
 
   &[data-action="create_done"]
-    .email
+    .email-panel
       background-image: url(asset-path("email-2@1x.png"))
-      background-position: 500px, 150px
+      background-position: top 60px right 60px
       background-repeat: no-repeat
 
   &[data-action="verification_github"],

--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -229,6 +229,8 @@ body[data-controller="publishers"]
       background-image: url(asset-path("email-2@1x.png"))
       background-position: top 60px right 60px
       background-repeat: no-repeat
+    .email-address
+      color: #ff3f3f
 
   &[data-action="verification_github"],
   &[data-action="verification_public_file"],

--- a/app/views/publishers/create_done.html.slim
+++ b/app/views/publishers/create_done.html.slim
@@ -11,8 +11,6 @@
       h3.text-center= t("publishers.create_done_header")
       = t("publishers.create_done_body_html",
               email: @publisher_email,
-              try_again: link_to(t("publishers.try_again"), "#", :onclick=>"document.forms[0].submit();"))
+              try_again: link_to(t("publishers.try_again"), "#", :onclick=>"document.getElementById('resend_email_form').submit();"))
 
-      = button_to t("publishers.create_done_resend_email"),
-              { controller: "publishers", action: "resend_email_verify_email" },
-              { method: "post", class: "hidden" }
+      = form_tag(resend_email_verify_email_publishers_path, method: "post", class: "hidden", id: "resend_email_form")


### PR DESCRIPTION
* Show flying email sent logo in the background pinned to the upper right corner (works well in this location as browser resizes)
* Highlight email address in orange
* Simplify email resend logic

Note: the content width will be addressed in a separate PR from @lgebhardt 

![screen shot 2017-10-19 at 10 20 24 am](https://user-images.githubusercontent.com/29122/31775627-2998fac0-b4b7-11e7-9013-7433f67a47fd.png)
