### PR TITLE
Add statement generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ gem "active_model_serializers", "~> 0.10.0"
 # Encrypt DB data at rest
 gem "attr_encrypted", "~> 3.0.0"
 
-gem "aws-sdk", "~> 2", require: false
-
 gem "bootstrap-sass", "~> 3.3.6"
 
 # Authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,12 +50,6 @@ GEM
       encryptor (~> 3.0.0)
     autoprefixer-rails (6.5.0.2)
       execjs
-    aws-sdk (2.6.10)
-      aws-sdk-resources (= 2.6.10)
-    aws-sdk-core (2.6.10)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.6.10)
-      aws-sdk-core (= 2.6.10)
     bcrypt (3.1.11)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -116,7 +110,6 @@ GEM
       parser (>= 2.2.3.0)
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
-    jmespath (1.3.1)
     json (2.0.2)
     jsonapi (0.1.1.beta6)
       jsonapi-parser (= 0.1.1.beta3)
@@ -313,7 +306,6 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   attr_encrypted (~> 3.0.0)
-  aws-sdk (~> 2)
   bootstrap-sass (~> 3.3.6)
   bundler-audit
   byebug

--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -516,11 +516,17 @@ body[data-controller="publishers"]
         margin-right: 10px
       .btn-generate
         padding: 5px 10px
-        margin-left: 10px
       .edit-link
-        text-transform: capitalize
+        font-size: 16px
+        font-weight: 500
         color: #00bcda
         display: inline-block
+        &#generate_statement
+          line-height: 26px
+          padding: 5px 0
+      #generate_statement_result
+        margin-bottom: 16px
+        font-weight: 500
       #publishers_list
         .list-label
           display: block

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -198,6 +198,18 @@ module PublishersHelper
     ]
   end
 
+  def publisher_statement_filename(publisher_statement)
+    publisher_id = publisher_statement.publisher.brave_publisher_id
+    date = publisher_statement.created_at.to_date.iso8601
+    period = publisher_statement.period.to_s.gsub('_', '-')
+
+    "#{publisher_id}-#{date}-#{period}.csv"
+  end
+
+  def link_to_publisher_statement(publisher_statement)
+    link_to(publisher_statement_filename(publisher_statement), statement_publishers_url(id: publisher_statement.id))
+  end
+
   def publisher_filtered_verification_token(publisher)
     if publisher.supports_https?
       publisher.verification_token

--- a/app/jobs/sync_publisher_statement_job.rb
+++ b/app/jobs/sync_publisher_statement_job.rb
@@ -1,0 +1,14 @@
+class SyncPublisherStatementJob < ApplicationJob
+  queue_as :default
+
+  def perform(publisher_statement_id:)
+    publisher_statement = PublisherStatement.find(publisher_statement_id)
+
+    PublisherStatementSyncer.new(publisher_statement: publisher_statement).perform
+
+    publisher_statement.reload
+    unless publisher_statement.contents.present?
+      SyncPublisherStatementJob.set(wait: 5.seconds).perform_later(publisher_statement_id: publisher_statement.id)
+    end
+  end
+end

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -138,4 +138,13 @@ class PublisherMailer < ApplicationMailer
       subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
     )
   end
+
+  def statement_ready(publisher_statement)
+    @publisher_statement = publisher_statement
+    @publisher = publisher_statement.publisher
+    mail(
+      to: @publisher.email,
+      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+    )
+  end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,6 +1,8 @@
 class Publisher < ApplicationRecord
   has_paper_trail
 
+  has_many :statements, class_name: 'PublisherStatement'
+
   attr_encrypted :authentication_token, key: :encryption_key
   attr_encrypted :uphold_code, key: :encryption_key
   attr_encrypted :uphold_access_parameters, key: :encryption_key

