### PR TITLE
Introduce capybara and headless chrome based tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,9 @@ group :development, :test do
   # Sweet REPL. To use, drop in "binding.pry" anywhere in code.
   gem "pry"
   gem "mocha"
+  gem "minitest-rails-capybara"
+  gem "capybara-selenium"
+  gem "chromedriver-helper"
 end
 
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    archive-zip (0.7.0)
+      io-like (~> 0.3.0)
     arel (7.1.4)
     ast (2.3.0)
     attr_encrypted (3.0.3)
@@ -59,6 +61,21 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.0.6)
+    capybara (2.16.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    capybara-selenium (0.0.6)
+      capybara
+      selenium-webdriver
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.1.0)
+      archive-zip (~> 0.7.0)
+      nokogiri (~> 1.6)
     clipboard-rails (1.5.15)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
@@ -111,6 +128,7 @@ GEM
       parser (>= 2.2.3.0)
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
+    io-like (0.3.0)
     json (2.0.2)
     jsonapi (0.1.1.beta6)
       jsonapi-parser (= 0.1.1.beta3)
@@ -135,8 +153,23 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    minitest-capybara (0.8.2)
+      capybara (~> 2.2)
+      minitest (~> 5.0)
+      rake
+    minitest-metadata (0.6.0)
+      minitest (>= 4.7, < 6.0)
+    minitest-rails (3.0.0)
+      minitest (~> 5.8)
+      railties (~> 5.0)
+    minitest-rails-capybara (3.0.1)
+      capybara (~> 2.7)
+      minitest-capybara (~> 0.8)
+      minitest-metadata (~> 0.6)
+      minitest-rails (~> 3.0)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.2)
@@ -256,6 +289,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.1)
     rufus-scheduler (3.4.0)
       et-orbi (~> 1.0)
     safe_yaml (1.0.4)
@@ -266,6 +300,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.8.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     sentry-raven (2.6.3)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (4.2.10)
@@ -329,6 +366,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.1.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -339,6 +378,8 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   bundler-audit
   byebug
+  capybara-selenium
+  chromedriver-helper
   clipboard-rails
   database_cleaner
   devise (~> 4.2.0)
@@ -349,6 +390,7 @@ DEPENDENCIES
   i18n-tasks (~> 0.9.12)
   listen (~> 3.0.5)
   lograge (~> 0.4)
+  minitest-rails-capybara
   mocha
   newrelic_rpm (~> 3.16)
   nokogiri (~> 1.8.1)

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class PublishersHomeTest < Capybara::Rails::TestCase
+  include Devise::Test::IntegrationHelpers
+
+  test "land page renders, can navigate to log in" do
+    visit root_path
+    assert_content page, "Brave Payments"
+    click_link('Log in')
+    assert_content page, "Log in to Brave Payments"
+  end
+
+  test "publishers page renders, 'edit contact' opens form, name can be changed" do
+    publisher = publishers(:completed)
+    sign_in publisher
+
+    visit home_publishers_path
+    assert_content page, publisher.name
+    assert_content page, publisher.email
+
+    click_link('Edit Contact')
+
+    new_name = 'Bob the Builder'
+    fill_in 'update_contact_name', with: new_name
+
+    click_button('Update')
+
+    assert_content page, new_name
+    refute_content 'Update'
+  end
+
+end

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -24,6 +24,7 @@ completed:
   name: "Alice the Completed"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  show_verification_status: false
   verification_token: "e3d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
   verified: true
   authentication_token_expires_at: "<%= 5.days.from_now %>"


### PR DESCRIPTION
This PR introduces full-stack feature testing, including JavaScript code. It is roughly related to #348.

Technical summary:

* Introduce minitest-rails-capybara for a feature test harness.
* Make all feature tests (which inherit from `Capybara::Rails::TestCase`) always run the full browser environment.
* Introduce Capybara for driving selenium and browser tests.
* Add chromedriver-selenium which permits us to use headless chrome.
* Write two simple proof-of-concept tests, including one which requires authentication.
* By default have webmock permit network connects (which Capybara uses), however disable them for tests using the `ActionDispatch::IntegrationTest` base class (most of ours, the integration tests).

w/ @kpfefferle.