### PR TITLE
Simplify and improve statement generation

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -561,17 +561,12 @@ body[data-controller="publishers"]
           font-size: 14px
           font-weight: 300
           margin-bottom: 6px
-          &:hover
-            font-weight: 400
-          .date
-            display: inline-block
-            width: 45%
           .period
             display: inline-block
-            width: 30%
+            width: 70%
           .download
             display: inline-block
-            width: 25%
+            width: 30%
       #statement_period
         margin-top: 5px
         margin-right: 10px

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -207,14 +207,26 @@ module PublishersHelper
     PublisherDnsRecordGenerator.new(publisher: publisher).perform
   end
 
-  def statement_periods
+  def all_statement_periods
     [:past_7_days,
      :past_30_days,
      :this_month,
      :last_month,
      :this_year,
      :last_year,
-     :all].collect do |period|
+     :all]
+  end
+
+  def unused_statement_periods
+    periods = all_statement_periods
+    current_publisher.statements.each do |s|
+      periods.delete(s.period.to_sym)
+    end
+    periods
+  end
+
+  def statement_periods_as_options(periods)
+    periods.collect do |period|
       [statement_period_description(period), period]
     end
   end

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -76,7 +76,7 @@ javascript:
 
       var defaultCurrencySelect = document.getElementById('publisher_default_currency');
       if (defaultCurrencySelect) {
-        defaultCurrencySelect.addEventListener('change', function (event) {
+        defaultCurrencySelect.addEventListener('change', function(event) {
           submitForm('update_default_currency_form', 'PATCH', true);
           refreshBalance();
         }, false);
@@ -101,6 +101,7 @@ javascript:
 
       var generateStatement = document.getElementById('generate_statement');
       var generateStatementResult = document.getElementById('generate_statement_result');
+      var statementGenerator = document.getElementById('statement_generator');
       var statementPeriod = document.getElementById('statement_period');
       var generatedStatements = document.getElementById('generated_statements');
 
@@ -139,56 +140,58 @@ javascript:
           });
       }, false);
 
-      generateStatement.addEventListener('click', function(event) {
-        var statementId;
-        var statementDownloadDiv;
+      if (generateStatement) {
+        generateStatement.addEventListener('click', function(event) {
+          var statementId;
+          var statementDownloadDiv;
 
-        event.preventDefault();
-        generateStatement.style.display = 'none';
+          event.preventDefault();
+          generateStatement.style.display = 'none';
 
-        submitForm('statement_generator', 'PATCH', false)
-          .then(function(response) {
-            return response.json();
-          })
-          .then(function(json) {
-            var newStatementDiv = document.createElement('div');
-            newStatementDiv.className = 'statement';
+          submitForm('statement_generator', 'PATCH', false)
+            .then(function(response) {
+              return response.json();
+            })
+            .then(function(json) {
+              statementPeriod.options.remove(statementPeriod.selectedIndex);
+              if (statementPeriod.options.length === 0) {
+                statementGenerator.style.display = 'none';
+              }
 
-            var statementDateDiv = document.createElement('div');
-            statementDateDiv.className = 'date';
-            statementDateDiv.appendChild(document.createTextNode(json.date));
-            newStatementDiv.appendChild(statementDateDiv);
+              var newStatementDiv = document.createElement('div');
+              newStatementDiv.className = 'statement';
 
-            var statementPeriodDiv = document.createElement('div');
-            statementPeriodDiv.className = 'period';
-            statementPeriodDiv.appendChild(document.createTextNode(json.period));
-            newStatementDiv.appendChild(statementPeriodDiv);
+              var statementPeriodDiv = document.createElement('div');
+              statementPeriodDiv.className = 'period';
+              statementPeriodDiv.appendChild(document.createTextNode(json.period));
+              newStatementDiv.appendChild(statementPeriodDiv);
 
-            statementDownloadDiv = document.createElement('div');
-            statementDownloadDiv.className = 'download';
-            statementDownloadDiv.appendChild(document.createTextNode('Generating'));
-            newStatementDiv.appendChild(statementDownloadDiv);
+              statementDownloadDiv = document.createElement('div');
+              statementDownloadDiv.className = 'download';
+              statementDownloadDiv.appendChild(document.createTextNode('Generating'));
+              newStatementDiv.appendChild(statementDownloadDiv);
 
-            generatedStatements.insertBefore(newStatementDiv, generatedStatements.firstChild);
+              generatedStatements.insertBefore(newStatementDiv, generatedStatements.firstChild);
 
-            dynamicEllipsis.start(statementDownloadDiv);
+              dynamicEllipsis.start(statementDownloadDiv);
 
-            statementId = json.id;
-            return pollUntilSuccess('/publishers/statement_ready?id=' + statementId, 3000, 2000, 7);
-          })
-          .then(function() {
-            dynamicEllipsis.stop(statementDownloadDiv);
-            statementDownloadDiv.innerHTML = '<a href="/publishers/statement?id=' + statementId + '">Download</a>';
-            generateStatement.style.display = 'inline-block';
-          })
-          .catch(function(e) {
-            if (statementDownloadDiv) {
+              statementId = json.id;
+              return pollUntilSuccess('/publishers/statement_ready?id=' + statementId, 3000, 2000, 7);
+            })
+            .then(function() {
               dynamicEllipsis.stop(statementDownloadDiv);
-              statementDownloadDiv.innerText = 'Delayed'
-            }
-            generateStatement.style.display = 'inline-block';
-          });
-      }, false);
+              statementDownloadDiv.innerHTML = '<a href="/publishers/statement?id=' + statementId + '">Download</a>';
+              generateStatement.style.display = 'inline-block';
+            })
+            .catch(function(e) {
+              if (statementDownloadDiv) {
+                dynamicEllipsis.stop(statementDownloadDiv);
+                statementDownloadDiv.innerText = 'Delayed';
+              }
+              generateStatement.style.display = 'inline-block';
+            });
+        }, false);
+      }
     }, false);
   })();
 
