### PR TITLE
Make channel images circular

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -494,6 +494,11 @@ body[data-controller="publishers"]
         margin-bottom: 18px
         .channel-name
           font-size: 16px
+        .channel-thumbnail
+          img
+            height: 88px
+            width: 88px
+            border-radius: 44px
       #publisher_verification_status
         font-size: $font-size-base
         vertical-align: middle


### PR DESCRIPTION
Makes the channel images circular to match google's normal display.

![screen shot 2017-11-14 at 11 07 13 am](https://user-images.githubusercontent.com/29154/32790282-05993322-c92c-11e7-8498-4cc7f23b54df.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
