### PR TITLE
List generated statements on dashboard

### DIFF
--- a/app/assets/javascripts/dynamic_ellipsis.js
+++ b/app/assets/javascripts/dynamic_ellipsis.js
@@ -1,14 +1,30 @@
 (function() {
 
   var ellipsisIntervals = {};
+  var tempId = 0;
 
   this.dynamicEllipsis = {
-    start: function(elementId, durationBetween, maxEllipsis) {
-      var element = document.getElementById(elementId);
-      var text = element.innerText;
+    start: function(elementOrId, durationBetween, maxEllipsis) {
+      var elementId;
+      var element;
+      var text;
       var count = 0;
       var max = maxEllipsis || 5;
       var duration = durationBetween || 200;
+
+      if (typeof elementOrId === 'string') {
+        elementId = elementOrId;
+        element = document.getElementById(elementId);
+      } else {
+        element = elementOrId;
+        if (element.id) {
+          elementId = element.id;
+        } else {
+          elementId = element.id = 'temp-' + tempId++;
+        }
+      }
+
+      text = element.innerText;
 
       ellipsisIntervals[elementId] = setInterval(function() {
         var displayText = text;
@@ -19,7 +35,8 @@
       }, duration);
     },
 
-    stop: function(elementId) {
+    stop: function(elementOrId) {
+      var elementId = typeof elementOrId === 'string' ? elementOrId : elementOrId.id;
       clearInterval(ellipsisIntervals[elementId]);
     }
   };

--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -526,6 +526,23 @@ body[data-controller="publishers"]
         font-weight: 700
       .statements
         white-space: nowrap
+      #generated_statements
+        margin: 12px 0 16px 0
+        .statement
+          font-size: 14px
+          font-weight: 300
+          margin-bottom: 6px
+          &:hover
+            font-weight: 400
+          .date
+            display: inline-block
+            width: 45%
+          .period
+            display: inline-block
+            width: 30%
+          .download
+            display: inline-block
+            width: 25%
       #statement_period
         margin-top: 5px
         margin-right: 10px
@@ -539,9 +556,6 @@ body[data-controller="publishers"]
         &#generate_statement
           line-height: 26px
           padding: 5px 0
-      #generate_statement_result
-        margin-bottom: 16px
-        font-weight: 500
       #publishers_list
         .list-label
           display: block

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -287,7 +287,11 @@ class PublishersController < ApplicationController
     statement_period = params[:statement_period]
     statement = PublisherStatementGenerator.new(publisher: publisher, statement_period: statement_period.to_sym).perform
     SyncPublisherStatementJob.perform_later(publisher_statement_id: statement.id)
-    render(json: { id: statement.id }, status: 200)
+    render(json: {
+      id: statement.id,
+      date: statement_period_date(statement.created_at),
+      period: statement_period_description(statement.period.to_sym)
+    }, status: 200)
   end
 
   def statement_ready

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -214,16 +214,24 @@ module PublishersHelper
     PublisherDnsRecordGenerator.new(publisher: publisher).perform
   end
 
-  def publisher_statement_periods
-    [
-      [t('publisher_statement_periods.past_7_days'), :past_7_days],
-      [t('publisher_statement_periods.past_30_days'), :past_30_days],
-      [t('publisher_statement_periods.this_month'), :this_month],
-      [t('publisher_statement_periods.last_month'), :last_month],
-      [t('publisher_statement_periods.this_year'), :this_year],
-      [t('publisher_statement_periods.last_year'), :last_year],
-      [t('publisher_statement_periods.all'), :all]
-    ]
+  def statement_periods
+    [:past_7_days,
+     :past_30_days,
+     :this_month,
+     :last_month,
+     :this_year,
+     :last_year,
+     :all].collect do |period|
+      [statement_period_description(period), period]
+    end
+  end
+
+  def statement_period_description(period)
+    t("publisher_statement_periods.#{period}")
+  end
+
+  def statement_period_date(date)
+    date.strftime('%B %e, %Y')
   end
 
   def publisher_statement_filename(publisher_statement)

--- a/app/jobs/sync_publisher_statement_job.rb
+++ b/app/jobs/sync_publisher_statement_job.rb
@@ -8,7 +8,7 @@ class SyncPublisherStatementJob < ApplicationJob
 
     publisher_statement.reload
     unless publisher_statement.contents.present?
-      SyncPublisherStatementJob.set(wait: 5.seconds).perform_later(publisher_statement_id: publisher_statement.id)
+      SyncPublisherStatementJob.set(wait: 3.seconds).perform_later(publisher_statement_id: publisher_statement.id)
     end
   end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,7 +1,7 @@
 class Publisher < ApplicationRecord
   has_paper_trail
 
-  has_many :statements, class_name: 'PublisherStatement'
+  has_many :statements, -> { order('created_at DESC') }, class_name: 'PublisherStatement'
 
   attr_encrypted :authentication_token, key: :encryption_key
   attr_encrypted :uphold_code, key: :encryption_key

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -138,6 +138,7 @@ javascript:
       var generateStatement = document.getElementById('generate_statement');
       var generateStatementResult = document.getElementById('generate_statement_result');
       var statementPeriod = document.getElementById('statement_period');
+      var generatedStatements = document.getElementById('generated_statements');
 
       editContact.addEventListener('click', function(event) {
         updateContactName.value = showContactName.innerText;
@@ -174,38 +175,54 @@ javascript:
           });
       }, false);
 
-      statementPeriod.addEventListener('click', function(event) {
-        hideSpinner();
-        generateStatement.style.display = 'inline-block';
-        generateStatementResult.style.display = 'none';
-      }, false);
-
       generateStatement.addEventListener('click', function(event) {
         var statementId;
+        var statementDownloadDiv;
 
         event.preventDefault();
+        generateStatement.style.display = 'none';
 
         submitForm('statement_generator', 'PATCH', false)
           .then(function(response) {
             return response.json();
           })
           .then(function(json) {
-            generateStatement.style.display = 'none';
-            generateStatementResult.style.display = 'inline-block';
-            generateStatementResult.innerText = 'Generating';
+            var newStatementDiv = document.createElement('div');
+            newStatementDiv.className = 'statement';
 
-            dynamicEllipsis.start('generate_statement_result');
+            var statementDateDiv = document.createElement('div');
+            statementDateDiv.className = 'date';
+            statementDateDiv.appendChild(document.createTextNode(json.date));
+            newStatementDiv.appendChild(statementDateDiv);
+
+            var statementPeriodDiv = document.createElement('div');
+            statementPeriodDiv.className = 'period';
+            statementPeriodDiv.appendChild(document.createTextNode(json.period));
+            newStatementDiv.appendChild(statementPeriodDiv);
+
+            statementDownloadDiv = document.createElement('div');
+            statementDownloadDiv.className = 'download';
+            statementDownloadDiv.appendChild(document.createTextNode('Generating'));
+            newStatementDiv.appendChild(statementDownloadDiv);
+
+            generatedStatements.insertBefore(newStatementDiv, generatedStatements.firstChild);
+
+            dynamicEllipsis.start(statementDownloadDiv);
 
             statementId = json.id;
-            return pollUntilSuccess('/publishers/statement_ready?id=' + statementId, 3000, 2000, 4);
+            return pollUntilSuccess('/publishers/statement_ready?id=' + statementId, 3000, 2000, 7);
           })
           .then(function() {
-            dynamicEllipsis.stop('generate_statement_result');
-            generateStatementResult.innerHTML = '<a href="/publishers/statement?id=' + statementId + '" class="btn btn-tertiary btn-generate">View statement</a>';
+            dynamicEllipsis.stop(statementDownloadDiv);
+            statementDownloadDiv.innerHTML = '<a href="/publishers/statement?id=' + statementId + '">Download</a>';
+            generateStatement.style.display = 'inline-block';
           })
           .catch(function(e) {
-            dynamicEllipsis.stop('generate_statement_result');
-            generateStatementResult.innerText = 'We will email you when your report is ready.'
+            if (statementDownloadDiv) {
+              dynamicEllipsis.stop(statementDownloadDiv);
+              statementDownloadDiv.innerText = 'Delayed'
+            }
+            generateStatement.style.display = 'inline-block';
           });
       }, false);
     }, false);
