### PR TITLE
Add bundler cache to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 bundler_args: --jobs=3 --retry=3 --without production --without staging
 dist: trusty
 addons:


### PR DESCRIPTION
`bundle install` can take 112 seconds, and seems like it isn't cached. Since Bundler already ensures the proper dependencies are loaded for an app lets use the cache and speed up the builds.

[travis docs for this option](https://docs.travis-ci.com/user/caching/#Bundler)