### PR TITLE
Allow developers to force a Captcha using query string param

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -59,7 +59,7 @@ class PublishersController < ApplicationController
 
     @publisher = Publisher.new(pending_email: params[:email])
 
-    @should_throttle = should_throttle_create? || params[:captcha] == "true"
+    @should_throttle = should_throttle_create? || params[:captcha]
     throttle_legit =
       @should_throttle ?
         verify_recaptcha(model: @publisher)
@@ -76,8 +76,7 @@ class PublishersController < ApplicationController
         redirect_to(root_path, notice: I18n.t("publishers.invalid_email_value") )
       end
     else
-      Rails.logger.error(I18n.t("recaptcha.errors.verification_failed"))
-      redirect_to(root_path, notice: I18n.t("recaptcha.errors.verification_failed"))
+      redirect_to root_path(:captcha => params[:captcha])
     end
   end
 
@@ -147,7 +146,7 @@ class PublishersController < ApplicationController
 
   def create_auth_token
     @publisher = Publisher.new(publisher_create_auth_token_params)
-    @should_throttle = should_throttle_create_auth_token? || params[:captcha] == "true"
+    @should_throttle = should_throttle_create_auth_token? || params[:captcha]
     throttle_legit =
       @should_throttle ?
         verify_recaptcha(model: @publisher)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -59,7 +59,7 @@ class PublishersController < ApplicationController
 
     @publisher = Publisher.new(pending_email: params[:email])
 
-    @should_throttle = should_throttle_create?
+    @should_throttle = should_throttle_create? || params[:captcha] == "true"
     throttle_legit =
       @should_throttle ?
         verify_recaptcha(model: @publisher)
@@ -147,7 +147,7 @@ class PublishersController < ApplicationController
 
   def create_auth_token
     @publisher = Publisher.new(publisher_create_auth_token_params)
-    @should_throttle = should_throttle_create_auth_token?
+    @should_throttle = should_throttle_create_auth_token? || params[:captcha] == "true"
     throttle_legit =
       @should_throttle ?
         verify_recaptcha(model: @publisher)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -76,7 +76,7 @@ class PublishersController < ApplicationController
         redirect_to(root_path, notice: I18n.t("publishers.invalid_email_value") )
       end
     else
-      redirect_to root_path(:captcha => params[:captcha])
+      redirect_to root_path(captcha: params[:captcha])
     end
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -5,6 +5,7 @@ class StaticController < ApplicationController
   before_action :redirect_if_current_publisher, only: :index
 
   def index
+    @should_throttle = should_throttle_create? || params[:captcha]
   end
 
   private
@@ -12,5 +13,15 @@ class StaticController < ApplicationController
   def redirect_if_current_publisher
     return if !current_publisher
     redirect_to publisher_next_step_path(current_publisher)
+  end
+
+  # Copied from PublishersController
+  # Level 1 throttling -- After the first two requests, ask user to
+  # submit a captcha. See rack-attack.rb for throttle keys.
+  def should_throttle_create?
+    Rails.env.production? &&
+      request.env["rack.attack.throttle_data"] &&
+      request.env["rack.attack.throttle_data"]["registrations/ip"] &&
+      request.env["rack.attack.throttle_data"]["registrations/ip"][:count] >= THROTTLE_THRESHOLD_CREATE
   end
 end

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -20,7 +20,8 @@
             .form-group
               = f.label(:email, t("publishers.new_auth_token_email_html"), class: "control-label")
               = f.email_field(:email, class: "form-control", placeholder: "alice@example.com")
-              = hidden_field_tag(:captcha, params[:captcha])
+              - if params[:captcha]
+                = hidden_field_tag(:captcha)
             - if @should_throttle
               .form-group
                 = recaptcha_tags

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -20,6 +20,7 @@
             .form-group
               = f.label(:email, t("publishers.new_auth_token_email_html"), class: "control-label")
               = f.email_field(:email, class: "form-control", placeholder: "alice@example.com")
+              = hidden_field_tag(:captcha, params[:captcha])
             - if @should_throttle
               .form-group
                 = recaptcha_tags

--- a/app/views/static/index.html.slim
+++ b/app/views/static/index.html.slim
@@ -21,6 +21,7 @@
                 .col.col-xs-12.col-sm-7
                   label.control-label for="email"
                     = email_field_tag(:email, nil, class: "form-control", placeholder: t("shared.email_address"), required: true)
+                  = hidden_field_tag(:captcha, params[:captcha])
                   - if @should_throttle
                     .form-group
                       = recaptcha_tags

--- a/app/views/static/index.html.slim
+++ b/app/views/static/index.html.slim
@@ -21,7 +21,8 @@
                 .col.col-xs-12.col-sm-7
                   label.control-label for="email"
                     = email_field_tag(:email, nil, class: "form-control", placeholder: t("shared.email_address"), required: true)
-                  = hidden_field_tag(:captcha, params[:captcha])
+                  - if params[:captcha]
+                    = hidden_field_tag(:captcha)
                   - if @should_throttle
                     .form-group
                       = recaptcha_tags

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,7 +288,6 @@ en:
   recaptcha:
     errors:
       recaptcha_unreachable: "reCAPTCHA server timeout; please try again."
-      verification_failed: "In case you’re not a bot, we just wanted you to know that reCaptcha didn’t pass this time. Please try again."
   shared:
     api_error: "Your request couldn't be processed due to an API error."
     cancel: "Cancel"


### PR DESCRIPTION
A hidden field captures the value of the param 'captcha' when the form is loaded, and passes it through to the controller when it is submitted.  When the controller checks to see if a captcha should be loaded, it will now also check if `params[captcha]` is true, and load the captcha if so.

**How To Use**
To test this on development, add the rack-attack and recaptcha gems to development.
1. Go to any form that is protected by captchas (homepage, login)
2. Tack on `?captcha=true` to the URL and reload
3. Submit the form

The captcha will open.


Resolves #339.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
