### PR TITLE
Refactor validations related to brave_publisher_id

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -181,7 +181,9 @@ class PublishersController < ApplicationController
           }, status: 200)
         elsif publisher.brave_publisher_id_error_code.present?
           render(json: {
-            error: I18n.t('activerecord.attributes.publisher.brave_publisher_id') + ' ' + publisher.brave_publisher_id_error_description
+            error: I18n.t('activerecord.attributes.publisher.brave_publisher_id') +
+                   ': ' +
+                   publisher.brave_publisher_id_error_description
           }, status: 200)
         else
           head 404

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -133,10 +133,12 @@ class PublishersController < ApplicationController
 
   def update_unverified
     @publisher = current_publisher
+    @publisher.brave_publisher_id = nil
+    success = @publisher.update(publisher_update_unverified_params)
 
     respond_to do |format|
       format.json {
-        if @publisher.update(publisher_update_unverified_params)
+        if success
           # Set the publisher's domain asynchronously when the form is submitted with xhr.
           # The results of the domain normalization and inspection will be polled afterward.
           if @publisher.brave_publisher_id_unnormalized
@@ -154,8 +156,6 @@ class PublishersController < ApplicationController
         #
         # NOTE: These requests are in danger of being long-running. However, this code path should
         # only be reached when JS is disabled.
-        success = @publisher.update(publisher_update_unverified_params)
-
         if success && @publisher.brave_publisher_id_unnormalized
           PublisherDomainSetter.new(publisher: @publisher).perform
           success = @publisher.save

--- a/app/jobs/set_publisher_domain_job.rb
+++ b/app/jobs/set_publisher_domain_job.rb
@@ -4,8 +4,10 @@ class SetPublisherDomainJob < ApplicationJob
   def perform(publisher_id:)
     publisher = Publisher.find(publisher_id)
 
-    PublisherDomainSetter.new(publisher: publisher).perform
-
-    publisher.save!
+    if publisher.brave_publisher_id_unnormalized
+      PublisherDomainSetter.new(publisher: publisher).perform
+      publisher.brave_publisher_id_unnormalized = nil
+      publisher.save!
+    end
   end
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -156,11 +156,13 @@ class Publisher < ApplicationRecord
   def brave_publisher_id_error_description
     case self.brave_publisher_id_error_code.to_sym
     when :exclusion_list_error
-      "#{I18n.t('activerecord.errors.models.publisher.attributes.brave_publisher_id.exclusion_list_error')} #{Rails.application.secrets[:support_email]}"
+      I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.exclusion_list_error")
     when :api_error_cant_normalize
       I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.api_error_cant_normalize")
     when :invalid_uri
       I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.invalid_uri")
+    when :taken
+      I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.taken")
     else
       raise "Unrecognized brave_publisher_id_error_code: #{self.brave_publisher_id_error_code}"
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     attributes:
       publisher:
         brave_publisher_id: "Website Domain"
+        brave_publisher_id_unnormalized: "Website Domain"
         phone_normalized: "Phone Number"
         show_verification_status: "List my site in Brave's verified publisher site once verified."
         name: "Contact Name"
@@ -32,11 +33,12 @@ en:
         publisher:
           attributes:
             brave_publisher_id:
-              api_error_cant_normalize: "can't be normalized because of an API error"
-              exclusion_list_error: "is on the Brave Publisher website exclusion list. For questions please contact "
+              api_error_cant_normalize: "Can't be normalized because of an API error"
+              # TODO: Configurable email here
+              exclusion_list_error: "Is on the Brave Publisher website exclusion list. If you have questions please contact support+publishers@basicattentiontoken.org."
               # TODO: Configurable email here
               taken: "Another person has already verified that website. If you have questions please contact support+publishers@basicattentiontoken.org."
-              invalid_uri: "invalid domain URI"
+              invalid_uri: "Invalid domain URI"
     models:
       publisher: "Publisher"
     shared:

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -232,16 +232,34 @@ class PublisherTest < ActiveSupport::TestCase
     end
   end
 
-  test "a publisher assigned a brave_publisher_id_error_code will not be valid" do
+  test "a publisher assigned a brave_publisher_id_error_code and brave_publisher_id will not be valid" do
     publisher = Publisher.new
 
     publisher.pending_email = "foo@bar.com"
     assert publisher.valid?
 
+    publisher.email = "foo@bar.com"
+    publisher.name = 'Joe Blow'
+    publisher.brave_publisher_id = 'asdf asdf'
     publisher.brave_publisher_id_error_code = :invalid_uri
 
     refute publisher.valid?
     assert_equal [:brave_publisher_id], publisher.errors.keys
+    assert_equal "invalid_uri", publisher.brave_publisher_id_error_code
+    assert_equal I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.invalid_uri"), publisher.brave_publisher_id_error_description
+  end
+
+  test "a publisher assigned a brave_publisher_id_error_code and brave_publisher_id_unnormalized will not be valid" do
+    publisher = Publisher.new
+
+    publisher.pending_email = "foo@bar.com"
+    publisher.brave_publisher_id_unnormalized = 'asdf asdf'
+    assert publisher.save
+
+    publisher.brave_publisher_id_error_code = :invalid_uri
+
+    refute publisher.valid?
+    assert_equal [:brave_publisher_id_unnormalized], publisher.errors.keys
     assert_equal "invalid_uri", publisher.brave_publisher_id_error_code
     assert_equal I18n.t("activerecord.errors.models.publisher.attributes.brave_publisher_id.invalid_uri"), publisher.brave_publisher_id_error_description
   end


### PR DESCRIPTION
This fixes a couple edge cases that were not handled well in #342:

* When domain normalization/inspection fails, it is now possible to reattempt submitting the domain (or an updated domain) in the contact info form.

* When a domain that matches an already verified domain has been entered, the error is now displayed properly to the user when JS is enabled.

Fixes #346 

/cc @ayumi 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
