### PR TITLE
Introduce rake task for clearing expired publisher statements

### DIFF
--- a/app/models/publisher_statement.rb
+++ b/app/models/publisher_statement.rb
@@ -11,6 +11,8 @@ class PublisherStatement < ApplicationRecord
 
   after_create :set_expiration
 
+  scope :expired, -> { where("expires_at < :now", now: Time.zone.now) }
+
   def set_expiration
     self.expires_at = Time.zone.now + EXPIRE_AFTER
     save!

--- a/lib/tasks/publisher_statements.rake
+++ b/lib/tasks/publisher_statements.rake
@@ -1,0 +1,5 @@
+namespace :publisher_statements do
+  task :delete_expired => [ :environment ] do
+    PublisherStatement.expired.delete_all
+  end
+end

--- a/test/models/publisher_statement_test.rb
+++ b/test/models/publisher_statement_test.rb
@@ -14,4 +14,22 @@ class PublisherStatementTest < ActiveSupport::TestCase
     assert statement.expires_at > Time.zone.now
     refute statement.expired?
   end
+
+  test "`expired` scope includes all expired statements" do
+    publisher = publishers(:verified)
+    statement1 = PublisherStatement.new(publisher: publisher, period: 'past_7_days')
+    statement1.save
+    statement2 = PublisherStatement.new(publisher: publisher, period: 'past_7_days')
+    statement2.save
+    statement3 = PublisherStatement.new(publisher: publisher, period: 'past_7_days')
+    statement3.save
+
+    statement2.expires_at = 2.days.ago
+    statement2.save
+
+    statement3.expires_at = 1.minute.ago
+    statement3.save
+
+    assert_equal 2,PublisherStatement.expired.count
+  end
 end


### PR DESCRIPTION
After this has been merged, we'll need to configure the heroku scheduler to run it periodically (hourly?).

Closes #206