### PR TITLE
Refine and test the OAuth callback controller

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -25,7 +25,8 @@ module Publishers
 
         publisher.save!
       else
-        publisher = Publisher.where(auth_provider: oauth_response.provider, auth_user_id: oauth_response.uid).first
+        publisher = Publisher.where(auth_provider: oauth_response.provider, auth_user_id: oauth_response.uid).
+            where.not(youtube_channel_id: nil).first
         unless publisher
           redirect_to('/', notice: I18n.t("youtube.account_not_found"))
           return

--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -22,18 +22,12 @@ module Publishers
         publisher.auth_email = oauth_response.dig('info', 'email')
 
         publisher.verified = true
-
-        publisher.save!
       else
         publisher = Publisher.where(auth_provider: oauth_response.provider, auth_user_id: oauth_response.uid).
             where.not(youtube_channel_id: nil).first
         unless publisher
           redirect_to('/', notice: I18n.t("youtube.account_not_found"))
           return
-        end
-
-        if publisher.auth_name != oauth_response.dig('info', 'name') || publisher.auth_email != oauth_response.dig('info', 'email')
-          refresh_eyeshade = true
         end
       end
 
@@ -45,11 +39,32 @@ module Publishers
 
       # Sync the Youtube channel details
       # Doing this only after login since token refresh is not being used
-      sync_result = PublisherYoutubeChannelSyncer.new(publisher: current_publisher,
-                                                      token: session['google_oauth2_credentials_token']).perform
+      begin
+        channel_changed = PublisherYoutubeChannelSyncer.new(publisher: current_publisher,
+                                                            token: session['google_oauth2_credentials_token']).perform
 
-      if sync_result == :new_channel
-        refresh_eyeshade = true
+        if channel_changed
+          refresh_eyeshade = true
+        end
+
+        current_publisher.save!
+
+      rescue PublisherYoutubeChannelSyncer::ChannelAlreadyClaimedError => e
+        require "sentry-raven"
+        Raven.capture_exception(e)
+
+        current_publisher.auth_provider = nil
+        current_publisher.auth_user_id = nil
+        current_publisher.auth_name = nil
+        current_publisher.name = nil
+        current_publisher.auth_email = nil
+        current_publisher.verified = false
+        current_publisher.youtube_channel = nil
+
+        current_publisher.save!
+
+        redirect_to email_verified_publishers_path, notice: t('youtube.channel_already_taken')
+        return
       end
 
       if refresh_eyeshade

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -29,6 +29,8 @@ class Publisher < ApplicationRecord
   # formats to support more publishers.
   validates :brave_publisher_id, uniqueness: { if: -> { brave_publisher_id.present? && brave_publisher_id_changed? && verified_publisher_exists? } }
 
+  validate :youtube_channel_not_changed_once_initialized
+
   # ensure that site publishers do not have oauth credentials (and vice versa)
   validates :brave_publisher_id, absence: true, if: -> { auth_user_id.present? }
   validates :auth_user_id, absence: true, if: -> { brave_publisher_id.present? }
@@ -187,5 +189,14 @@ class Publisher < ApplicationRecord
 
   def verified_publisher_exists?
     self.class.where(brave_publisher_id: brave_publisher_id, verified: true).any?
+  end
+
+  # verification to ensure youtube_channel is not changed
+  def youtube_channel_not_changed_once_initialized
+    return if youtube_channel_id_was.nil?
+
+    if youtube_channel_id_was != youtube_channel_id
+      errors.add(:youtube_channel_id, "can not change once initialized")
+    end
   end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -30,6 +30,7 @@ class Publisher < ApplicationRecord
   validates :brave_publisher_id, uniqueness: { if: -> { brave_publisher_id.present? && brave_publisher_id_changed? && verified_publisher_exists? } }
 
   validate :youtube_channel_not_changed_once_initialized
+  validates_uniqueness_of :youtube_channel_id, if: -> { youtube_channel_id.present? }
 
   # ensure that site publishers do not have oauth credentials (and vice versa)
   validates :brave_publisher_id, absence: true, if: -> { auth_user_id.present? }

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -200,4 +200,8 @@ class Publisher < ApplicationRecord
       errors.add(:youtube_channel_id, "can not change once initialized")
     end
   end
+
+  def self.youtube_channel_in_use(id)
+    self.where(youtube_channel_id: id).count > 0
+  end
 end

--- a/app/models/youtube_channel.rb
+++ b/app/models/youtube_channel.rb
@@ -5,7 +5,6 @@ class YoutubeChannel < ApplicationRecord
 
   validates :title, presence: true
   validates :thumbnail_url, presence: true
-  validates :id, uniqueness: true, presence: true
 
   def channel_identifier
     "youtube#channel:#{id}"

--- a/app/models/youtube_channel.rb
+++ b/app/models/youtube_channel.rb
@@ -5,8 +5,15 @@ class YoutubeChannel < ApplicationRecord
 
   validates :title, presence: true
   validates :thumbnail_url, presence: true
