### PR TITLE
Logging: staging logs to INFO level, add LOG_API_REQUESTS

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,7 +1,7 @@
 # To set authorization for the API, configure ENV["API_AUTH_TOKEN"] and
 # api_auth_token ENV["API_IP_WHITELIST"] (see secrets.yml)
 class Api::BaseController < ActionController::API
-  before_action :log_full_request, if: -> { !Rails.env.production? }
+  before_action :log_full_request, if: -> { Rails.application.secrets[:log_api_requests] }
 
   API_AUTH_TOKEN = Rails.application.secrets[:api_auth_token].freeze
 
@@ -27,7 +27,6 @@ class Api::BaseController < ActionController::API
     # Set this in Fastly.
     remote_ip = request.headers["Fastly-Client-IP"].presence || request.remote_ip
     ip_auth_result = API_IP_WHITELIST.any? { |ip_addr| ip_addr.include?(remote_ip) }
-    Rails.logger.debug("IP auth result for #{remote_ip}: #{ip_auth_result}")
     ip_auth_result
   end
 
@@ -48,8 +47,8 @@ class Api::BaseController < ActionController::API
         envs[key] = value if key == key.upcase
       end
     end
-    Rails.logger.debug("Headers: #{http_envs}")
-    Rails.logger.debug("Body: #{request&.raw_post}")
+    Rails.logger.info("Headers: #{http_envs}")
+    Rails.logger.info("Body: #{request&.raw_post}")
   end
 
   def render_unauthorized

--- a/app/services/publisher_verifier.rb
+++ b/app/services/publisher_verifier.rb
@@ -111,7 +111,7 @@ class PublisherVerifier < BaseApiClient
       answer_part.strings.each do |string|
         token_match = /^brave\-ledger\-verification\=([a-zA-Z0-9]+)$/.match(string)
         next if !token_match || !token_match[1]
-        Rails.logger.debug("Found token on #{brave_publisher_id}: #{token_match[1]}")
+        Rails.logger.info("Found token on #{brave_publisher_id}: #{token_match[1]}")
         dns_publisher = Publisher.find_by(brave_publisher_id: brave_publisher_id, verification_token: token_match[1])
         if dns_publisher
           return dns_publisher.id

--- a/app/services/slack_messenger.rb
+++ b/app/services/slack_messenger.rb
@@ -13,7 +13,7 @@ class SlackMessenger < BaseApiClient
 
   def perform
     if !can_perform?
-      Rails.logger.debug("SlackMessenger: Local notification: #{message}")
+      Rails.logger.info("SlackMessenger: Local notification: #{message}")
       return
     end
     params = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  # info so ActionMailer doesn't spam the logs with full attachments
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -61,6 +61,7 @@ default: &default
   bat_twitter_url: <%= ENV["BAT_TWITTER_URL"] %>
   bat_reddit_url: <%= ENV["BAT_REDDIT_URL"] %>
   bat_rocketchat_url: <%= ENV["BAT_ROCKETCHAT_URL"] %>
+  log_api_requests: <%= ENV["LOG_API_REQUESTS"] %>
 
 development:
   <<: *default

--- a/docs/publishers-secrets.example.sh
+++ b/docs/publishers-secrets.example.sh
@@ -15,6 +15,7 @@ export API_LEDGER_OFFLINE=1
 #export BASIC_AUTH_USER="" # Enable HTTP basic auth for the whole app.
 #export BASIC_AUTH_PASSWORD="" # see above
 export INTERNAL_EMAIL="admin@publishers.local" # Admin notifications get sent here.
+#export LOG_API_REQUESTS=1 # Enable to log publishers' external API access.
 #export MAILER_SENDER="" # The From: header in emails sent to users.
 export RECAPTCHA_PUBLIC_KEY="" # For recaptcha for rate limiting.
 export RECAPTCHA_PRIVATE_KEY=""
@@ -35,4 +36,3 @@ export TERMS_OF_SERVICE_URL="https://basicattentiontoken.org/publisher-terms-of-
 # - make sure the authorized redirect url goes to the endpoint /publishers/auth/google_oauth2/callback
 export GOOGLE_CLIENT_ID=""
 export GOOGLE_CLIENT_SECRET=""
-


### PR DESCRIPTION
Fix #310 

after discussing options with @lgebhardt this seems like the cleanest way (remove #debug log statements and change staging to INFO level).

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
