### PR TITLE
Handle nil case for show_verification_status

### DIFF
--- a/app/serializers/publisher_serializer.rb
+++ b/app/serializers/publisher_serializer.rb
@@ -1,3 +1,7 @@
 class PublisherSerializer < ActiveModel::Serializer
   attributes :id, :email, :name, :phone, :phone_normalized, :verified, :verification_method, :verification_token, :show_verification_status, :created_at, :updated_at, :last_sign_in_at
+
+  def show_verification_status
+    object.show_verification_status?
+  end
 end

--- a/app/services/publisher_channel_setter.rb
+++ b/app/services/publisher_channel_setter.rb
@@ -23,7 +23,7 @@ class PublisherChannelSetter < BaseApiClient
       "providers" => [
         {
           "publisher" => publisher.youtube_channel.channel_identifier,
-          "show_verification_status" => publisher.show_verification_status
+          "show_verification_status" => publisher.show_verification_status?
         }
       ]
     }

--- a/app/services/publisher_token_requester.rb
+++ b/app/services/publisher_token_requester.rb
@@ -12,7 +12,7 @@ class PublisherTokenRequester < BaseApiClient
     return perform_offline if Rails.application.secrets[:api_eyeshade_offline]
     response = connection.get do |request|
       request.headers["Authorization"] = api_authorization_header
-      qp = "show_verification_status=#{publisher.show_verification_status}"
+      qp = "show_verification_status=#{publisher.show_verification_status?}"
       request.url("/v1/publishers/#{publisher.brave_publisher_id}/verifications/#{publisher.id}?#{qp}")
     end
     JSON.parse(response.body)["token"]

--- a/test/controllers/api/publishers_controller_test.rb
+++ b/test/controllers/api/publishers_controller_test.rb
@@ -103,4 +103,24 @@ class Api::PublishersControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal(200, response.status)
   end
+
+  test "show_verification_status returns as false if nil" do
+    default_publisher = publishers(:default)
+    assert_nil default_publisher.show_verification_status
+
+    get "/api/publishers/#{default_publisher.brave_publisher_id}"
+
+    assert_equal(200, response.status)
+    refute_nil JSON.parse(response.body)[0]['show_verification_status']
+  end
+
+  test "show_verification_status returns as true if true" do
+    uphold_connected = publishers(:uphold_connected)
+    assert uphold_connected.show_verification_status
+
+    get "/api/publishers/#{uphold_connected.brave_publisher_id}"
+
+    assert_equal(200, response.status)
+    assert JSON.parse(response.body)[0]['show_verification_status']
+  end
 end

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -53,6 +53,7 @@ uphold_connected:
   verification_token: "e3d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
   verified: true
   uphold_verified: true
+  show_verification_status: true
 
 youtube_initial:
   brave_publisher_id: nil


### PR DESCRIPTION
Fixes #277 by translating nils to false for `show_verification_status`. 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [x] Adequate test coverage exists to prevent regressions

Security:
- [x] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [x] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
