### PR TITLE
Tune up

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -53,7 +53,7 @@ body[data-controller="publishers"]
     .panel-controls
       margin-top: 58px
     .content-panel
-      padding: 0 30px
+      padding: 0 10px
   .process-panel
     padding-top: 64px
     padding-bottom: 105px
@@ -235,6 +235,8 @@ body[data-controller="publishers"]
   &[data-action="verification_wordpress"]
     h3
       margin-bottom: 18px
+    .download-link
+      font-weight: 600
 
   &[data-action="verification_github"],
   &[data-action="verification_public_file"],
@@ -246,7 +248,7 @@ body[data-controller="publishers"]
       p
         margin-bottom: 12px
       .note-text
-        margin-bottom: 12px
+        margin-bottom: 24px
     .file-content
       width: 360px
     .file-content-header
@@ -427,7 +429,6 @@ body[data-controller="publishers"]
       h4
         font-size: 13px
         font-weight: 300
-        text-transform: uppercase
         letter-spacing: 0.5px
       legend
         margin-bottom: 12px
@@ -446,8 +447,7 @@ body[data-controller="publishers"]
           margin: 0 0 0 -50px
           padding: 12px 0 12px 50px
           vertical-align: middle
-          text-transform: capitalize
-          font-weight: 700
+          font-weight: 400
           background-position: center left
           background-repeat: no-repeat
           background-size: 34px 42px
@@ -473,6 +473,7 @@ body[data-controller="publishers"]
       .publisher-domain-name
         font-size: 28px
         margin-bottom: 12px
+        font-weight: 500
       #publisher_status
         font-size: $font-size-base
         vertical-align: middle
@@ -493,11 +494,11 @@ body[data-controller="publishers"]
           .bat-amount
             font-size: 48px
             color: #222326
-            weight: 500
+            font-weight: 500
           .bat-code
             font-size: 16px
             color: #222326
-            weight: 500
+            font-weight: 500
           .converted
             margin-top: -8px
             font-size: 14px

--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -378,6 +378,8 @@ body[data-controller="publishers"]
       .btn-secondary
         border-color: #fd4246
         color: #fd4246
+        &:hover, &:active
+          color: #fc624e
       .img-container
         height: 215px
         vertical-align: middle

--- a/app/assets/stylesheets/shared/buttons.sass
+++ b/app/assets/stylesheets/shared/buttons.sass
@@ -1,4 +1,11 @@
 .btn
+  a
+    text-decoration: none
+    &:hover
+      text-decoration: none
+    &:active
+      text-decoration: none
+
   &.btn-primary
     padding: 9px 24px
     border-radius: 20px
@@ -11,13 +18,14 @@
     box-shadow: 2px 2px 100px rgba(255, 255, 255, 0.5)
     color: #fff
     font-weight: 400
-    a
-      color: #ff4d3f
-      text-decoration-line: none
     &:hover
+      color: #fff
       background: #fc624e
+      text-decoration: none
     &:active
+      color: #fff
       background: #e22a1f
+      text-decoration: none
 
   &.btn-secondary
     padding: 9px 24px
@@ -31,11 +39,14 @@
     box-shadow: 2px 2px 100px rgba(255, 255, 255, 0.5)
     color: #8F9397
     font-weight: 400
-    a
-      color: #d3d5d7
-      text-decoration-line: none
+    text-decoration: none
     &:hover
+      color: #8F9397
       border: 1px solid #aaa
+      text-decoration: none
+    &:active
+      text-decoration: none
+      color: #8F9397
 
   &.btn-tertiary
     background: white

--- a/app/views/publishers/verification_background.html.slim
+++ b/app/views/publishers/verification_background.html.slim
@@ -8,7 +8,6 @@
 .publisher-main-panel.publisher-panel.col-center
   .sub-panel.info-panel.col-center
     .content-panel
-      .brave-logo-large.img-responsive
       h3.text-center= t("publishers.verification_background_header")
       p= t("publishers.verification_background_help")
       p

