### PR TITLE
Clarify @ symbol for DNS site verifcation

### DIFF
--- a/app/views/publishers/verification_dns_record.html.slim
+++ b/app/views/publishers/verification_dns_record.html.slim
@@ -16,24 +16,24 @@
           strong= I18n.t("publishers.verification_dns_record_help_2")
 
         p
+          span= I18n.t("publishers.verification_dns_record_instruction3")
+
+        p
           span= I18n.t("publishers.verification_dns_record_instruction1")
           strong= current_publisher.brave_publisher_id
           span= I18n.t("publishers.verification_dns_record_instruction2")
 
         .form-group
-          label.control-label= I18n.t("publishers.verification_option_dns_record_name")
-          span.form-control
-            span.color-orange#name= "@"
-          button.btn.btn-xs.btn-default.copy-button data-clipboard-target="#name" Copy to Clipboard
-        .form-group
           label.control-label= I18n.t("publishers.verification_option_dns_record_type")
           span.color-orange.form-control#type TXT
-          button.btn.btn-xs.btn-default.copy-button data-clipboard-target="#type" Copy to Clipboard
+          button.btn.btn-xs.btn-default.copy-button data-clipboard-target="#type" 
+            = I18n.t("publishers.copy_to_clipboard")
         .form-group
           label.control-label= I18n.t("publishers.verification_option_dns_record_value")
           textarea.color-orange.dns-record-value.form-control#value readonly="true"
             = publisher_verification_dns_record(current_publisher)
-          button.btn.btn-xs.btn-default.copy-button data-clipboard-target="#value" Copy to Clipboard
+          button.btn.btn-xs.btn-default.copy-button data-clipboard-target="#value" 
+            = I18n.t("publishers.copy_to_clipboard")
         .form-group
           p= I18n.t("publishers.verification_dns_record_verify")
           p.note-text= I18n.t("publishers.verification_option_dns_record_note")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
     balance_pending_approximate: "Approximately %{amount} %{code}"
     contact_person: "Contact person"
     contact: "Contact"
+    copy_to_clipboard: "Copy to clipboard"
     create_done_header: "An email is on its way!"
     create_done_body_html: |
       <p>We're excited that you want to be in on Brave Payments. We just sent an email to
@@ -108,8 +109,9 @@ en:
     reconnect_to_uphold: "Reconnect to Uphold"
     verification_dns_record_help: "To verify ownership of your site, you'll need to add a new DNS record for "
     verification_dns_record_help_2: " using the account for your DNS host."
-    verification_dns_record_instruction1: "Copy and Paste the info below into the zone file for "
+    verification_dns_record_instruction1: "Copy and paste the info below into the zone file for "
     verification_dns_record_instruction2: " using your DNS host's control panel."
+    verification_dns_record_instruction3: "Please add the record on your root domain, not a subdomain. The @ symbol is often used to indicate the root domain name/host/host record."
     verification_dns_record_verify: "After adding and saving this TXT record with your DNS host, click the button below to verify."
     verification_choose_header: "Choose a Verification Method"
     verification_choose_trusted_file_header: "Download a trusted file"


### PR DESCRIPTION
### DNS verification page after changes
![image](https://user-images.githubusercontent.com/12549658/33508071-3796f826-d6c6-11e7-8f4f-a2c9ee109c33.png)

### Changes
* Remove 'Name' form with @ symbol that may confuse users

* Replace with instructions on adding to root domain, clarify this is often represented by @

* Downcase the 'P' in 'Copy and Paste'

* Add translation for 'Copy to Clipboard' and downcase the 'C'

Resolves #135.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
