### PR TITLE
Tweak styles for the login page on mobile

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -14,6 +14,7 @@ body[data-controller="u2f_registrations"]
 
   .main-content
     padding-top: 25px
+    padding-bottom: 25px
     background: #eaedef
     background: -webkit-linear-gradient(-75deg, #e9eaef , #e0e3e6 , #d6d6d6 , #e7ccc9 ,#f7ada7 , #d68588 , #ca3884 , #c7297b )
     min-height: calc(100vh - 80px)
@@ -27,7 +28,6 @@ body[data-controller="u2f_registrations"]
     box-shadow: 2px 2px 0px 0px rgba(47,48,50,0.15)
   .publisher-panel
     max-width: 880px
-    min-width: 448px
   .publisher-main-panel
     margin-top: 0px
     margin-bottom: 150px
@@ -77,10 +77,36 @@ body[data-controller="u2f_registrations"]
       padding: 0 30px
 
   .login-panel
+    margin-top: 46px
     .row
       padding: 0 40px
     .site-login, .youtube-login
       padding: 30px 0
+
+  @media (max-width: $screen-sm-max)
+    .login-panel
+      margin-top: 0px
+      max-width: 500px
+    .process-panel
+      padding-bottom: 15px
+      .panel-controls
+        margin-top: 15px
+      h3
+        margin-bottom: 23px
+    .login-penal
+      .site-login
+        padding: 10px 0
+
+  @media (max-width: $screen-xxs-max)
+    .process-panel
+      padding-left: 0
+      padding-right: 0
+      padding-bottom: 0
+      h3
+        margin-bottom: 18px
+    .sub-panel
+      padding-left: 0
+      padding-right: 0
 
   .signup-panel
     .col
@@ -216,7 +242,7 @@ body[data-controller="u2f_registrations"]
         line-height: 14px
         padding: 0 5px
         color: $progress-train-label
-        @media (max-width: 991px)
+        @media (max-width: $screen-md-max)
           display: none
       &.unstarted, &.finished
         label
@@ -418,7 +444,7 @@ body[data-controller="u2f_registrations"]
       color: #999ea2
       a
         color: #00bcd6
-    @media (max-width: 991px)
+    @media (max-width: $screen-md-max)
       .content-panel
         width: 340px
       .or
@@ -459,7 +485,7 @@ body[data-controller="u2f_registrations"]
       .dashboard-panel
         padding-left: 95px
         padding-right: 45px
-        @media (min-width: 992px)
+        @media (min-width: $screen-md-min)
           min-height: 460px
         min-width: 450px
         .panel-header
@@ -762,12 +788,12 @@ body[data-controller="u2f_registrations"]
         background: #fff
         border-radius: 0
 
-    @media (max-width: 991px)
+    @media (max-width: $screen-md-max)
       .publisher-panel
-        width: 400px
+        max-width: 400px
       .site-operator
         margin-bottom: 32px
-    @media (min-width: 992px)
+    @media (min-width: $screen-md-min)
       .publisher-panel
         width: 840px
       .choice-panel-left

--- a/app/assets/stylesheets/partials/nav.sass
+++ b/app/assets/stylesheets/partials/nav.sass
@@ -5,7 +5,6 @@
   margin-bottom: 0px
   height: 80px
   padding-top: 15px
-  min-width: 520px
   .container-fluid
     .navbar-brand
       margin-left: -10px
@@ -15,7 +14,6 @@
   border-width: 0 0 0px
 .nav
   padding: 10px 0
-  min-width: 230px
   .menu-container
     height: 50px
     margin-top: 10px

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,7 +4,7 @@ html
     = csrf_meta_tags
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=edge"
-    meta name="viewport" content="width=device-width, initial-scale=0.6"
+    meta name="viewport" content=("width=device-width, initial-scale=#{if local_assigns[:viewport_initial_scale] then viewport_initial_scale else '0.6' end}")
     title= t("publishers.app_title")
     = stylesheet_link_tag('application', media: 'all')
     = javascript_include_tag('application')

--- a/app/views/layouts/publishers.html.slim
+++ b/app/views/layouts/publishers.html.slim
@@ -2,4 +2,9 @@
   .main-content
     #content.container
       = yield
-= render(template: "layouts/application")
+
+= render \
+  template: "layouts/application",
+  locals: { \
+    viewport_initial_scale: ((action_name === 'new_auth_token') && '1.0') \
+  }

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -1,13 +1,9 @@
 - content_for(:navbar_content) do
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    | &nbsp;
-
 .publisher-panel.login-panel.col-center
   .sub-panel.process-panel
     .row
-      .col.col-md-12
+      .col
         h3.text-center= t("publishers.new_auth_token")
     .row
       .col.col-md-5.site-login


### PR DESCRIPTION
Refs #349

* Change the viewport scaling to be `1`
* Add padding so the background gradient is visible after the container box on a small screen
* Remove minimum widths from several elements
* Tweak styles at small and extra-small breakpoints to be more reasonable

TODO:

* [x] general approval by @jenn-rhim 
* [x] Need to sanity check logged-in dashboard pages, perhaps limit this change to the login page. **Done, this only impacts the login page.**

**Mobile at 375px (iPhone7)**

before:

<img width="389" alt="screen shot 2017-12-07 at 11 08 18 am" src="https://user-images.githubusercontent.com/8752/33725345-df953ad8-db3f-11e7-9179-d0d27993164b.png">

after:

<img width="385" alt="screen shot 2017-12-07 at 11 08 27 am" src="https://user-images.githubusercontent.com/8752/33725359-e6a2f158-db3f-11e7-95a9-40012596c623.png">

<img width="388" alt="screen shot 2017-12-07 at 11 08 42 am" src="https://user-images.githubusercontent.com/8752/33725376-f34d025e-db3f-11e7-9b8a-fe6db9ca6325.png">

**Mobile at 768px (tablet)**

before:

<img width="781" alt="screen shot 2017-12-07 at 11 09 32 am" src="https://user-images.githubusercontent.com/8752/33725413-11c5608c-db40-11e7-9d67-6abfee48873c.png">

<img width="783" alt="screen shot 2017-12-07 at 11 09 40 am" src="https://user-images.githubusercontent.com/8752/33725420-165472be-db40-11e7-966a-e533139b0702.png">

after:

<img width="778" alt="screen shot 2017-12-07 at 2 39 46 pm" src="https://user-images.githubusercontent.com/8752/33735183-92326a3c-db5c-11e7-9b0d-e2feec9c36e5.png">

<img width="779" alt="screen shot 2017-12-07 at 2 39 57 pm" src="https://user-images.githubusercontent.com/8752/33735190-97f78e98-db5c-11e7-9466-d92f52719edb.png">

**At all sizes larger than this, there is no visual change**