### PR TITLE
Ensure that email subjects properly display publication titles as a prefix

### DIFF
--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -7,7 +7,7 @@ class PublisherMailer < ApplicationMailer
     @private_reauth_url = generate_publisher_private_reauth_url(@publisher)
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -20,7 +20,7 @@ class PublisherMailer < ApplicationMailer
     attachments[generator.filename] = generator.generate_file_content
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -34,7 +34,7 @@ class PublisherMailer < ApplicationMailer
     mail(
       to: INTERNAL_EMAIL,
       reply_to: @publisher.email,
-      subject: "<Internal> #{I18n.t(:subject, brave_publisher_id: @publisher.brave_publisher_id, scope: %w(publisher_mailer verification))}",
+      subject: "<Internal> #{I18n.t(:subject, publication_title: @publisher.publication_title, scope: %w(publisher_mailer verification))}",
       template_name: "verification"
     )
   end
@@ -46,7 +46,7 @@ class PublisherMailer < ApplicationMailer
     attachments.inline["verified-icon.png"] = File.read(path)
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -61,7 +61,7 @@ class PublisherMailer < ApplicationMailer
     mail(
       to: INTERNAL_EMAIL,
       reply_to: @publisher.email,
-      subject: "<Internal> #{I18n.t(:subject, brave_publisher_id: @publisher.brave_publisher_id, scope: %w(publisher_mailer verification_done))}",
+      subject: "<Internal> #{I18n.t(:subject, publication_title: @publisher.publication_title, scope: %w(publisher_mailer verification_done))}",
       template_name: "verification_done"
     )
   end
@@ -72,7 +72,7 @@ class PublisherMailer < ApplicationMailer
     @private_reauth_url = generate_publisher_private_reauth_url(@publisher)
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -85,7 +85,7 @@ class PublisherMailer < ApplicationMailer
     mail(
       to: INTERNAL_EMAIL,
       reply_to: @publisher.email,
-      subject: "<Internal> #{I18n.t(:subject, brave_publisher_id: @publisher.brave_publisher_id, scope: %w(publisher_mailer welcome))}",
+      subject: "<Internal> #{I18n.t(:subject, publication_title: @publisher.publication_title, scope: %w(publisher_mailer welcome))}",
       template_name: "welcome"
     )
   end
