### PR TITLE
Provide link to sign up within flash message if publisher attempts to…

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -164,7 +164,8 @@ class PublishersController < ApplicationController
     if emailer.perform
       # Success shown in view #create_auth_token
     else
-      flash.now[:alert] = %Q[#{emailer.error[0]}<a href="/">#{emailer.error[1]}</a>].html_safe
+      # Failed to find publisher
+      flash.now[:login_link] = "" # Uses login_link partial instead of explicit message
       render(:new_auth_token)
     end
   end

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -164,7 +164,7 @@ class PublishersController < ApplicationController
     if emailer.perform
       # Success shown in view #create_auth_token
     else
-      flash.now[:alert] = emailer.error
+      flash.now[:alert] = %Q[#{emailer.error[0]}<a href="/">#{emailer.error[1]}</a>].html_safe
       render(:new_auth_token)
     end
   end

--- a/app/services/publisher_login_link_emailer.rb
+++ b/app/services/publisher_login_link_emailer.rb
@@ -47,7 +47,7 @@ class PublisherLoginLinkEmailer < BaseService
       verified: false
     )
     if publishers_not_verified.none?
-      @error = I18n.t("publishers.new_auth_token_publisher_not_found")
+      @error = %W{#{I18n.t("publishers.new_auth_token_publisher_not_found_part_one")} #{I18n.t("publishers.new_auth_token_publisher_not_found_part_two")}}
       return false
     end
 

--- a/app/services/publisher_login_link_emailer.rb
+++ b/app/services/publisher_login_link_emailer.rb
@@ -47,7 +47,6 @@ class PublisherLoginLinkEmailer < BaseService
       verified: false
     )
     if publishers_not_verified.none?
-      @error = %W{#{I18n.t("publishers.new_auth_token_publisher_not_found_part_one")} #{I18n.t("publishers.new_auth_token_publisher_not_found_part_two")}}
       return false
     end
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,6 +17,8 @@ html
       .notifications.navbar-static-top
         - if flash[:alert]
           .alert.alert-warning.flash= flash[:alert]
+        - if flash[:login_link]
+          = render partial: "publishers/login_link"
         - if flash[:notice]
           .alert.alert-success.flash= flash[:notice]
         - if content_for(:content_form_errors)

--- a/app/views/publishers/_login_link.html.slim
+++ b/app/views/publishers/_login_link.html.slim
@@ -1,0 +1,3 @@
+.alert.alert-warning.flash
+		= t('publishers.new_auth_token_publisher_not_found_part_one')
+		= link_to(t('publishers.new_auth_token_publisher_not_found_part_two'), root_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,7 +80,8 @@ en:
     new_auth_token_button: "Email me a link to log in"
     new_auth_token_email_html: |
       Email Address <span class="optional">(for unverified domains)</span>
-    new_auth_token_publisher_not_found: "Couldn't find a publisher with that domain name. Please try again or start a new verification."
+    new_auth_token_publisher_not_found_part_one: "Couldn't find a publisher with that domain name. Please try again or "
+    new_auth_token_publisher_not_found_part_two: "start a new verification."
     new_auth_token_wrong_email_publisher_not_verified: "Email doesn't match the publisher verification. Please try again or start a new verification."
     new_auth_token_wrong_email_publisher_verified: "Email doesn't match the publisher verification. Try leaving email blank to use the most recent email."
     not_verified: "Unverified"


### PR DESCRIPTION
… log in with unregistered domain

* Separate en.publishers.new_auth_token_publisher_not_found into two parts, the second of which will be the link

* Modify `find_publisher` to pass both parts as the error message to the publisher controller instead of the removed translation

* Modify publisher controller to flash both messages, adding a link to the homepage for the second

**Security Warning**
This code does contain `.html_safe` - the link would not activate otherwise.  I tried to use `link_to` and ERB instead, but since we are passing plain text via a controller I don't think this is possible.

Resolves #325

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did no already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:
Since this is small and straightforward, I tested through the browser.

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
