### PR TITLE
Clarify the error messages and flow for signup

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,7 @@ en:
       The YouTube channel "%{youtube_channel_title}" was registered by %{youtube_channel_registered_by} on %{youtube_channel_registration_date}.
       Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error.
     missing_info_provide_email: "We seem to be missing some info. Please make sure you provided an email address."
+    invalid_email_value: "We seem to be missing some info. Please make sure you have provided a full email address."
   publisher_mailer:
     shared:
       contact_help: "If you have any questions, please contact us"
@@ -344,7 +345,7 @@ en:
   recaptcha:
     errors:
       recaptcha_unreachable: "reCAPTCHA server timeout; please try again."
-      verification_failed: "reCAPTCHA verification failed; please try again."
+      verification_failed: "In case you’re not a bot, we just wanted you to know that reCaptcha didn’t pass this time. Please try again."
   shared:
     api_error: "Your request couldn't be processed due to an API error."
     cancel: "Cancel"


### PR DESCRIPTION
This will give different error messages for each error case we test for during signup. Also adds additional logging.

I removed the `sign_out` calls since a signed in user should never be able to get to this method. I don't think it was causing issues, but it's possible.

Not sure this will close #293, but it will hopefully help with debugging. 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))