### PR TITLE
Improve the landing page on mobile.

### DIFF
--- a/app/assets/stylesheets/application/static.sass
+++ b/app/assets/stylesheets/application/static.sass
@@ -38,13 +38,13 @@ body[data-controller="static"]
       font-weight: 100
       font-size: 32px
       margin-bottom: 0px
-    @media (max-width: 991px)
+    @media (max-width: $screen-md-max)
       h1
         font-weight: 600
         font-size: 48px
         margin-top: 5px
         margin-bottom: 30px
-    @media (min-width: 992px)
+    @media (min-width: $screen-md-min)
       h1
         font-weight: 600
         font-size: 48px
@@ -62,6 +62,10 @@ body[data-controller="static"]
     font-size: 15px
     font-weight: 200
     letter-spacing: 0.02em
+    padding-bottom: 0
+    margin-bottom: 0
+    @media (max-width: $screen-xs-max)
+      padding-bottom: 15px
     strong
       color: white
       font-weight: 500
@@ -80,13 +84,19 @@ body[data-controller="static"]
     margin-top: 25px
     background: rgba(#222326, 0.2)
     border-radius: 8px
-    padding: 60px 40px 20px 40px
+    padding: 60px 40px 35px 40px
+    @media (max-width: $screen-xs-max)
+      padding: 40px 30px 35px 30px
 
     .form-group
       margin-top: 40px
+      @media (max-width: $screen-xs-max)
+        margin-top: 20px
     hr
       margin-top: 70px
       margin-bottom: 30px
+      @media (max-width: $screen-xs-max)
+        margin-top: 35px
 
   .terms-of-service
     margin: 20px 0 150px 0
@@ -95,17 +105,7 @@ body[data-controller="static"]
       font-size: 14px
       font-weight: 300
 
-  @media (max-width: 767px)
-    .logo
-      margin-top: 50px
-      margin-bottom: 50px
-    .col-centered
-      float: none
-      margin: 0 auto
-      padding-left: 30px
-      padding-right: 30px
-
-  @media (max-width: 991px)
+  @media (max-width: $screen-sm-max)
     .col-centered
       float: none
       margin: 0 auto
@@ -115,7 +115,18 @@ body[data-controller="static"]
       margin-top: 0px
       margin-bottom: 10px
 
-  @media (min-width: 992px)
+  @media (max-width: $screen-xxs-max)
+    .logo
+      margin-top: 50px
+      margin-bottom: 50px
+    .col-centered
+      float: none
+      margin: 0 auto
+      padding-left: 20px
+      padding-right: 20px
+
+
+  @media (min-width: $screen-md-min)
     .col-left
       padding-left: 60px
       padding-right: 20px
@@ -126,7 +137,7 @@ body[data-controller="static"]
       margin-top: 10px
       margin-bottom: 35px
 
-  @media (min-width: 1200px)
+  @media (min-width: $screen-lg-min)
     .col-left
       padding-left: 80px
       padding-right: 20px
@@ -160,6 +171,9 @@ body[data-controller="static"]
     color: white
   .button-column
     padding-left: 0px
+    @media (max-width: $screen-xs-max)
+      &.col-xs-12
+        padding-left: 15px
   .btn
     &.btn-primary
       background: #72008B

--- a/app/assets/stylesheets/shared/forms.sass
+++ b/app/assets/stylesheets/shared/forms.sass
@@ -11,3 +11,6 @@ legend + .help-block
 
 .field_with_errors
   @extend .has-error
+
+.row.form-row .col
+  margin-bottom: 15px

--- a/app/assets/stylesheets/variables/breakpoints.scss
+++ b/app/assets/stylesheets/variables/breakpoints.scss
@@ -1,0 +1,5 @@
+/*
+ * See http://bootstrapdocs.com/v3.0.3/docs/css/#grid for default breakpoints
+ */
+$screen-xxs-max: 560px;
+

--- a/app/views/layouts/static.html.slim
+++ b/app/views/layouts/static.html.slim
@@ -4,7 +4,7 @@ html
     = csrf_meta_tags
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=edge"
-    meta name="viewport" content="width=device-width, initial-scale=0.6"
+    meta name="viewport" content="width=device-width, initial-scale=1"
     title= t("publishers.app_title")
     = stylesheet_link_tag('application', media: 'all')
     = javascript_include_tag('application')

--- a/app/views/static/index.html.slim
+++ b/app/views/static/index.html.slim
@@ -17,20 +17,20 @@
           p= t("static.landing_new_body")
           = form_tag publishers_path, method: :post do |f|
             .form-group
-              .row
-                .col.col-xs-7
+              .row.form-row
+                .col.col-xs-12.col-sm-7
                   label.control-label for="email"
                     = email_field_tag(:email, nil, class: "form-control", placeholder: t("shared.email_address"), required: true)
                   - if @should_throttle
                     .form-group
                       = recaptcha_tags
-                .col.col-xs-5.button-column
+                .col.col-xs-12.col-sm-5.button-column
                   = submit_tag(t("static.landing_begin_button"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
           hr.divider
           .row
-            .col.col-xs-8
+            .col.col-xs-12.col-sm-8
               p.alt-path-copy= t("static.landing_login_body_html")
-            .col.col-xs-4.button-column
+            .col.col-xs-12.col-sm-4.button-column
               = link_to(t("static.landing_login_button"), new_auth_token_publishers_path, class: "btn btn-block btn-secondary", :"data-piwik-action" => "LandingLoginClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
         .terms-of-service.pull-right
           = link_to(t("shared.terms_of_service"), "https://basicattentiontoken.org/publisher-terms-of-service/")


### PR DESCRIPTION
Closes #199. The goal is to improve the mobile responsiveness of the landing page. This PR does not attempt to improve the responsiveness of the site as a whole, only the landing page.

![brave-responsive](https://user-images.githubusercontent.com/8752/33033972-3c4ad8fe-cddb-11e7-848d-8b95a0c8ee18.gif)


Test Plan:

- Run the branch with your browsers's responsive layout emulation.

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
