### PR TITLE
Support owners/statement endpoint

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -373,7 +373,7 @@ noscript
             .statement
               .date= statement_period_date(s.created_at)
               .period= statement_period_description(s.period.to_sym)
-              .download= link_to('Download', statement_publishers_url(id: s.id))
+              .download= s.encrypted_contents? ? link_to(t("publishers.statement_download"), statement_publishers_url(id: s.id)) : t("publishers.statement_delayed")
 
       .panel-header.panel-header-h4#publishers_contact
         = t("publishers.contact")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,8 @@ en:
       verify_site: "Verify Your Site"
       create_wallet: "Create Your Wallet"
     statements: "Statements"
+    statement_download: "Download"
+    statement_delayed: "Delayed"
     verified_phone_html: |
       Phone Number <span class="optional">(optional)</span>
     status_complete: "Verified"

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -57,6 +57,7 @@ uphold_connected:
 google_verified:
   auth_user_id: "abc123"
   auth_provider: "google_oauth2"
+  youtube_channel_id: 'yt123'
   email: "alice@verified.org"
   name: "Alice the Verified"
   phone: "4159001421"


### PR DESCRIPTION
This endpoint is used by the PublisherStatementGenerator service to
generate statements. It must be used for content creators (i.e. not
site publishers).

Closes #247

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [x] Adequate test coverage exists to prevent regressions

Security:
- [x] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [x] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
