### PR TITLE
Support passing a publisher through to the original account when trying to reclaim a channel

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -17,6 +17,8 @@ module Publishers
       if existing_publisher && current_publisher && current_publisher.youtube_channel_id.nil? &&
           existing_publisher.email == current_publisher.email &&
           existing_publisher.id != current_publisher.id
+        require "sentry-raven"
+        Raven.capture_message("Logging user in instead as existing user with same email and oauth credentials.")
         current_publisher.destroy
         sign_out(current_publisher)
       end

--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -18,7 +18,7 @@ module Publishers
           existing_publisher.email == current_publisher.email &&
           existing_publisher.id != current_publisher.id
         require "sentry-raven"
-        Raven.capture_message("Logging user in instead as existing user with same email and oauth credentials.")
+        Raven.capture_message("Logging user (#{oauth_response.dig('info', 'name')}) in instead as existing user with same email (#{current_publisher.email}) and oauth credentials (#{oauth_response.provider}, #{oauth_response.uid}).")
         current_publisher.destroy
         sign_out(current_publisher)
       end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -41,6 +41,8 @@ class Publisher < ApplicationRecord
   before_validation :normalize_inspect_brave_publisher_id, if: -> { brave_publisher_id.present? && brave_publisher_id_changed?}
   after_validation :generate_verification_token, if: -> { brave_publisher_id.present? && brave_publisher_id_changed? }
 
+  before_destroy :dont_destroy_verified_publishers
+
   belongs_to :youtube_channel
 
   scope :created_recently, -> { where("created_at > :start_date", start_date: 1.week.ago) }
@@ -213,5 +215,9 @@ class Publisher < ApplicationRecord
 
   def self.youtube_channel_in_use(id)
     self.where(youtube_channel_id: id).count > 0
+  end
+
+  def dont_destroy_verified_publishers
+    throw :abort if verified?
   end
 end

--- a/test/controllers/publishers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/publishers/omniauth_callbacks_controller_test.rb
@@ -163,6 +163,83 @@ module Publishers
       end
     end
 
+    test "an email verified publisher logging into the same oauth account and having the same email as an existing publisher is logged in as that publisher" do
+      begin
+        OmniAuth.config.test_mode = true
+
+        token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
+
+        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+            {
+                "provider" => "google_oauth2",
+                "uid" => "abc123",
+                "info" => {
+                    "name" => "Some Other Guy's Channel",
+                    "email" => "brand@nonfunctional.google.com",
+                    "first_name" => "Test Brand Account",
+                    "image" => "https://some_image_host.com/some_image.png"
+                },
+                "credentials" => {
+                    "token" => token,
+                    "expires_at" => 2510156374,
+                    "expires" => true
+                }
+            }
+        )
+
+        # signup using an email that is already used for an existing youtube publisher
+        assert_difference("Publisher.count", 1) do
+          perform_enqueued_jobs do
+            post(publishers_path, params: { email: "alice@verified.org" })
+          end
+        end
+
+        publisher = Publisher.order(created_at: :asc).last
+        url = publisher_url(publisher, token: publisher.authentication_token)
+        get(url)
+
+        some_other_channel = youtube_channels(:some_other_channel)
+
+        channel_data = {
+            "id" => some_other_channel.id,
+            "snippet" => {
+                "title" => "Some Other Guy's Channel",
+                "description" => "Some Other Guy's Channel",
+                "thumbnails" => {
+                    "default" => {
+                        "url" => "http://some_host.com/thumb.png"
+                    }
+                }
+            },
+            "statistics" => {
+                "subscriberCount" => 1200
+            }
+        }
+
+        stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?id=#{some_other_channel.id}&part=statistics,snippet").
+            with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                            'Authorization' => "Bearer #{token}",
+                            'User-Agent' => 'Faraday v0.9.2' }).
+            to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
+
+        assert_difference("Publisher.count", -1) do
+          get(publisher_google_oauth2_omniauth_authorize_url)
+          follow_redirect!
+        end
+
+        assert_raises ActiveRecord::RecordNotFound do
+          publisher.reload
+        end
+
+        # should redirect to the existing publishers home page, as the existing publisher
+        assert_redirected_to home_publishers_path
+        follow_redirect!
+        assert_select('div.dashboard-id span') do |element|
+          assert_match("Some Other Guy's Channel", element.text)
+        end
+      end
+    end
+
     test "a new publisher who hasn't verified through email will be created and sent to the dashboard" do
       begin
         OmniAuth.config.test_mode = true

--- a/test/jobs/enqueue_publisher_verifications_test.rb
+++ b/test/jobs/enqueue_publisher_verifications_test.rb
@@ -4,7 +4,7 @@ class EnqueuePublisherVerificationsTest < ActiveJob::TestCase
   test "#perform enqueue verifications" do
     publisher = publishers(:default)
     # Hack to clean DB
-    Publisher.where.not(id: publisher.id).destroy_all
+    Publisher.where.not(id: publisher.id).delete_all
     assert_enqueued_with(job: VerifyPublisher, args: [{ brave_publisher_id: publisher.brave_publisher_id }]) do
       EnqueuePublisherVerifications.perform_now
     end
@@ -13,7 +13,7 @@ class EnqueuePublisherVerificationsTest < ActiveJob::TestCase
   test "#perform doesn't enqueue verifications for old publishers" do
     publisher = publishers(:stale)
     # Hack to clean DB
-    Publisher.where.not(id: publisher.id).destroy_all
+    Publisher.where.not(id: publisher.id).delete_all
     assert_no_enqueued_jobs do
       EnqueuePublisherVerifications.perform_now
     end

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -213,4 +213,22 @@ class PublisherTest < ActiveSupport::TestCase
     publisher.pending_email = "bad_email_addresscom"
     refute publisher.valid?
   end
+
+  test "a publisher can be destroyed if it is not verified" do
+    publisher = Publisher.new
+
+    publisher.pending_email = "foo@foo.com"
+    assert publisher.valid?
+    publisher.save
+    assert_difference("Publisher.count", -1) do
+      assert publisher.destroy
+    end
+  end
+
+  test "a publisher can not be destroyed if it is verified" do
+    publisher = publishers(:verified)
+    assert_difference("Publisher.count", 0) do
+      refute publisher.destroy
+    end
+  end
 end


### PR DESCRIPTION
Handles the special case described in #305.

In the special case where a publisher already has a channel claimed, and tries to claim the same channel again using the same email address, they will be taken to the dashboard for their existing account. The new publisher record is removed as it is unneeded.

Adds protection from `destroy` for verified publishers. This is used to assure that the step of destroying the new unneeded publisher is safe.

Fixes #305

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
