### PR TITLE
Add escape hatch link for misidentified WordPress sites

### DIFF
--- a/app/views/publishers/verification_wordpress.html.slim
+++ b/app/views/publishers/verification_wordpress.html.slim
@@ -9,6 +9,7 @@
   .sub-panel.process-panel.col-center
     .content-panel
       h3= t("publishers.verification_option_wordpress")
+      p= link_to t("publishers.verification_option_wordpress_not"), verification_choose_method_publishers_path
       = render :partial => 'https_check', :locals => { publisher: current_publisher }
 
       div class=(current_publisher.supports_https? ? "instructions" : "instructions dimmed")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
     verification_https_check_no_https_alt: "Your domain is NOT using HTTPS."
     verification_download_verification: "Download"
     verification_option_wordpress: "Hello. It looks like you are using Wordpress!"
+    verification_option_wordpress_not: "Not using WordPress? Choose another verification method."
     verification_option_wordpress_install_plugin_html: |
       <p class="li-text"><a href="https://wordpress.org/plugins/well-known-uris/" class="download-link">Install the plugin</a> that makes the
        entire process a snap.</p>


### PR DESCRIPTION
Resolves #358 

![image](https://user-images.githubusercontent.com/250934/33683519-32ea67dc-da99-11e7-86bb-7906edf5846a.png)

cc: @jenn-rhim for feedback on wording and placement

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
