### PR TITLE
Make log in button border transparent on hover instead of removing

### DIFF
--- a/app/assets/stylesheets/application/static.sass
+++ b/app/assets/stylesheets/application/static.sass
@@ -194,9 +194,8 @@ body[data-controller="static"]
       text-transform: uppercase
 
       &:hover
-        border: none
+        border-color: transparent
         background: rgba(#fff, 0.30)
       &:active
         border: none
         background: rgba(#fff, 0.15)
-


### PR DESCRIPTION
Resolves #311 by leaving the button border transparently in place rather than removing it on `:hover`

cc: @jenn-rhim 

![log-in](https://user-images.githubusercontent.com/250934/33038437-a640146e-ce02-11e7-8298-dbc778f383f0.gif)

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