--- a/app/views/publishers/verification_choose_method.html.slim
+++ b/app/views/publishers/verification_choose_method.html.slim
@@ -25,4 +25,4 @@
           .img-container= image_tag("choose-dns@1x.png", class: "choose-dns")
           div= link_to(t("publishers.verification_choose_dns_button"), verification_dns_record_publishers_path, class: "btn btn-secondary", :"data-piwik-action" => "ChoseDNSClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")
 
-      .fine-print.text-center= t("publishers.verification_choose_support_queue_html", support_queue_link: link_to(t("publishers.verification_choose_support_queue_link"), verification_support_queue_publishers_path, class: "link-secondary", :"data-piwik-action" => "ChoseSupportClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow"))
+      .fine-print.text-center= t("publishers.verification_choose_support_queue_html", support_queue_link: link_to(t("publishers.verification_choose_support_queue_link"), verification_support_queue_publishers_path, :"data-piwik-action" => "ChoseSupportClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow"))

--- a/app/views/publishers/verification_github.html.slim
+++ b/app/views/publishers/verification_github.html.slim
@@ -16,7 +16,7 @@
           li
             p= t("publishers.verification_option_github_nojekyll_html")
           li
-            p= t("publishers.verification_download_html", download_link: link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path))
+            p= t("publishers.verification_download_html", download_link: link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path, class: "download-link"))
             .pull-left
               = image_tag("file@1x.png", class: "instruction-img")
             .pull-right

--- a/app/views/publishers/verification_public_file.html.slim
+++ b/app/views/publishers/verification_public_file.html.slim
@@ -14,7 +14,7 @@
       div class=(current_publisher.supports_https? ? "instructions" : "instructions dimmed")
         ol
           li
-            p= t("publishers.verification_download_html", download_link: link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path))
+            p= t("publishers.verification_download_html", download_link: link_to(t("publishers.verification_download_verification"), download_verification_file_publishers_path, class: "download-link"))
             .pull-left
               = image_tag("file@1x.png", class: "instruction-img")
             .pull-right

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
     already_logged_in: "You can't do that because you have an active session. Please exit or clear your cookies."
     authentication_token_invalid: "Authentication failed. Your login link may have expired; please send yourself a new sign in link."
     balance_error: "Unavailable"
-    balance_pending: "Current Contribution Balance"
+    balance_pending: "CURRENT CONTRIBUTION BALANCE"
     balance_pending_approximate: "Approximately %{amount} %{code}"
     legacy_balance_pending: "Legacy balance pending (Bitcoin system)"
     claim_funds: "Claim funds"
@@ -187,7 +187,7 @@ en:
     verification_option_public_file_verify_note: "Note: This may take a few minutes to several hours to become available for verification depending on where your site is hosted."
     verification_option_wordpress: "Hello. It looks like you are using Wordpress!"
     verification_option_wordpress_install_plugin_html: |
-      <p class="li-text"><a href="https://wordpress.org/plugins/well-known-uris/">Install the plugin</a> that makes the
+      <p class="li-text"><a href="https://wordpress.org/plugins/well-known-uris/" class="download-link">Install the plugin</a> that makes the
        entire process a snap.</p>
       <p class="note-text">(Plugin location: <a href="https://wordpress.org/plugins/well-known-uris/">
       https://wordpress.org/plugins/well-known-uris/</a>)</p>


### PR DESCRIPTION
Fixes style issues reported by Jenn:

- Buttons based on A tags no long show underlined style on hover
- Multiple font weights adjusted
- Minor spacing adjustments
- Info type pages are now slightly wider

Also, the Brave logo removed from "Now verifying your domain..." page. A spinner was asked for, but I have reservations about that issue since this page will never stop the spinner. It would be nice to have this page poll, with a spinner, for verification and then navigate to the dashboard when complete.

Still to do: look at installing additional font weights.