### PR TITLE
Remove border-radius from alerts

### DIFF
--- a/app/assets/stylesheets/partials/notifications.sass
+++ b/app/assets/stylesheets/partials/notifications.sass
@@ -4,3 +4,4 @@
 
 .alert
   padding: 13px 15px
+  border-radius: 0


### PR DESCRIPTION
Removes the awkward rounded corners from alerts, like this "Session expired" notice:

![screen shot 2017-10-25 at 9 08 12 am](https://user-images.githubusercontent.com/29122/32000450-be36fca2-b964-11e7-9579-7898a3d9f944.png)