--- a/app/models/publisher_statement.rb
+++ b/app/models/publisher_statement.rb
@@ -1,0 +1,26 @@
+class PublisherStatement < ApplicationRecord
+  EXPIRE_AFTER = 1.day
+
+  attr_encrypted :contents, key: :encryption_key
+
+  belongs_to :publisher
+  validates :publisher_id, presence: true
+  validates :period,
+            inclusion: { in: %w(past_7_days past_30_days this_month last_month this_year last_year all) },
+            presence: true
+
+  after_create :set_expiration
+
+  def set_expiration
+    self.expires_at = Time.zone.now + EXPIRE_AFTER
+    save!
+  end
+
+  def expired?
+    Time.zone.now > self.expires_at
+  end
+
+  def encryption_key
+    Rails.application.secrets[:attr_encrypted_key]
+  end
+end

--- a/app/services/publisher_statement_generator.rb
+++ b/app/services/publisher_statement_generator.rb
@@ -17,13 +17,29 @@ class PublisherStatementGenerator < BaseApiClient
       request.url("/v1/publishers/#{publisher.brave_publisher_id}/statement#{query_params}")
     end
 
-    return JSON.parse(response.body)["reportURL"]
+    statement = PublisherStatement.new(
+      publisher: @publisher,
+      period: @statement_period,
+      source_url: JSON.parse(response.body)["reportURL"])
+
+    statement.save!
+
+    return statement
   end
 
   def perform_offline
-    fake_report = "/publishers/home#{query_params}"
+    fake_report = "/assets/fake_statement.pdf#{query_params}"
+
     Rails.logger.info("PublisherStatementGenerator eyeshade offline; generating fake report: #{fake_report}")
-    fake_report
+
+    statement = PublisherStatement.new(
+      publisher: @publisher,
+      period: @statement_period,
+      source_url: fake_report)
+
+    statement.save!
+
+    return statement
   end
 
   def query_params

--- a/app/services/publisher_statement_getter.rb
+++ b/app/services/publisher_statement_getter.rb
@@ -1,0 +1,34 @@
+class PublisherStatementGetter < BaseApiClient
+  attr_reader :publisher_statement
+
+  def initialize(publisher_statement:)
+    @publisher_statement = publisher_statement
+  end
+
+  def perform
+    return perform_offline if Rails.application.secrets[:api_eyeshade_offline]
+    response = connection.get do |request|
+      request.headers["Authorization"] = api_authorization_header
+      request.url(@publisher_statement.source_url)
+    end
+    response.body
+  rescue Faraday::Error => e
+    Rails.logger.warn("PublisherStatementGetter #perform error: #{e}")
+    nil
+  end
+
+  def perform_offline
+    Rails.logger.info("PublisherStatementGetter offline.")
+    'Fake offline data'
+  end
+
+  private
+
+  def api_base_uri
+    Rails.application.secrets[:api_eyeshade_base_uri]
+  end
+
+  def api_authorization_header
+    "Bearer #{Rails.application.secrets[:api_eyeshade_key]}"
+  end
+end

--- a/app/services/publisher_statement_syncer.rb
+++ b/app/services/publisher_statement_syncer.rb
@@ -1,0 +1,19 @@
+class PublisherStatementSyncer
+  attr_reader :publisher_statement
+
+  def initialize(publisher_statement:)
+    @publisher_statement = publisher_statement
+  end
+
+  def perform
+    return if publisher_statement.contents.present?
+
+    contents = PublisherStatementGetter.new(publisher_statement: publisher_statement).perform
+    if contents
+      publisher_statement.contents = contents
+      publisher_statement.save!
+
+      PublisherMailer.statement_ready(publisher_statement).deliver_later
+    end
+  end
+end

--- a/app/views/publisher_mailer/statement_ready.html.slim
+++ b/app/views/publisher_mailer/statement_ready.html.slim
@@ -1,0 +1,13 @@
+/ Sent as soon as a publisher fills out the first step.
+- content_for(:title) do
+  h3= I18n.t("publisher_mailer.statement_ready.title")
+
+p= I18n.t("publisher_mailer.statement_ready.body")
+
+p= link_to_publisher_statement(@publisher_statement)
+
+p= I18n.t("publisher_mailer.statement_ready.expiration_note")
+
+p.hint
+  span.attribute= "#{I18n.t("publisher_mailer.shared.contact_help")}:"
+  = mail_to(Rails.application.secrets[:support_email])

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -50,29 +50,52 @@ javascript:
         });
     }
 