@@ -96,7 +96,7 @@ class PublisherMailer < ApplicationMailer
     @private_reauth_url = generate_publisher_private_reauth_url(@publisher)
     mail(
         to: @publisher.pending_email,
-        subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+        subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -119,7 +119,7 @@ class PublisherMailer < ApplicationMailer
     @private_reauth_url = generate_publisher_private_reauth_url(@publisher, @publisher.pending_email)
     mail(
       to: @publisher.pending_email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -127,7 +127,7 @@ class PublisherMailer < ApplicationMailer
     @publisher = publisher
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -135,7 +135,7 @@ class PublisherMailer < ApplicationMailer
     @publisher = publisher
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 
@@ -144,7 +144,7 @@ class PublisherMailer < ApplicationMailer
     @publisher = publisher_statement.publisher
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject(brave_publisher_id: @publisher.brave_publisher_id)
+      subject: default_i18n_subject(publication_title: @publisher.publication_title)
     )
   end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -78,8 +78,17 @@ class Publisher < ApplicationRecord
     Rails.application.secrets[:attr_encrypted_key]
   end
 
+  def publication_title
+    case publication_type
+    when :site
+      brave_publisher_id
+    when :youtube_channel
+      youtube_channel.title
+    end
+  end
+
   def to_s
-    brave_publisher_id
+    publication_title
   end
 
   def prepare_uphold_state_token

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,19 +272,19 @@ en:
       rocketchat: "Rocket.Chat"
 
     uphold_account_changed:
-      subject: "[%{brave_publisher_id}] Brave Publisher Uphold account changed"
+      subject: "[%{publication_title}] Brave Publisher Uphold account changed"
       title: "Publisher Uphold account changed"
       body: "This message confirms that you've updated your Uphold account through the Brave Payments website."
     login_email:
       body_html: |
         Click the private access link below to log in to your account with <strong>Brave Payments</strong>. This link can only be used once.
-      subject: "[%{brave_publisher_id}] Brave Publisher login link"
+      subject: "[%{publication_title}] Brave Publisher login link"
       title: "Brave Publisher login link"
       button: "Log in to Brave Payments"
     verification:
       click_verify: "Click Verify from the Brave Publisher management website."
       download_attached_file: "Download the attached verification file"
-      subject: "[%{brave_publisher_id}] Verify your Brave Publisher website"
+      subject: "[%{publication_title}] Verify your Brave Publisher website"
       title: "Verify website ownership"
       access_link_help_header: "Publisher management website"
       access_link_help_body: "You can find your publisher access link in the previous email we sent to you."
@@ -292,7 +292,7 @@ en:
       erroneous_email_help: "If you believe you received this message in error, you may safely ignore it."
       intro: "We've received a request to register a website with Brave Payments:"
       private_email_notice: "NOTE: This email contains a private access link. Anyone with it can manage private publisher info, including payment information. Before forwarding this email, ensure you trust the recipient."
-      subject: "[%{brave_publisher_id}] Brave Publisher registration"
+      subject: "[%{publication_title}] Brave Publisher registration"
       title: "Publisher registration"
     verify_email:
       body_html: |
@@ -304,12 +304,12 @@ en:
       intro: "Congratulations! You are now a verified Brave publisher Brave users will see a verified symbol next to your website domain."
       payment_help_header: "Ready to claim your funds now?"
       payment_help: "To receive funds contributed by Brave users please visit the publisher management site and submit payment information."
-      subject: "[%{brave_publisher_id}] Publisher website verified"
+      subject: "[%{publication_title}] Publisher website verified"
       title: "Verification complete"
       claim_funds_header: "Ready to claim your funds?"
       claim_funds_body: "To claim your funds please visit the Publishers website to submit your payment information using the link below."
     confirm_email_change:
-      subject: "[%{brave_publisher_id}] Confirm your Brave Publisher email change"
+      subject: "[%{publication_title}] Confirm your Brave Publisher email change"
       title: "Confirm email change"
       erroneous_email_help: "If you believe you received this message in error, you may safely ignore it."
       intro: "We've received a request to update your email address with Brave Payments:"
@@ -321,7 +321,7 @@ en:
       confirmation_link: "Confirm your email change"
       confirmation_link_help: "Use this link to confirm that you would like to proceed with this change"
     notify_email_change:
-      subject: "[%{brave_publisher_id}] Notification of Brave Publisher email change"
+      subject: "[%{publication_title}] Notification of Brave Publisher email change"
       title: "Notification of email change"
       intro: "We're notifying you of an update made to your email address with Brave Payments:"
       previous_email: "Previous email"
@@ -329,7 +329,7 @@ en:
       change_ok: "If you made this change, check your new email account for a link to confirm it."
       contact_support: "If you did not make this change yourself, please contact support ASAP"
     statement_ready:
-      subject: "[%{brave_publisher_id}] Brave Publisher statement is ready to view"
+      subject: "[%{publication_title}] Brave Publisher statement is ready to view"
       title: "Publisher statement is ready to view"
       body: "The following statement has recently been generated:"
       expiration_note: "This statement must be downloaded within the next 24 hours."

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -56,14 +56,12 @@ uphold_connected:
   show_verification_status: true
 
 youtube_initial:
-  brave_publisher_id: nil
   email: "alice@spud.com"
   name: "Alice the Youtuber"
   phone: "4159001420"
   phone_normalized: "+14159001420"
 
 youtube_new:
-  brave_publisher_id: nil
   email: "alice@spud.com"
   name: "Alice the Youtuber"
   phone: "4159001420"

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -6,6 +6,20 @@ class PublisherTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
   include MailerTestHelper
 
+  test "publication_title is the site domain for site publishers" do
+    publisher = publishers(:verified)
+    assert_equal 'verified.org', publisher.brave_publisher_id
+    assert_equal 'verified.org', publisher.publication_title
+    assert_equal 'verified.org', publisher.to_s
+  end
+
+  test "publication_title is the youtube channel title for youtube creators" do
+    publisher = publishers(:youtube_new)
+    assert_equal 'The DIY Channel', publisher.youtube_channel.title
+    assert_equal 'The DIY Channel', publisher.publication_title
+    assert_equal 'The DIY Channel', publisher.to_s
+  end
+
   test "uphold_code is only valid without uphold_access_parameters and before uphold_verified" do
     publisher = publishers(:verified)
     publisher.uphold_code = "foo"


### PR DESCRIPTION
Currently, many email subjects are prefixed with `[%{brave_publisher_id}] The actual subject`.  This results in empty brackets for YouTube creators (e.g. `[] The actual subject`).

This PR introduces a new method on `Publisher` models, `publication_title`, that returns the `brave_publisher_id` for site owners and the `youtube_channel.title` for YouTube creators.

Email subjects that previously relied on `brave_publisher_id` now rely on `publication_title`.

Resolves #292

/cc @ayumi 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