+  validates :id, uniqueness: true, presence: true
 
   def channel_identifier
     "youtube#channel:#{id}"
+  end
+
+  def self.assign_or_new(attributes)
+    obj = first || new
+    obj.assign_attributes(attributes)
+    obj
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,4 +342,5 @@ en:
     authenticate_with_youtube: "Authenticate with YouTube"
     account_not_found: "Couldn't find a matching publisher record"
     channel_not_found: "Channel not found"
+    channel_already_taken: "Channel already taken"
     oauth_error: "Error connecting to YouTube"

--- a/db/migrate/20171108212006_add_index_to_youtube_channels.rb
+++ b/db/migrate/20171108212006_add_index_to_youtube_channels.rb
@@ -1,0 +1,5 @@
+class AddIndexToYoutubeChannels < ActiveRecord::Migration[5.0]
+  def change
+    add_index :youtube_channels, :id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171101165616) do
+ActiveRecord::Schema.define(version: 20171108212006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 20171101165616) do
     t.integer  "subscriber_count"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
+    t.index ["id"], name: "index_youtube_channels_on_id", unique: true, using: :btree
   end
 
 end

--- a/test/controllers/publishers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/publishers/omniauth_callbacks_controller_test.rb
@@ -155,6 +155,11 @@ module Publishers
 
         # should redirect to email_verified so user can try another youtube account
         assert_redirected_to email_verified_publishers_path
+        follow_redirect!
+
+        assert_select('div.notifications') do |element|
+          assert_match(I18n.translate('youtube.channel_already_taken'), element.text)
+        end
       end
     end
 

--- a/test/controllers/publishers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/publishers/omniauth_callbacks_controller_test.rb
@@ -1,0 +1,161 @@
+require "test_helper"
+require "shared/mailer_test_helper"
+require "webmock/minitest"
+
+module Publishers
+  class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+    include ActionMailer::TestHelper
+    include MailerTestHelper
+    include PublishersHelper
+
+    SIGNUP_PARAMS = {
+        email: "alice@example.com"
+    }.freeze
+
+    test "credentials are associated with the current publisher if it exists" do
+      begin
+        OmniAuth.config.test_mode = true
+
+        token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
+
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+            {
+                "provider" => "google_oauth2",
+                "uid" => "123545",
+                "info" => {
+                    "name" => "Test Brand Account",
+                    "email" => "brand@nonfunctional.google.com",
+                    "first_name" => "Test Brand Account",
+                    "image" => "https://lh4.googleusercontent.com/-tP57axXeGuI/AAAAAAAAAAI/AAAAAAAAAA0/LSxNfj3nB8c/photo.jpg"
+                },
+                "credentials" => {
+                    "token" => token,
+                    "expires_at" => 2510156374,
+                    "expires" => true
+                }
+            }
+        )
+
+        perform_enqueued_jobs do
+          post(publishers_path, params: SIGNUP_PARAMS)
+        end
+        publisher = Publisher.order(created_at: :asc).last
+        url = publisher_url(publisher, token: publisher.authentication_token)
+        get(url)
+
+        publisher.verified = true
+        publisher.save!
+
+        channel_data = {
+            "id" => "234542342332134",
+            "snippet" => {
+                "title" => "DIY",
+                "description" => "DIY Description",
+                "thumbnails" => {
+                    "default" => {
+                        "url" => "http://some_host.com/thumb.png"
+                    }
+                }
+            },
+            "statistics" => {
+                "subscriberCount" => 12
+            }
+        }
+
+
+        stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?mine=true&part=statistics,snippet").
+            with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                            'Authorization' => "Bearer #{token}",
+                            'User-Agent' => 'Faraday v0.9.2' }).
+            to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
+
+        get(publisher_google_oauth2_omniauth_authorize_url)
+        follow_redirect!
+
+        publisher.reload
+
+        assert_not_nil publisher.youtube_channel_id
+        assert_equal "google_oauth2", publisher.auth_provider
+        assert_equal "Test Brand Account", publisher.name
+      end
+    end
+
+    test "a new publisher is sent back to email_verified if a channel exists" do
+      begin
+        OmniAuth.config.test_mode = true
+
+        token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
+
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+            {
+                "provider" => "google_oauth2",
+                "uid" => "123545",
+                "info" => {
+                    "name" => "Test Brand Account",
+                    "email" => "brand@nonfunctional.google.com",
+                    "first_name" => "Test Brand Account",
+                    "image" => "https://lh4.googleusercontent.com/-tP57axXeGuI/AAAAAAAAAAI/AAAAAAAAAA0/LSxNfj3nB8c/photo.jpg"
+                },
+                "credentials" => {
+                    "token" => token,
+                    "expires_at" => 2510156374,
+                    "expires" => true
+                }
+            }
+        )
+
+        perform_enqueued_jobs do
+          post(publishers_path, params: SIGNUP_PARAMS)
+        end
+        publisher = Publisher.order(created_at: :asc).last
+        url = publisher_url(publisher, token: publisher.authentication_token)
+        get(url)
+
+        publisher.verified = true
+        publisher.save!
+
+        diy_channel = youtube_channels(:diy_channel)
+
+        channel_data = {
+            "id" => diy_channel.id,
+            "snippet" => {
+                "title" => "DIY",
+                "description" => "DIY Description",
+                "thumbnails" => {
+                    "default" => {
+                        "url" => "http://some_host.com/thumb.png"
+                    }
+                }
+            },
+            "statistics" => {
+                "subscriberCount" => 12
+            }
+        }
+
+        stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?mine=true&part=statistics,snippet").
+            with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                            'Authorization' => "Bearer #{token}",
+                            'User-Agent' => 'Faraday v0.9.2' }).
+            to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
+
+        get(publisher_google_oauth2_omniauth_authorize_url)
+        follow_redirect!
+
+        publisher.reload
+
+        # All OAuth set fields should be nil
+        assert_nil publisher.youtube_channel_id
+        assert_nil publisher.auth_provider
+        assert_nil publisher.auth_name
+        assert_nil publisher.auth_user_id
+        assert_nil publisher.name
+        assert_nil publisher.auth_email
+        refute publisher.verified
+
+        # should redirect to email_verified so user can try another youtube account
+        assert_redirected_to email_verified_publishers_path
+      end
+    end
+  end
+end

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -54,6 +54,21 @@ uphold_connected:
   verified: true
   uphold_verified: true
 