@@ -300,15 +317,21 @@ noscript
     .sub-panel.dashboard-panel
       .statements#statement_section style=(current_publisher.uphold_verified ? '' : 'display: none')
         .panel-header.panel-header-h4#publishers_statement
-          = t("publishers.statement")
+          = t("publishers.statements")
         = form_for(current_publisher, url: generate_statement_publishers_path, html: { id: "statement_generator" }) do |f|
           .form-group
-            = select_tag(:statement_period, options_for_select(publisher_statement_periods, :past_30_days))
+            = select_tag(:statement_period, options_for_select(statement_periods, :past_30_days))
             .pull-right
               a.edit-link#generate_statement href="#"
                 = t("shared.generate")
         .clearfix
-        #generate_statement_result
+        #generated_statements
+          - current_publisher.statements.each do |s|
+            .statement
+              .date= statement_period_date(s.created_at)
+              .period= statement_period_description(s.period.to_sym)
+              .download= link_to('Download', statement_publishers_url(id: s.id))
+
       .panel-header.panel-header-h4#publishers_contact
         = t("publishers.contact")
         .pull-right

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,7 +102,7 @@ en:
       contact_info: "Contact Info"
       verify_site: "Verify Your Site"
       create_wallet: "Create Your Wallet"
-    statement: "Statement"
+    statements: "Statements"
     verified_phone_html: |
       Phone Number <span class="optional">(optional)</span>
     status_complete: "Verified"

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -372,7 +372,12 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     publisher_statement = PublisherStatement.order(created_at: :asc).last
 
     assert_response 200
-    assert_match("{\"id\":\"#{publisher_statement.id}\"}", response.body)
+    assert_match(
+      '{"id":"' + publisher_statement.id + '",' +
+        '"date":"' + publisher_statement.created_at.strftime('%B %e, %Y') + '",' +
+        '"period":"All"}',
+      response.body)
+    # assert_match("{\"id\":\"#{publisher_statement.id}\"}", response.body)
   end
 
   test "a publisher's status can be polled via ajax" do


### PR DESCRIPTION
The dashboard now shows a listing of generated statements. The statements are shown in chronological order, newest at the top. For example:

![screen shot 2017-10-26 at 6 20 38 pm](https://user-images.githubusercontent.com/29122/32079841-8387ed48-ba7a-11e7-8fda-3bedbc079d09.png)

When Generate is clicked, a new row is added to the top, and `Generating...` is displayed in the "Download" column. 

![screen shot 2017-10-26 at 6 20 03 pm](https://user-images.githubusercontent.com/29122/32079847-882f35cc-ba7a-11e7-9985-27599426ee81.png)

Once the report is available, the `Generating` link becomes a `Download` link like the others.

If the report doesn't become available within a couple minutes of polling, polling stops and `Delayed` is displayed. The user must either refresh the page or wait for an email (or both) to know when the report is ready.

Only one report can be generated at a time. After the report has been generated, the Generate link reappears.

Fixes #208 