-    function waitForReport(reportURL, delay, backoff, attempts) {
+    function pollUntilSuccess(url, delay, backoff, attempts) {
       return new Promise(function(resolve, reject) {
-        if (attempts > 0) {
-          setTimeout(function() {
-            window.fetch(reportURL, { method: 'GET' })
-              .then(function(response) {
-                if (response.status === 200) {
-                  // report successfully fetched
-                  resolve(reportURL);
-                } else {
-                  // report could not be fetched, so try again
-                  return waitForReport(reportURL, delay + backoff, backoff, --attempts)
-                    .catch(reject);
-                }
-              }, function(e) {
-                // swallow exception and try again
-                return waitForReport(reportURL, delay + backoff, backoff, --attempts)
-                  .catch(reject);
-              });
-          }, delay);
-        } else {
-          throw new Error('Attempts exceeded!');
+        var attempt = 0;
+        var currentDelay = delay;
+
+        function fetchAttempt() {
+          attempt++;
+
+          if (attempt > attempts) {
+            reject(new Error('Attempts exceeded!'));
+            return;
+          }
+
+          fetchAfterDelay(url, currentDelay)
+            .then(function(response) { resolve(response); })
+            .catch(function(e) {
+              currentDelay += backoff;
+              fetchAttempt();
+            });
         }
+
+        fetchAttempt();
+      });
+    }
+
+    function fetchAfterDelay(url, delay) {
+      return new Promise(function(resolve, reject) {
+        setTimeout(function() {
+          var options = {
+            headers: {
+              'Accept': 'application/json'
+            },
+            credentials: 'same-origin',
+            method: 'GET'
+          };
+          window.fetch(url, options)
+            .then(function(response) {
+              if (response.status >= 200 && response.status < 300) {
+                resolve(response);
+              } else {
+                reject(response);
+              }
+            }, function(e) {
+              reject(e);
+            });
+        }, delay);
       });
     }
 
@@ -114,8 +137,7 @@ javascript:
 
       var generateStatement = document.getElementById('generate_statement');
       var generateStatementResult = document.getElementById('generate_statement_result');
-      // FIXME: Remove once #74 is fixed.
-      // var statementPeriod = document.getElementById('statement_period');
+      var statementPeriod = document.getElementById('statement_period');
 
       editContact.addEventListener('click', function(event) {
         updateContactName.value = showContactName.innerText;
@@ -152,38 +174,40 @@ javascript:
           });
       }, false);
 
