### PR TITLE
Display modal when channel has already been claimed

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -711,6 +711,54 @@ body[data-controller="publishers"]
       &::before
         content: 'YOUTUBE CREATOR'
 
+    #taken_youtube_channel_modal
+      width: 650px
+      .md-content
+        padding: 70px 80px 70px 80px
+        background: #fff
+        border-radius: 10px
+        h1
+          font-size: 32px
+          font-weight: 300
+          color: #ff3f3f
+          margin-top: 0
+          padding-top: 0
+        .youtube-channel
+          margin: 50px 0 50px 40px
+          .summary
+            margin-bottom: 20px
+            img
+              display: inline-block
+              width: 40px
+              height: 40px
+              border-radius: 20px
+              margin-right: 10px
+            .title
+              display: inline-block
+          .registration-date
+            label
+              display: inline-block
+              margin-right: 8px
+            .value
+              display: inline-block
+          .registered-by
+            label
+              display: inline-block
+              margin-right: 8px
+            .value
+              display: inline-block
+        .panel-section
+          margin-top: 35px
+          text-align: center
+        a.btn
+          min-width: 150px
+          margin: 10px 0
+    @media (max-width: 550px)
+      #taken_youtube_channel_modal .md-content
+        padding: 60px
+        background: #fff
+        border-radius: 0
+
     @media (max-width: 991px)
       .publisher-panel
         width: 400px

--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -73,7 +73,8 @@ module Publishers
 
         current_publisher.save!
 
-        redirect_to email_verified_publishers_path, notice: t('youtube.channel_already_taken')
+        session[:taken_youtube_channel_id] = e.channel_id
+        redirect_to email_verified_publishers_path
         return
       end
 

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -190,6 +190,10 @@ class PublishersController < ApplicationController
   end
 
   def email_verified
+    if session[:taken_youtube_channel_id]
+      @taken_youtube_channel = YoutubeChannel.find(session[:taken_youtube_channel_id])
+      session[:taken_youtube_channel_id] = nil
+    end
     @publisher = current_publisher
   end
 

--- a/app/models/youtube_channel.rb
+++ b/app/models/youtube_channel.rb
@@ -1,5 +1,7 @@
 class YoutubeChannel < ApplicationRecord
 
+  has_one :publisher
+
   #ToDo: Do we want this?
   # has_paper_trail
 

--- a/app/services/publisher_youtube_channel_syncer.rb
+++ b/app/services/publisher_youtube_channel_syncer.rb
@@ -59,7 +59,10 @@ class PublisherYoutubeChannelSyncer
   end
 
   class ChannelAlreadyClaimedError < RuntimeError
+    attr_reader :channel_id
+
     def initialize(channel_id)
+      @channel_id = channel_id
       super "Channel #{channel_id} has already been claimed"
     end
   end

--- a/app/views/publishers/email_verified.html.slim
+++ b/app/views/publishers/email_verified.html.slim
@@ -1,3 +1,61 @@
+- if @taken_youtube_channel
+  - support_email = Rails.application.secrets[:support_email]
+  - taken_youtube_channel_title = @taken_youtube_channel.title
+  - taken_youtube_channel_registered_by = @taken_youtube_channel.publisher.name.present? ? @taken_youtube_channel.publisher.name : t("publishers.youtube_channel_taken_dialog.default_registerer")
+  - taken_youtube_channel_registration_date = @taken_youtube_channel.created_at.to_date
+
+  noscript
+    div.noscript-warning= t("publishers.youtube_channel_taken_noscript_html",
+            { support_email: support_email,
+              youtube_channel_title: taken_youtube_channel_title,
+              youtube_channel_registered_by: taken_youtube_channel_registered_by,
+              youtube_channel_registration_date: taken_youtube_channel_registration_date })
+
+  javascript:
+    (function() {
+      function showYoutubeChannelTakenModal() {
+        var modal = document.getElementById('taken_youtube_channel_modal');
+        classie.add(modal, 'md-show');
+
+        var closeModal = document.getElementById('close_modal');
+        closeModal.addEventListener('click', function() {
+          hideYoutubeChannelTakenModal();
+        });
+        document.addEventListener('keyup', function(e) {
+          if (e.keyCode === 27) hideYoutubeChannelTakenModal();
+        });
+      }
+
+      function hideYoutubeChannelTakenModal() {
+        var modal = document.getElementById('taken_youtube_channel_modal');
+        classie.remove(modal, 'md-show');
+      }
+
+      window.addEventListener('load', function() {
+        showYoutubeChannelTakenModal();
+      });
+    })();
+
+  .md-container#taken_youtube_channel_modal
+    .md-content
+      h1= t("publishers.youtube_channel_taken_dialog.title")
+      p= t("publishers.youtube_channel_taken_dialog.leadin")
+      .youtube-channel
+        .summary
+          img src=@taken_youtube_channel.thumbnail_url
+          .title= taken_youtube_channel_title
+        .registration-date
+          label= t("publishers.youtube_channel_taken_dialog.registration_date") + ":"
+          .value= taken_youtube_channel_registration_date
+        .registered-by
+          label= t("publishers.youtube_channel_taken_dialog.registered_by") + ":"
+          .value= taken_youtube_channel_registered_by
+      p= t("publishers.youtube_channel_taken_dialog.contact_support_html", { support_email: support_email })
+
+      .panel-section
+        a.btn.btn-primary#close_modal= t("publishers.youtube_channel_taken_dialog.ok")
+  .md-overlay
+
 .publisher-panel.col-center
   h1.text-center=t("publishers.pub_type_welcome")
   h2.col-center.text-center=t("publishers.pub_type_lets_start")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -244,6 +244,17 @@ en:
     pub_type_site_individual_creator: "INDIVIDUAL CREATOR"
     pub_type_site_individual_creator_description_html: "I use other platforms to publish my content (currently <strong>YouTube</strong> only)."
     pub_type_site_youtube_creator: "YOUTUBE CREATOR"
+    youtube_channel_taken_dialog:
+      title: "Channel already registered!"
+      leadin: "The following YouTube channel has already been registered."
+      registration_date: "Date"
+      registered_by: "Registered by"
+      default_registerer: "A channel manager"
+      contact_support_html: "Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error."
+      ok: "OK"
+    youtube_channel_taken_noscript_html: |
+      The YouTube channel "%{youtube_channel_title}" was registered by %{youtube_channel_registered_by} on %{youtube_channel_registration_date}.
+      Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error.
 
   publisher_mailer:
     shared:

--- a/test/controllers/publishers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/publishers/omniauth_callbacks_controller_test.rb
@@ -157,8 +157,8 @@ module Publishers
         assert_redirected_to email_verified_publishers_path
         follow_redirect!
 
-        assert_select('div.notifications') do |element|
-          assert_match(I18n.translate('youtube.channel_already_taken'), element.text)
+        assert_select('div#taken_youtube_channel_modal h1') do |element|
+          assert_match(I18n.translate('publishers.youtube_channel_taken_dialog.title'), element.text)
         end
       end
     end


### PR DESCRIPTION
When a user attempts to claim a channel that's already been claimed, present a useful dialog to let them know who claimed the channel and when.

This dialog can be dismissed either by clicking OK or pressing `Esc`.

Please review: @ayumi @jenn-rhim

Resolves #264

![screen shot 2017-11-14 at 6 27 42 pm](https://user-images.githubusercontent.com/29122/32810619-cc671a40-c969-11e7-95fe-3be306ed8061.png)

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
