### PR TITLE
Improve tests related to 233

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -27,7 +27,7 @@ class Publisher < ApplicationRecord
   # brave_publisher_id is a normalized identifier provided by ledger API
   # It is like base domain (eTLD + left part) but may include additional
   # formats to support more publishers.
-  validates :brave_publisher_id, uniqueness: { if: -> { brave_publisher_id_changed? && verified_publisher_exists? } }
+  validates :brave_publisher_id, uniqueness: { if: -> { brave_publisher_id.present? && brave_publisher_id_changed? && verified_publisher_exists? } }
 
   # ensure that site publishers do not have oauth credentials (and vice versa)
   validates :brave_publisher_id, absence: true, if: -> { auth_user_id.present? }

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -53,3 +53,12 @@ uphold_connected:
   verification_token: "e3d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
   verified: true
   uphold_verified: true
+
+google_verified:
+  auth_user_id: "abc123"
+  auth_provider: "google_oauth2"
+  email: "alice@verified.org"
+  name: "Alice the Verified"
+  phone: "4159001421"
+  phone_normalized: "+14159001421"
+  verified: true

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -137,6 +137,8 @@ class PublisherTest < ActiveSupport::TestCase
 
   test "a publisher cannot be associated with both a site and auth credentials" do
     publisher = publishers(:verified)
+    assert publisher.valid?
+
     publisher.auth_user_id = '123'
     refute publisher.valid?
 

--- a/test/services/youtube_channel_getter_test.rb
+++ b/test/services/youtube_channel_getter_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+require "webmock/minitest"
+
+class YoutubeChannelGetterTest < ActiveJob::TestCase
+  test "returns data for a single YouTube channel when channels are requested" do
+    token = 'token123'
+    publisher = publishers(:google_verified)
+    channel_data = { 'id' => 'yt123' }
+
+    stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?mine=true&part=statistics,snippet").
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                       'Authorization' => "Bearer #{token}",
+                       'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
+
+    assert_equal channel_data, YoutubeChannelGetter.new(publisher: publisher, token: token).perform
+  end
+
+  test "returns nil when channels are requested for a YouTube user has no channels" do
+    token = 'token123'
+    publisher = publishers(:google_verified)
+
+    stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?mine=true&part=statistics,snippet").
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Authorization' => "Bearer #{token}",
+                     'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 200, body: {}.to_json, headers: {})
+
+    assert_nil YoutubeChannelGetter.new(publisher: publisher, token: token).perform
+  end
+
+  test "returns data for a single YouTube channel when a particular channel is requested" do
+    token = 'token123'
+    publisher = publishers(:google_verified)
+    channel_id = 'yt123'
+    channel_data = { 'id' => channel_id }
+
+    stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?id=#{channel_id}&part=statistics,snippet").
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Authorization' => "Bearer #{token}",
+                     'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
+
+    assert_equal channel_data, YoutubeChannelGetter.new(publisher: publisher, token: token, channel_id: channel_id).perform
+  end
+
+  test "raises a ChannelForbiddenError when a particular channel is requested but can not be accessed" do
+    token = 'token123'
+    publisher = publishers(:google_verified)
+    channel_id = 'yt123'
+    channel_data = { 'id' => channel_id }
+
+    stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?id=#{channel_id}&part=statistics,snippet").
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Authorization' => "Bearer #{token}",
+                     'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 403, headers: {})
+
+    assert_raises(YoutubeChannelGetter::ChannelForbiddenError) do
+      YoutubeChannelGetter.new(publisher: publisher, token: token, channel_id: channel_id).perform
+    end
+  end
+
+  test "raises a ChannelNotFoundError when a particular channel is requested but can not be found" do
+    token = 'token123'
+    publisher = publishers(:google_verified)
+    channel_id = 'yt123'
+    channel_data = { 'id' => channel_id }
+
+    stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?id=#{channel_id}&part=statistics,snippet").
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Authorization' => "Bearer #{token}",
+                     'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 404, headers: {})
+
+    assert_raises(YoutubeChannelGetter::ChannelNotFoundError) do
+      YoutubeChannelGetter.new(publisher: publisher, token: token, channel_id: channel_id).perform
+    end
+  end
+
+  test "raises a ChannelBadRequestError when a particular channel is requested but an unexpected error is raised" do
+    token = 'token123'
+    publisher = publishers(:google_verified)
+    channel_id = 'yt123'
+    channel_data = { 'id' => channel_id }
+
+    stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?id=#{channel_id}&part=statistics,snippet").
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Authorization' => "Bearer #{token}",
+                     'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 400, headers: {})
+
+    assert_raises(YoutubeChannelGetter::ChannelBadRequestError) do
+      YoutubeChannelGetter.new(publisher: publisher, token: token, channel_id: channel_id).perform
+    end
+  end
+end


### PR DESCRIPTION
Adds tests for the `YoutubeChannelGetter` service.

Also fixes a validation bug for the `Publisher` model, which should only be validating the uniqueness of `brave_publisher_id` if it is present.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
