### PR TITLE
Add client side validations for publishers phone numbers

### DIFF
--- a/app/views/publishers/contact_info.html.slim
+++ b/app/views/publishers/contact_info.html.slim
@@ -20,7 +20,7 @@
             = f.text_field(:name, class: "form-control", placeholder: "Alice Bloglette", required: true)
           .form-group
             = f.label(:phone, t("publishers.verified_phone_html"), class: "control-label")
-            = f.phone_field(:phone, class: "form-control", placeholder: "+1 888 555 9001", required: false)
+            = f.phone_field(:phone, class: "form-control", pattern: "^[0-9\-\+\.\s\(\)]*$", title: t("publishers.phone_number_validation"), id: "update_contact_phone", placeholder: "+1 888 555 9001", required: false)
           - if @should_throttle
             .form-group
               = recaptcha_tags

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -442,7 +442,7 @@ noscript
             = f.email_field(:pending_email, class: "form-control", id: "update_contact_email", placeholder: "alice@example.com", required: true)
           .form-group
             = f.label(:phone, t("publishers.verified_phone_html"), class: "control-label")
-            = f.phone_field(:phone, class: "form-control", id: "update_contact_phone", placeholder: "+1 888 555 9001", required: false)
+            = f.phone_field(:phone, class: "form-control", pattern: "^[0-9\-\+\.\s\(\)]*$", title: t("publishers.phone_number_validation"), id: "update_contact_phone", placeholder: "+1 888 555 9001", required: false)
           .button.form-group
             = f.submit(translate("shared.update"), class: "btn btn-primary", :"data-piwik-action" => "SubmitContactUpdateClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
             a#cancel_edit_contact href="#"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,7 @@ en:
     statement_delayed: "Delayed"
     verified_phone_html: |
       Phone Number <span class="optional">(optional)</span>
+    phone_number_validation: "Phone numbers should only include numbers, dashes, periods, plus (+), and/or parentheses."
     status_uphold_processing: "Your Uphold wallet is being connected to your account"
     status_unverified: "Your account has not been verified"
     uphold_status_verified: "Your Uphold wallet is ready to receive Brave Payments."


### PR DESCRIPTION
* Add validation that forces phone numbers to only include numbers, dashes, parentheses, periods, and plus (+).  There is no restrictions on the order or length of characters in accordance with the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle).

* Add title field within html tag to give user more information as to why they can't submit the form if their phone number is invalid

* Add the title message to en.yml for internationalization

Previously, phone numbers were being normalized and saved under a property `phone_normalized`.  If a publisher added an invalid number, only the `phone` property was updated, and `phone_normalized` was untouched.  Only valid numbers will update `phone_normalized`.  So this change does not affect the database, only nudges publishers to provide a valid number client side.

Resolves #324 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
