### PR TITLE
Change format of from_email

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -69,7 +69,7 @@ development:
   host_inspector_offline: true
   internal_email: brave-publishers@localhost.local
   support_email: brave-publishers@localhost.local
-  from_email: '"Brave Payments Publishers Dev"<brave-publishers@localhost.local>'
+  from_email: Brave Payments Publishers Dev<brave-publishers@localhost.local>
   attr_encrypted_key: 499a4c51df667b4edfab40c1f8b813b7ed6ce02096d59f23b5dcb095369375f6
   secret_key_base: dd7b12788a804315fd75f1ff97fae33310b451c39d83d1d015543d25d0ba034c02fd312e83735f0d0aeaaf70131f26e614629e3c40531b949445b4dfacd3bad3
   # Social media links
@@ -85,7 +85,7 @@ test:
   host_inspector_offline: true
   internal_email: brave-publishers@localhost.local
   support_email: brave-publishers@localhost.local
-  from_email: '"Brave Payments Publishers Test"<brave-publishers@localhost.local>'
+  from_email: Brave Payments Publishers Test<brave-publishers@localhost.local>
   attr_encrypted_key: 44c101d4dab61a9aa6f13ebd63ad361ba79567604c6ac8bb68e0874d9cf84f05
   secret_key_base: 2a6a0e458f1a3513655583c806f654e0b2be3dac10be16cad9562c089384cb968f30a9774f7ed247e95d48d51f21d69edeab89b95d140a1007bae21621b284f8
   uphold_authorization_endpoint: "https://uphold.example.com/authorize/<UPHOLD_CLIENT_ID>?scope=<UPHOLD_SCOPE>&intention=signup&state=<STATE>"


### PR DESCRIPTION
Removed quotes from the display name portion of the address. These
are not needed (looked at outdated examples), and if the format is
followed on Heroku it causes a crash on app load.

fixes #275

Note: this change only affects the dev and test environments. Removing the quotes in the staging environment var was enough to fix #275. Still, we should not have a bad example in the app.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))