@@ -300,17 +303,17 @@ noscript
       .statements#statement_section style=(current_publisher.uphold_verified ? '' : 'display: none')
         .panel-header.panel-header-h4#publishers_statement
           = t("publishers.statements")
-        = form_for(current_publisher, url: generate_statement_publishers_path, html: { id: "statement_generator" }) do |f|
-          .form-group
-            = select_tag(:statement_period, options_for_select(statement_periods, :past_30_days))
-            .pull-right
-              a.edit-link#generate_statement href="#"
-                = t("shared.generate")
+        - if unused_statement_periods.length > 0
+          = form_for(current_publisher, url: generate_statement_publishers_path, html: { id: "statement_generator" }) do |f|
+            .form-group
+              = select_tag(:statement_period, options_for_select(statement_periods_as_options(unused_statement_periods), :past_30_days))
+              .pull-right
+                a.edit-link#generate_statement href="#"
+                  = t("shared.generate")
         .clearfix
         #generated_statements
           - current_publisher.statements.each do |s|
             .statement
-              .date= statement_period_date(s.created_at)
               .period= statement_period_description(s.period.to_sym)
               .download= s.encrypted_contents? ? link_to(t("publishers.statement_download"), statement_publishers_url(id: s.id)) : t("publishers.statement_delayed")
 


### PR DESCRIPTION
This work addresses the dashboard statement generation issues mentioned in #329 as follows:

* Statement date is no longer shown as a column. Since statements generated > 24 hours ago will be purged, the date is rather meaningless.

* As statements are generated for a period, the corresponding option is eliminated from the select element. Once all options have been exhausted, the statement generation controls are hidden. Thus, only one statement per period can be generated. 

Here's how the dashboard looks with a few statements generated:

![screen shot 2017-11-30 at 5 04 35 pm](https://user-images.githubusercontent.com/29122/33458487-6d8b1002-d5f4-11e7-834a-47c140d4ce07.png)

And here's how it looks with all the options exhausted:

![screen shot 2017-11-30 at 5 19 59 pm](https://user-images.githubusercontent.com/29122/33458499-715c0ace-d5f4-11e7-8b7c-30549133de76.png)

I believe @jenn-rhim will want to further refine this approach, but this is at least a start.

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
