### PR TITLE
Add timeout message for Uphold status polling

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -396,6 +396,7 @@ class PublishersController < ApplicationController
         render(json: {
           status: publisher_status(publisher).to_s,
           status_description: publisher_status_description(publisher),
+          timeout_message: publisher_status_timeout(publisher),
           uphold_status: publisher.uphold_status.to_s,
           uphold_status_description: uphold_status_description(publisher)
         }, status: 200)

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -146,6 +146,15 @@ module PublishersHelper
     end
   end
 
+  def publisher_status_timeout(publisher)
+    case publisher_status(publisher)
+    when :uphold_processing
+      t("publishers.status_uphold_processing_timeout")
+    else
+      nil
+    end
+  end
+
   def publisher_status_description(publisher)
     case publisher_status(publisher)
     when :complete

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -199,6 +199,7 @@ javascript:
   javascript:
     (function() {
       var checkUpholdStatusInterval;
+      var checkUpholdStatusCount = 0;
 
       function checkUpholdStatus() {
         var options = {
@@ -211,6 +212,7 @@ javascript:
 
         return window.fetch('./status', options)
           .then(function(response) {
+            checkUpholdStatusCount += 1;
             if (response.status === 200 || response.status === 304) {
               return response.json();
             }
@@ -223,6 +225,11 @@ javascript:
               publisherStatus.className = body.status;
               var upholdDashboard = document.getElementById('uphold_dashboard');
               upholdDashboard.style.display = '';
+              dynamicEllipsis.stop('publisher_status');
+              clearInterval(checkUpholdStatusInterval);
+            } else if (checkUpholdStatusCount >= 15) {
+              var publisherStatus = document.getElementById('publisher_status');
+              publisherStatus.innerText = body.timeout_message;
               dynamicEllipsis.stop('publisher_status');
               clearInterval(checkUpholdStatusInterval);
             }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,7 @@ en:
       Phone Number <span class="optional">(optional)</span>
     phone_number_validation: "Phone numbers should only include numbers, dashes, periods, plus (+), and/or parentheses."
     status_uphold_processing: "Your Uphold wallet is being connected to your account"
+    status_uphold_processing_timeout: "We are having trouble connecting your Uphold wallet to your account. Please check back later."
     status_unverified: "Your account has not been verified"
     uphold_status_verified: "Your Uphold wallet is ready to receive Brave Payments."
     uphold_status_access_parameters_acquired: "Connecting your Uphold account."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,7 @@ en:
       Phone Number <span class="optional">(optional)</span>
     phone_number_validation: "Phone numbers should only include numbers, dashes, periods, plus (+), and/or parentheses."
     status_uphold_processing: "Your Uphold wallet is being connected to your account"
-    status_uphold_processing_timeout: "We are having trouble connecting your Uphold wallet to your account. Please check back later."
+    status_uphold_processing_timeout: "We are having trouble connecting to your Uphold wallet. Please check back later."
     status_unverified: "Your account has not been verified"
     uphold_status_verified: "Your Uphold wallet is ready to receive Brave Payments."
     uphold_status_access_parameters_acquired: "Connecting your Uphold account."

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -625,6 +625,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_match(
       '{"status":"uphold_unconnected",' +
        '"status_description":"You need to create a wallet with Uphold to receive contributions from Brave Payments.",' +
+       '"timeout_message":null,' +
        '"uphold_status":"unconnected",' +
        '"uphold_status_description":"Not connected to Uphold."}',
       response.body)


### PR DESCRIPTION
Resolves #223 

When the status check polling for the Uphold wallet connection keeps failing (whether Publishers, Eyeshade, or Uphold is having trouble completing wallet verification), this introduces a timeout message that displays after 30 seconds letting the Publisher know that we're having some trouble:

![Uphold Timeout](https://user-images.githubusercontent.com/250934/33733220-1e5758de-db57-11e7-9bca-1ab3b40fb120.png)

This gets the Publisher out of the visually "stuck" state while the background job keeps attempting to verify the Uphold wallet. Should the Publisher reload the page or logout/login, then they will again see the polling message unless/until it again times out.

The worst case scenario of Uphold verification not working at all ultimately will be handled by @nvonpentz's work on #366 which would then result in this page returning to the original "connect to Uphold" prompt after the stalled verification codes have been cleared out.

cc: @jenn-rhim for approval on timeout message wording

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:

If you want to make your local dev environment timeout during this polling, temporarily comment out this line to prevent the Uphold verification from completing:
https://github.com/brave-intl/publishers/blob/4b6575c8fb6b1f104f8a879802dc9c7fb40e2e70/app/jobs/upload_uphold_access_parameters_job.rb#L9

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
