### PR TITLE
Have CI precompile assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ bundler_args: --jobs=3 --retry=3 --without production --without staging
 dist: trusty
 addons:
   postgresql: "9.6"
+  chrome: "stable"
 services:
   - postgresql
   - redis-server
 before_script:
   - RAILS_ENV=test bundle exec rake db:setup
+    # Fails if assets don't build. If it is successful, these assets are then
+    # use by the subsequent test run.
+  - RAILS_ENV=test bundle exec rake assets:precompile

--- a/app/assets/javascripts/u2f_authentications.js
+++ b/app/assets/javascripts/u2f_authentications.js
@@ -7,10 +7,10 @@
   function authenticate(formElement, responseInput) {
     formElement.classList.add('js-u2f-working');
 
-    let appId = formElement.querySelector('[name=u2f_app_id]').value;
-    let challenge = JSON.parse(formElement.querySelector('[name=u2f_challenge]').value);
-    let signRequests = JSON.parse(formElement.querySelector('[name=u2f_sign_requests]').value);
-    window.u2f.sign(appId, challenge, signRequests, signingResponse => {
+    var appId = formElement.querySelector('[name=u2f_app_id]').value;
+    var challenge = JSON.parse(formElement.querySelector('[name=u2f_challenge]').value);
+    var signRequests = JSON.parse(formElement.querySelector('[name=u2f_sign_requests]').value);
+    window.u2f.sign(appId, challenge, signRequests, function(signingResponse) {
       switch(signingResponse.errorCode) {
 
         case undefined: // OK
@@ -38,7 +38,7 @@
 
       formElement.classList.remove('js-u2f-working');
       // Reset the form after an error to permit a second attempt
-      let submit = formElement.querySelector('input[type=submit][disabled=disabled]');
+      var submit = formElement.querySelector('input[type=submit][disabled=disabled]');
       if (submit) {
         submit.removeAttribute('disabled');
         submit.blur();
@@ -50,12 +50,12 @@
    * Setup the DOM event listeners
    *
    */
-  document.addEventListener('DOMContentLoaded', () => {
-    let formElement = document.querySelector('.js-authenticate-u2f');
+  document.addEventListener('DOMContentLoaded', function() {
+    var formElement = document.querySelector('.js-authenticate-u2f');
 
     if (formElement) {
-      let responseInput = formElement.querySelector('[name=u2f_response]');
-      formElement.addEventListener('submit', event => {
+      var responseInput = formElement.querySelector('[name=u2f_response]');
+      formElement.addEventListener('submit', function(event) {
         window.U2FShared.clearErrors('register-u2f-error');
         if (!responseInput.value) {
           event.preventDefault();

--- a/app/assets/javascripts/u2f_registrations.js
+++ b/app/assets/javascripts/u2f_registrations.js
@@ -5,10 +5,10 @@
    * Register a u2f device
    */
   function registerU2fDevice(formElement, responseInput) {
-    let appId = formElement.querySelector('[name=u2f_app_id]').value;
-    let registrationRequests = JSON.parse(formElement.querySelector('[name=u2f_registration_requests]').value);
-    let registeredKeys = JSON.parse(formElement.querySelector('[name=u2f_sign_requests]').value);
-    window.u2f.register(appId, registrationRequests, registeredKeys, registerResponse => {
+    var appId = formElement.querySelector('[name=u2f_app_id]').value;
+    var registrationRequests = JSON.parse(formElement.querySelector('[name=u2f_registration_requests]').value);
+    var registeredKeys = JSON.parse(formElement.querySelector('[name=u2f_sign_requests]').value);
+    window.u2f.register(appId, registrationRequests, registeredKeys, function(registerResponse) {
       switch(registerResponse.errorCode) {
 
         case undefined: // OK
@@ -35,7 +35,7 @@
       }
 
       // Reset the form after an error to permit a second attempt
-      let submit = formElement.querySelector('input[type=submit][disabled=disabled]');
+      var submit = formElement.querySelector('input[type=submit][disabled=disabled]');
       if (submit) {
         submit.removeAttribute('disabled');
         submit.blur();
@@ -47,12 +47,12 @@
    * Setup the DOM event listeners
    *
    */
-  document.addEventListener('DOMContentLoaded', () => {
-    let formElement = document.querySelector('.js-register-u2f');
+  document.addEventListener('DOMContentLoaded', function() {
+    var formElement = document.querySelector('.js-register-u2f');
     if (formElement) {
-      formElement.addEventListener('submit', event => {
+      formElement.addEventListener('submit', function(event) {
         window.U2FShared.clearErrors('register-u2f-error');
-        let responseInput = formElement.querySelector('[name=u2f_response]');
+        var responseInput = formElement.querySelector('[name=u2f_response]');
         if (!responseInput.value) {
           event.preventDefault();
           registerU2fDevice(formElement, responseInput);

--- a/app/assets/javascripts/u2f_shared.js
+++ b/app/assets/javascripts/u2f_shared.js
@@ -3,8 +3,9 @@
 
   window.U2FShared = {
     clearErrors: function clearErrors(errorGroupClassName) {
-      let errorElements = document.querySelectorAll('.js-'+errorGroupClassName+' > div');
-      for (let i=0;i<errorElements.length;i++) {
+      var errorElements = document.querySelectorAll('.js-'+errorGroupClassName+' > div');
+      var i;
+      for (i=0;i<errorElements.length;i++) {
         errorElements[i].classList.remove('show');
       }
     },

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   # and recreated between test runs. Don"t rely on the data there!
   config.cache_classes = true
 
+  config.assets.js_compressor = :uglifier
+
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.


### PR DESCRIPTION
Recent staging builds have failed https://dashboard.heroku.com/apps/bat-publishers-staging/activity/builds/a9f62851-f233-4542-8ed0-4a9da485a8e1 The error causing this is a syntax error raised when the Uglify gem attempts to parse modern JavaScript code (in this case `let`).

In this PR, we have two goals:

* Fix the bug for now by not using modern JavaScript (`let`)
* Ensure that CI will fail in the future for other developers.

We can further pursue plans for being able to use modern JS via https://github.com/brave-intl/publishers/issues/348

/cc @kpfefferle 

TODO:

* [x] Confirm Travis failure as expected
* [x] Remove ES6 usage from JS