### PR TITLE
create publisher when user login from scratch using oauth

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -26,8 +26,15 @@ module Publishers
         publisher = Publisher.where(auth_provider: oauth_response.provider, auth_user_id: oauth_response.uid).
             where.not(youtube_channel_id: nil).first
         unless publisher
-          redirect_to('/', notice: I18n.t("youtube.account_not_found"))
-          return
+          # create new publisher
+          publisher = Publisher.new(
+              auth_provider: oauth_response.provider,
+              auth_user_id: oauth_response.uid,
+              name: oauth_response.dig('info', 'name'),
+              email: oauth_response.dig('info', 'email'),
+              auth_email: oauth_response.dig('info', 'email'),
+              verified: true)
+          publisher.save!
         end
       end
 


### PR DESCRIPTION
Submitter Checklist:
Automatically creates a new publisher if the user signs up using oauth, but hasn't created a publisher account using existing flow.

Resolves #235 @ayumi 

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
