### PR TITLE
Update Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 App for [publishers.brave.com](https://publishers.brave.com).
 
-[![Build Status](https://travis-ci.org/brave/publishers.svg?branch=master)](https://travis-ci.org/brave/publishers)
+[![Build Status](https://travis-ci.org/brave-intl/publishers.svg?branch=master)](https://travis-ci.org/brave-intl/publishers)
 
 ## Quick start
 


### PR DESCRIPTION
I noticed during project setup that the TravisCI badge in the README displays `unknown` as it refers to `brave/publishers` instead of `brave-intl/publishers`. Updating to the correct TravisCI URL displays the current build status as expected:

[![Build Status](https://travis-ci.org/brave-intl/publishers.svg?branch=master)](https://travis-ci.org/brave-intl/publishers)

