### PR TITLE
Run the development server as SSL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dump.rdb
 
 # Ignore Byebug command history file.
 .byebug_history
+ssl/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ dump.rdb
 
 # Ignore Byebug command history file.
 .byebug_history
-ssl/
+/ssl/

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "phony_rails", "~> 0.14"
 gem "premailer-rails", "~> 1.9.4", require: false
 
 # Puma as app server
-gem "puma", "~> 3.0"
+gem "puma", "~> 3.11"
 
 gem "rails", "~> 5.0.0", ">= 5.0.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
-    puma (3.6.0)
+    puma (3.11.0)
     rack (2.0.3)
     rack-attack (5.0.1)
       rack
@@ -351,7 +351,7 @@ DEPENDENCIES
   premailer-rails (~> 1.9.4)
   pry
   pry-byebug
-  puma (~> 3.0)
+  puma (~> 3.11)
   rack-attack (~> 5.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   recaptcha (~> 3.3)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,44 @@ App for [publishers.brave.com](https://publishers.brave.com).
   - `rails db:create RAILS_ENV=development`
   - `rails db:migrate RAILS_ENV=development`
 
+### HTTPS Setup
+
+Local development of brave-intl uses HTTPS. This allow us to use web APIs such
+as U2F in development.
+
+We use the domain `localhost.ssl`. This avoids Chrome idiosyncrasies on
+`localhost` and HSTS issues for non-SSL projects you might run on `localhost`.
+
+If you already have a key and certificate for this domain places them in the
+`ssl/` directory:
+
+```
+ssl/server.key
+ssl/server.crt
+```
+
+If you don't, first add an entry to `/etc/hosts` for this domain:
+
+```
+echo "echo '127.0.0.1 localhost.ssl' >> /etc/hosts" | sudo -s
+```
+
+Then generate a key and certificate (tested on OSX):
+
+```
+bundle exec rake ssl:generate
+```
+
+Install that certificate into the OSX keychain:
+
+```
+bundle exec rake ssl:install
+```
+
+When you first visit the application in a browser you may need to add an
+exception to trust this self-signed certificate. Sometimes this is under an
+"advanced" or "proceed" link.
+
 ### Google API Setup
 
 Setup a google API project:
@@ -46,11 +84,10 @@ These steps based on [directions at the omniauth-google-oauth2 gem](https://gith
 2. Run Rails server and async worker
 `foreman start -f Procfile.dev`
 
-3. Visit http://localhost:3000
+3. Visit https://localhost:3001
 
 4. To test email, run a local mail server at localhost:25
 `mailcatcher`
-
 
 ## Development
 
@@ -64,10 +101,10 @@ It might be useful to maintain a local bash script with a list of env vars. For 
 
 Some variables are set automagically with Heroku addons:
 
-- FIXIE_URL - Proxy provider. For outbound API requests.
-- MAILGUN_* - For sending emails.
-- NEW_RELIC_APP_NAME, NEW_RELIC_LICENSE_KEY - New Relic app monitoring.
-- REDIS_URL - For Sidekiq and rack-attack
+- `FIXIE_URL` - Proxy provider. For outbound API requests.
+- `MAILGUN_*` - For sending emails.
+- `NEW_RELIC_APP_NAME`, `NEW_RELIC_LICENSE_KEY` - New Relic app monitoring.
+- `REDIS_URL` - For Sidekiq and rack-attack
 
 #### Other vars
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@ App for [publishers.brave.com](https://publishers.brave.com).
 Local development of brave-intl uses HTTPS. This allow us to use web APIs such
 as U2F in development.
 
-We use the domain `localhost.ssl`. This avoids Chrome idiosyncrasies on
-`localhost` and HSTS issues for non-SSL projects you might run on `localhost`.
-
-If you already have a key and certificate for this domain places them in the
+If you already have a key and certificate for the `localhost` domain place them in the
 `ssl/` directory:
 
 ```
@@ -32,22 +29,10 @@ ssl/server.key
 ssl/server.crt
 ```
 
-If you don't, first add an entry to `/etc/hosts` for this domain:
-
-```
-echo "echo '127.0.0.1 localhost.ssl' >> /etc/hosts" | sudo -s
-```
-
-Then generate a key and certificate (tested on OSX):
+If you don't, you will need to generate certificates for this domain:
 
 ```
 bundle exec rake ssl:generate
-```
-
-Install that certificate into the OSX keychain:
-
-```
-bundle exec rake ssl:install
 ```
 
 When you first visit the application in a browser you may need to add an
@@ -84,7 +69,7 @@ These steps based on [directions at the omniauth-google-oauth2 gem](https://gith
 2. Run Rails server and async worker
 `foreman start -f Procfile.dev`
 
-3. Visit https://localhost:3001
+3. Visit https://localhost:3000
 
 4. To test email, run a local mail server at localhost:25
 `mailcatcher`

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "localhost.ssl", port: 3001, protocol: 'https' }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000, protocol: 'https' }
 
   # Mailcatcher
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.default_url_options = { host: "localhost.ssl", port: 3001, protocol: 'https' }
 
   # Mailcatcher
   config.action_mailer.delivery_method = :smtp

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,7 +15,7 @@ environment rails_env
 # `bind` server to 'url' on which to listen for requests.
 #
 if rails_env == "development"
-  ssl_bind '127.0.0.1', '3001', {
+  ssl_bind '127.0.0.1', '3000', {
     key: ENV.fetch("SSL_KEY_PATH") { 'ssl/server.key' },
     cert: ENV.fetch("SSL_CERT_PATH") { 'ssl/server.crt' },
     verify_mode: 'none'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -13,14 +13,18 @@ rails_env = ENV.fetch("RAILS_ENV") { "development" }
 environment rails_env
 
 # `bind` server to 'url' on which to listen for requests.
-
-bind ENV.fetch("BIND") {
-  if rails_env == "development"
-    "tcp://localhost:3000"
-  else
+#
+if rails_env == "development"
+  ssl_bind '127.0.0.1', '3001', {
+    key: ENV.fetch("SSL_KEY_PATH") { 'ssl/server.key' },
+    cert: ENV.fetch("SSL_CERT_PATH") { 'ssl/server.crt' },
+    verify_mode: 'none'
+  }
+else
+  bind ENV.fetch("BIND") {
     "tcp://0.0.0.0:#{ENV.fetch('PORT') { 5000 }}"
-  end
-}
+  }
+end
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/lib/tasks/ssl.rake
+++ b/lib/tasks/ssl.rake
@@ -1,0 +1,22 @@
+namespace :ssl do
+  task :generate => [ :environment ] do
+    sh 'which openssl' do |ok, res|
+      if ! ok
+        puts "The `openssl` executable is not available. Please manually generate a key `ssl/server.key` and certificate `ssl/server.crt`."
+      else
+        sh 'openssl genrsa -out ssl/server.key 4096'
+        sh "echo \"openssl req -new -key ssl/server.key -x509 -nodes -new -out ssl/server.crt -subj /CN=localhost.ssl -reqexts SAN -extensions SAN -config <(cat /System/Library/OpenSSL/openssl.cnf <(printf '[SAN]\\nsubjectAltName=DNS:localhost.ssl')) -sha256 -days 3650\" | bash"
+      end
+    end
+  end
+
+  task :install => [ :environment ] do
+    sh 'which security' do |ok, res|
+      if ! ok
+        puts "The `securty` executable is not available. Please manually trust the certificates in `ssl/`."
+      else
+        sh 'security add-trusted-cert -d -r trustRoot -k ~/Library/Keychains/login.keychain ssl/server.crt'
+      end
+    end
+  end
+end

--- a/lib/tasks/ssl/rootCA.cnf
+++ b/lib/tasks/ssl/rootCA.cnf
@@ -1,0 +1,14 @@
+[req]
+default_bits = 4096
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[dn]
+C=US
+ST=California
+L=Santa Barbara
+O=End Point
+OU=Testing Domain
+emailAddress=testing-domain@tesing-domain.fake-tld
+CN = localhost

--- a/lib/tasks/ssl/server.csr.cnf
+++ b/lib/tasks/ssl/server.csr.cnf
@@ -1,0 +1,14 @@
+[req]
+default_bits = 4096
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[dn]
+C=US
+ST=California
+L=Santa Barbara
+O=End Point
+OU=Testing Domain
+emailAddress=testing-domain@tesing-domain.fake-tld
+CN = localhost

--- a/lib/tasks/ssl/v3.ext
+++ b/lib/tasks/ssl/v3.ext
@@ -1,0 +1,7 @@
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost


### PR DESCRIPTION
As we add support for U2F-based 2FA and adopt other cutting-edge web features, we need to be working on an HTTPS domain. This is because some APIs (like U2F) are only available to an SSL host.

## Adding a domain for SSL

Please create an entry in your `/etc/hosts` file for `localhost.ssl` pointing at `127.0.0.1`. The following command should be sufficient:

```
echo "echo '127.0.0.1 localhost.ssl' >> /etc/hosts" | sudo -s
```

I've preferred `localhost.ssl` as a domain over `localhost`. There are two motivations for this:

* Chrome and other browsers have some special `localhost`-only behaviors intended to make development simpler, however the rules are vague and poorly documented. It seems simpler to use a non-standard TLD and avoid any confusion.
* Second we may want to use HSTS at some point. HSTS sets an SSL-only rule for an entire domain, and if we set HSTS for `localhost` we might make it difficult to develop non-SSL projects on that domain. 

## Installing SSL certificates

The built-in development Puma server expects two files to exist in the `ssl/` directory:

```
ssl/server.key
ssl/server.crt
```

These should be a key and certificate for the domain `localhost.ssl`. You may already have certificates for this domain, and re-using those is encouraged.

However if you need to generate a key and certificate, you can use the following commands on OSX:

```
bundle exec rake ssl:generate
```

Will generate a key, signing request, and certificate.

```
bundle exec rake ssl:install
```

Will add the certificate to your OSX keychain.

Once you've run these commands you can simply run the Foreman server like normal and visit https://localhost.ssl:3001/. You may still need to approve an exception to allow the certificate the first time you use it in a browser.

References: https://github.com/brave-intl/publishers/pull/323