### PR TITLE
Notify admins when publisher emails change

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -117,6 +117,7 @@ class PublishersController < ApplicationController
     if success && update_params[:pending_email]
       PublisherMailer.notify_email_change(publisher).deliver_later
       PublisherMailer.confirm_email_change(publisher).deliver_later
+      PublisherMailer.confirm_email_change_internal(publisher).deliver_later if PublisherMailer.should_send_internal_emails?
     end
 
     respond_to do |format|

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -95,6 +95,17 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
+  def confirm_email_change_internal(publisher)
+    @publisher = publisher
+    @private_reauth_url = "{redacted}"
+    mail(
+      to: INTERNAL_EMAIL,
+      reply_to: @publisher.email,
+      subject: "<Internal> #{I18n.t(:subject, publication_title: @publisher.publication_title, scope: %w(publisher_mailer confirm_email_change))}",
+      template_name: "confirm_email_change"
+    )
+  end
+
   def notify_email_change(publisher)
     @publisher = publisher
     mail(

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -50,4 +50,19 @@ class PublisherMailerTest < ActionMailer::TestCase
     assert_match "( http://www.example.com/ )", email.text_part.body.to_s
     assert_match "href=\"http://www.example.com/\"", email.html_part.body.to_s
   end
+
+  test "confirm_email_change" do
+    publisher = publishers(:verified)
+    publisher.pending_email = "alice-pending@verified.com"
+    publisher.save
+
+    email = PublisherMailer.confirm_email_change(publisher)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ['brave-publishers@localhost.local'], email.from
+    assert_equal [publisher.pending_email], email.to
+  end
 end


### PR DESCRIPTION
When a publisher changes their contact email, three emails are now sent.

1. Notification email to original email address
2. Confirmation email to pending email address, with a link to activate the change
3. Copy of confirmation email to Brave internal **(new)**

### Changes
* Create new `confirm_email_change_internal` email in the publisher mailer

* Add unit tests for existing `confirm_email_change` email in publisher_mailer_tests.rb

* Add test for the entire email change flow in publisher_controller_tests.rb

Resolves #116

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:
There wasn't a test that covered the entire email update flow.  I added this test, and in one of the checks, verify that the internal email is sent.

I also added a unit test for the existing `confirm_email_change` email in publisher_mailer.rb.

More unit tests in publisher_mailer_test.rb could be written, although they are low priority as they follow the form of other emails with tests, and have already demonstrated they work.

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions
Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