+youtube_initial:
+  brave_publisher_id: nil
+  email: "alice@spud.com"
+  name: "Alice the Youtuber"
+  phone: "4159001420"
+  phone_normalized: "+14159001420"
+
+youtube_new:
+  brave_publisher_id: nil
+  email: "alice@spud.com"
+  name: "Alice the Youtuber"
+  phone: "4159001420"
+  phone_normalized: "+14159001420"
+  youtube_channel_id: "323541525412313421"
+
 google_verified:
   auth_user_id: "abc123"
   auth_provider: "google_oauth2"

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -77,3 +77,4 @@ google_verified:
   phone: "4159001421"
   phone_normalized: "+14159001421"
   verified: true
+  youtube_channel_id: "78032"

--- a/test/fixtures/youtube_channels.yml
+++ b/test/fixtures/youtube_channels.yml
@@ -1,0 +1,14 @@
+diy_channel:
+  id: "323541525412313421"
+  title: "The DIY Channel"
+  thumbnail_url: "https://some_image_host.com/some_image.png"
+
+some_channel:
+  id: "123456"
+  title: "Some Guy's Channel"
+  thumbnail_url: "https://some_image_host.com/some_image.png"
+
+some_other_channel:
+  id: "78032"
+  title: "Some Other Guy's Channel"
+  thumbnail_url: "https://some_image_host.com/some_image.png"

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -164,4 +164,13 @@ class PublisherTest < ActiveSupport::TestCase
     publisher.youtube_channel = some_other_channel
     refute publisher.valid?
   end
+
+  test "a publisher cannot have the same youtube channel as another publisher" do
+    publisher = publishers(:youtube_initial)
+    assert publisher.valid?
+
+    diy_channel = youtube_channels(:diy_channel)
+    publisher.youtube_channel = diy_channel
+    refute publisher.valid?
+  end
 end

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -149,4 +149,19 @@ class PublisherTest < ActiveSupport::TestCase
     publisher.brave_publisher_id = 'example.com'
     assert publisher.valid?
   end
+
+  test "a publisher cannot change youtube channels" do
+    publisher = publishers(:youtube_initial)
+    assert publisher.valid?
+
+    some_channel = youtube_channels(:some_channel)
+    publisher.youtube_channel = some_channel
+    assert publisher.valid?
+
+    publisher.save
+
+    some_other_channel = youtube_channels(:some_other_channel)
+    publisher.youtube_channel = some_other_channel
+    refute publisher.valid?
+  end
 end

--- a/test/services/publisher_channel_setter_test.rb
+++ b/test/services/publisher_channel_setter_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PublisherChannelSetterTest < ActiveJob::TestCase
+  test "when offline does nothing" do
+    prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = true
+
+      publisher = publishers(:youtube_new)
+
+      assert PublisherChannelSetter.new(publisher: publisher).perform
+
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
+    end
+  end
+
+  test "when online sends the channel info" do
+    prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+
+      stub_request(:post, /v1\/owners/).
+          with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+          to_return(status: 200, body: nil, headers: {})
+
+      publisher = publishers(:youtube_new)
+
+      result = PublisherChannelSetter.new(publisher: publisher).perform
+      assert_equal 200, result.status
+
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
+    end
+  end
+end


### PR DESCRIPTION
Adds tests for the OAuth callback controller to handle login, signup, and attempted registration of a claimed channel.

Adds validations on channels and publisher models. Fixes missing index on the text ind for yt channels.

Refines logic around when to send the channels to eyeshade. Still need to determine the best way to test this.

Fixes #246, Fixes #244

A migration is needed after deployment. This may have issue with existing data. If so it's probably easiest to truncate the database.

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [x] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [x] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