-      // FIXME: Remove once #74 is fixed.
-      //statementPeriod.addEventListener('click', function(event) {
-      //  hideSpinner();
-      //  generateStatement.style.display = 'inline-block';
-      //  generateStatementResult.style.display = 'none';
-      //}, false);
-      //
-      //generateStatement.addEventListener('click', function(event) {
-      //  event.preventDefault();
-      //
-      //  submitForm('statement_generator', 'PATCH', false)
-      //    .then(function(response) {
-      //      return response.json();
-      //    })
-      //    .then(function(json) {
-      //      generateStatement.style.display = 'none';
-      //      generateStatementResult.style.display = 'inline-block';
-      //      generateStatementResult.innerText = 'Generating';
-      //
-      //      dynamicEllipsis.start('generate_statement_result');
-      //
-      //      return waitForReport(json.reportURL, 3000, 2000, 4);
-      //    })
-      //    .then(function(reportURL) {
-      //      dynamicEllipsis.stop('generate_statement_result');
-      //      generateStatementResult.innerHTML = '<a href="' + reportURL + '" class="btn btn-tertiary btn-generate">View report</a>';
-      //    })
-      //    .catch(function() {
-      //      dynamicEllipsis.stop('generate_statement_result');
-      //      generateStatementResult.innerText = 'We will email you a link when your report is ready.'
-      //    });
-      //}, false);
+      statementPeriod.addEventListener('click', function(event) {
+        hideSpinner();
+        generateStatement.style.display = 'inline-block';
+        generateStatementResult.style.display = 'none';
+      }, false);
+
+      generateStatement.addEventListener('click', function(event) {
+        var statementId;
+
+        event.preventDefault();
+
+        submitForm('statement_generator', 'PATCH', false)
+          .then(function(response) {
+            return response.json();
+          })
+          .then(function(json) {
+            generateStatement.style.display = 'none';
+            generateStatementResult.style.display = 'inline-block';
+            generateStatementResult.innerText = 'Generating';
+
+            dynamicEllipsis.start('generate_statement_result');
+
+            statementId = json.id;
+            return pollUntilSuccess('/publishers/statement_ready?id=' + statementId, 3000, 2000, 4);
+          })
+          .then(function() {
+            dynamicEllipsis.stop('generate_statement_result');
+            generateStatementResult.innerHTML = '<a href="/publishers/statement?id=' + statementId + '" class="btn btn-tertiary btn-generate">View statement</a>';
+          })
+          .catch(function(e) {
+            dynamicEllipsis.stop('generate_statement_result');
+            generateStatementResult.innerText = 'We will email you when your report is ready.'
+          });
+      }, false);
     }, false);
   })();
 
@@ -272,17 +296,17 @@ noscript
           .panel-section= link_to(t("publishers.uphold_check_balance"), "https://uphold.com/dashboard", class: "btn btn-primary")
   .col.col-details.col-md-6.col-xs-10.col-xs-center.col-sm-center
     .sub-panel.dashboard-panel
-      .hidden.statements
+      .statements#statement_section style=(current_publisher.uphold_verified ? '' : 'display: none')
         .panel-header.panel-header-h4#publishers_statement
           = t("publishers.statement")
         = form_for(current_publisher, url: generate_statement_publishers_path, html: { id: "statement_generator" }) do |f|
           .form-group
-            = select_tag(:statement_period, options_for_select(publisher_statement_periods))
+            = select_tag(:statement_period, options_for_select(publisher_statement_periods, :past_30_days))
             .pull-right
-              a#generate_statement href="#" class="edit-link"
+              a.edit-link#generate_statement href="#"
                 = t("shared.generate")
-              span#generate_statement_result
         .clearfix
+        #generate_statement_result
       .panel-header.panel-header-h4#publishers_contact
         = t("publishers.contact")
         .pull-right

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,11 @@ en:
       updated_email: "New email"
       change_ok: "If you made this change, check your new email account for a link to confirm it."
       contact_support: "If you did not make this change yourself, please contact support ASAP"
+    statement_ready:
+      subject: "[%{brave_publisher_id}] Brave Publisher statement is ready to view"
+      title: "Publisher statement is ready to view"
+      body: "The following statement has recently been generated:"
+      expiration_note: "This statement must be downloaded within the next 24 hours."
   publisher_statement_periods:
     past_7_days: "Past 7 days"
     past_30_days: "Past 30 days"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
       get :verification_support_queue
       get :status
       get :uphold_verified
+      get :statement
+      get :statement_ready
       patch :verify
       patch :check_for_https
       patch :update

--- a/db/migrate/20171004075024_create_publisher_statements.rb
+++ b/db/migrate/20171004075024_create_publisher_statements.rb
@@ -1,0 +1,13 @@
+class CreatePublisherStatements < ActiveRecord::Migration[5.0]
+  def change
+    create_table :publisher_statements, id: :uuid do |t|
+      t.references :publisher, type: :uuid, index: true, null: false
+      t.string :period, null: :false
+      t.string :source_url
+      t.text :encrypted_contents
+      t.string :encrypted_contents_iv
+      t.timestamp :expires_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170915124337) do
+ActiveRecord::Schema.define(version: 20171004075024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "publisher_statements", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid     "publisher_id",          null: false
+    t.string   "period"
+    t.string   "source_url"
+    t.text     "encrypted_contents"
+    t.string   "encrypted_contents_iv"
+    t.datetime "expires_at"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.index ["publisher_id"], name: "index_publisher_statements_on_publisher_id", using: :btree
+  end
 
   create_table "publishers", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "brave_publisher_id"

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -369,10 +369,12 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
           params: { statement_period: 'all' },
           headers: { 'HTTP_ACCEPT' => "application/json" })
 
