### PR TITLE
Fix `foreman start` when developing

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb -e ${RACK_ENV:-development}
+worker: bundle exec sidekiq -C config/sidekiq.yml -e ${RACK_ENV:-development}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These steps based on [directions at the omniauth-google-oauth2 gem](https://gith
 1. Start Postgres and redis.
 
 2. Run Rails server and async worker
-`foreman start`
+`foreman start -f Procfile.dev`
 
 3. Visit http://localhost:3000
 


### PR DESCRIPTION
Added an additional Procfile, Procfile.dev without the release phase that was causing the app to exit immediately after start.  You now can start the app with `foreman start -f Procfile.dev`.  This change is reflected in README.md.

Open to other solutions as this is only a slight improvement to the workaround described in #315.

Resolves #315

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
