### PR TITLE
Fix dashboard JS error when default currency is not present.

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -142,10 +142,12 @@ javascript:
       }, false);
 
       var defaultCurrencySelect = document.getElementById('publisher_default_currency');
-      defaultCurrencySelect.addEventListener('change', function (event) {
-        submitForm('update_default_currency_form', 'PATCH', true);
-        refreshBalance();
-      }, false);
+      if (defaultCurrencySelect) {
+        defaultCurrencySelect.addEventListener('change', function (event) {
+          submitForm('update_default_currency_form', 'PATCH', true);
+          refreshBalance();
+        }, false);
+      }
 
       var showContact = document.getElementById('show_contact');
       var showContactName = document.getElementById('show_contact_name');


### PR DESCRIPTION
Unless Uphold has been connected, this error will prevent some of
the dashboard’s dynamic functionality.

Fixes #231

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
