### PR TITLE
Don't show converted currency if none is set (or if set to BAT)

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -46,6 +46,7 @@ module PublishersHelper
 
   def publisher_converted_balance(publisher)
     currency = publisher_default_currency(publisher)
+    return if currency == "BAT"
     if balance = publisher.balance
       converted_amount = '%.2f' % balance.convert_to(currency)
       I18n.t("publishers.balance_pending_approximate", amount: converted_amount, code: currency)

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -6,4 +6,25 @@ class PublishersHelperTest < ActionView::TestCase
     assert_dom_equal %{<a href="http://#{publisher.brave_publisher_id}">#{publisher.brave_publisher_id}</a>},
                      link_to_brave_publisher_id(publisher)
   end
+
+  test "publisher_converted_balance should return nothing for unset publisher currency" do
+    publisher = publishers(:default)
+    publisher.default_currency = nil
+    publisher.save
+    assert_dom_equal %{}, publisher_converted_balance(publisher)
+  end
+
+  test "publisher_converted_balance should return nothing for BAT publisher currency" do
+    publisher = publishers(:default)
+    publisher.default_currency = "BAT"
+    publisher.save
+    assert_dom_equal %{}, publisher_converted_balance(publisher)
+  end
+
+  test "publisher_converted_balance should return something for set publisher currency" do
+    publisher = publishers(:default)
+    publisher.default_currency = "USD"
+    publisher.save
+    assert_dom_equal %{Approximately 9001.00 USD}, publisher_converted_balance(publisher)
+  end
 end


### PR DESCRIPTION
Resolves #222 

![image](https://user-images.githubusercontent.com/250934/32468097-e687e012-c31a-11e7-923c-fb52eaedf584.png)
![image](https://user-images.githubusercontent.com/250934/32468277-968a30c8-c31b-11e7-9271-8be061960c5d.png)

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
