### PR TITLE
Handle case when email is missing on a create (Get Started) call

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -260,6 +260,6 @@ module PublishersHelper
   def name_from_email(email)
     return "Publisher" unless email.is_a?(String)
 
-    email.split("@")[0].capitalize
+    email.split("@")[0].try(:capitalize)
   end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -13,6 +13,7 @@ class Publisher < ApplicationRecord
   phony_normalize :phone, as: :phone_normalized, default_country_code: "US"
 
   validates :email, email: { strict_mode: true }, presence: true, if: -> { brave_publisher_id.present? }
+  validates :pending_email, email: { strict_mode: true }, presence: true, if: -> { email.blank? }
   validates :name, presence: true, if: -> { brave_publisher_id.present? }
   validates :phone_normalized, phony_plausible: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,7 +255,7 @@ en:
     youtube_channel_taken_noscript_html: |
       The YouTube channel "%{youtube_channel_title}" was registered by %{youtube_channel_registered_by} on %{youtube_channel_registration_date}.
       Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error.
-
+    missing_info_provide_email: "We seem to be missing some info. Please make sure you provided an email address."
   publisher_mailer:
     shared:
       contact_help: "If you have any questions, please contact us"

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -173,4 +173,30 @@ class PublisherTest < ActiveSupport::TestCase
     publisher.youtube_channel = diy_channel
     refute publisher.valid?
   end
+
+  test "a publisher must have a valid pending email address if it does not have an email address" do
+    publisher = Publisher.new
+
+    assert_nil publisher.email
+    assert_nil publisher.pending_email
+    refute publisher.valid?
+
+    publisher.pending_email = "foo@bar.com"
+    assert publisher.valid?
+
+    publisher.email = "foo@bar.com"
+    publisher.pending_email = nil
+    assert publisher.valid?
+
+    publisher.email = "foo@bar.com"
+    publisher.pending_email = "bar@bar.com"
+    assert publisher.valid?
+  end
+
+  test "a publisher pending_email address must be valid" do
+    publisher = Publisher.new
+
+    publisher.pending_email = "bad_email_addresscom"
+    refute publisher.valid?
+  end
 end


### PR DESCRIPTION
Adds validation to model to ensure a valid pending email is present
if email is not present

Cleanup controller flow

Protects name_from_email in case it's given an invalid email

Fixes #281

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))