+    publisher_statement = PublisherStatement.order(created_at: :asc).last
+
     assert_response 200
-    assert_match("{\"reportURL\":\"/publishers/home\"}", response.body)
+    assert_match("{\"id\":\"#{publisher_statement.id}\"}", response.body)
   end
-  
+
   test "a publisher's status can be polled via ajax" do
     perform_enqueued_jobs do
       post(publishers_path, params: SIGNUP_PARAMS)

--- a/test/fixtures/publisher_statements.yml
+++ b/test/fixtures/publisher_statements.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+#one: {}
+# column: value
+#
+#two: {}
+# column: value

--- a/test/models/publisher_statement_test.rb
+++ b/test/models/publisher_statement_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class PublisherStatementTest < ActiveSupport::TestCase
+  test "statements can be created with a publisher and a period" do
+    publisher = publishers(:verified)
+    statement = PublisherStatement.new(publisher: publisher, period: 'past_7_days')
+    assert statement.save
+  end
+
+  test "statements are assigned an expiration date" do
+    publisher = publishers(:verified)
+    statement = PublisherStatement.new(publisher: publisher, period: 'past_7_days')
+    statement.save
+    assert statement.expires_at > Time.zone.now
+    refute statement.expired?
+  end
+end

--- a/test/services/publisher_statement_getter_test.rb
+++ b/test/services/publisher_statement_getter_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PublisherStatementGetterTest < ActiveJob::TestCase
+  test "when offline returns true" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    Rails.application.secrets[:api_eyeshade_offline] = true
+
+    publisher = publishers(:verified)
+
+    publisher_statement = PublisherStatement.new(
+      publisher: publisher,
+      period: :all,
+      source_url: 'example.com')
+
+    result = PublisherStatementGetter.new(publisher_statement: publisher_statement).perform
+
+    assert_equal "Fake offline data", result
+
+    Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+  end
+
+  test "when online returns the response document received by fetching source_url" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    Rails.application.secrets[:api_eyeshade_offline] = false
+
+    stub_request(:get, /report\/123/).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: "Fake", headers: {})
+
+    publisher = publishers(:verified)
+
+    publisher_statement = PublisherStatement.new(
+      publisher: publisher,
+      period: :all,
+      source_url: '/report/123')
+
+    result = PublisherStatementGetter.new(publisher_statement: publisher_statement).perform
+    assert_equal "Fake", result
+
+    Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+  end
+end


### PR DESCRIPTION
Allows publishers connected to uphold to download statements from eyeshade.

The flow is as follows:

1. A publisher requests a statement for a given period from the dashboard.
2. A request is made to eyeshade's `/v1/publishers/#{publisher.brave_publisher_id}/statement` endpoint. A `reportURL` is returned.
3. The `reportURL` endpoint is polled until eyeshade returns the report as CSV data.
4. The report is saved to the `PublisherStatement` record's `contents`, an encrypted `text` field.
5. An email is sent out to notify the publisher that the statement is ready to view.
6. The dashboard continues to poll a `statement_ready` endpoint, which checks for the presence of `contents`. While polling, `Generating...` is shown with varying ellipsis.
    a. When polling succeeds, a `View statement` link is presented on the dashboard.
    b. If the statement is not ready when polling ends, a notice is displayed saying that an email will be sent out when the statement is ready.

Todo: Statements expire after 24 hours. We need a task to clear them out. Tracked via #206.

Closes #74 