### PR TITLE
use deliver_later instead of deliver_later!

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -67,7 +67,7 @@ class PublishersController < ApplicationController
 
     if throttle_legit
       if @publisher.save
-        PublisherMailer.verify_email(@publisher).deliver_later!
+        PublisherMailer.verify_email(@publisher).deliver_later
         PublisherMailer.verify_email_internal(@publisher).deliver_later if PublisherMailer.should_send_internal_emails?
         session[:created_publisher_id] = @publisher.id
         redirect_to create_done_publishers_path
@@ -89,7 +89,7 @@ class PublishersController < ApplicationController
   def resend_email_verify_email
     @publisher = Publisher.find(session[:created_publisher_id])
 
-    PublisherMailer.verify_email(@publisher).deliver_later!
+    PublisherMailer.verify_email(@publisher).deliver_later
     PublisherMailer.verify_email_internal(@publisher).deliver_later if PublisherMailer.should_send_internal_emails?
     session[:created_publisher_id] = @publisher.id
     session[:created_publisher_email] = @publisher.pending_email
@@ -115,8 +115,8 @@ class PublishersController < ApplicationController
     success = publisher.update(update_params)
 
     if success && update_params[:pending_email]
-      PublisherMailer.notify_email_change(publisher).deliver_later!
-      PublisherMailer.confirm_email_change(publisher).deliver_later!
+      PublisherMailer.notify_email_change(publisher).deliver_later
+      PublisherMailer.confirm_email_change(publisher).deliver_later
     end
 
     respond_to do |format|

--- a/app/services/publisher_login_link_emailer.rb
+++ b/app/services/publisher_login_link_emailer.rb
@@ -63,6 +63,6 @@ class PublisherLoginLinkEmailer < BaseService
 
   def send_email
     return false if !publisher
-    PublisherMailer.login_email(publisher).deliver_later!
+    PublisherMailer.login_email(publisher).deliver_later
   end
 end


### PR DESCRIPTION
Use `deliver_later` instead of `deliver_later!`. Messages sent with `deliver_later!` do not trigger the 
ActionMailer::LogSubscriber `deliver` method (which handles the logging). And carry this [warning](http://api.rubyonrails.org/classes/ActionMailer/MessageDelivery.html#method-i-deliver_later-21):

"Enqueues the email to be delivered through Active Job. When the job runs it will send the email using deliver_now!. That means that the message will be sent bypassing checking perform_deliveries and raise_delivery_errors, so use with caution."

This will give us consistency in the logging of emails, and combined with #326 will produce short log entries.

Fixes #327

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))