### PR TITLE
Tweak font sizes on mobile

### DIFF
--- a/app/assets/stylesheets/application/static.sass
+++ b/app/assets/stylesheets/application/static.sass
@@ -33,6 +33,13 @@ body[data-controller="static"]
     margin-top: 75px
     margin-bottom: 75px
 
+  @media (max-width: $screen-md-max)
+    p.leadin
+      font-size: 20px
+    .logo
+      margin-top: 55px
+      margin-bottom: 20px
+
   .main-heading
     h2
       font-weight: 100
@@ -41,9 +48,11 @@ body[data-controller="static"]
     @media (max-width: $screen-md-max)
       h1
         font-weight: 600
-        font-size: 48px
+        font-size: 36px
         margin-top: 5px
         margin-bottom: 30px
+      h2
+        font-size: 24px
     @media (min-width: $screen-md-min)
       h1
         font-weight: 600
@@ -117,8 +126,8 @@ body[data-controller="static"]
 
   @media (max-width: $screen-xxs-max)
     .logo
-      margin-top: 50px
-      margin-bottom: 50px
+      margin-top: 35px
+      margin-bottom: 0px
     .col-centered
       float: none
       margin: 0 auto


### PR DESCRIPTION
Closes https://github.com/brave-intl/publishers/issues/199. @jenn-rhim and I agree we should open another issue for any further responsiveness work with more detail.

Tweaks font sizes and margins around the logo for the landing page on mobile. This is based on iteration with @jenn-rhim over Slack.

![brave-responsive-v2](https://user-images.githubusercontent.com/8752/33339005-a8653abe-d42c-11e7-85a9-6fd4769912b4.gif)

**Desktop**

<img width="1447" alt="screen shot 2017-11-28 at 11 09 09 am" src="https://user-images.githubusercontent.com/8752/33339050-bfa37f56-d42c-11e7-8c75-bca4ac6dc8dc.png">

**iPad**

<img width="777" alt="screen shot 2017-11-28 at 11 09 23 am" src="https://user-images.githubusercontent.com/8752/33339049-bf85ab20-d42c-11e7-86db-726a26358471.png">

**iPhone 7**

<img width="387" alt="screen shot 2017-11-28 at 11 09 35 am" src="https://user-images.githubusercontent.com/8752/33339048-bf634f76-d42c-11e7-8526-1b154bd03220.png">

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
