### PR TITLE
Back off statement sync retries and stop entirely after 3 minutes

### DIFF
--- a/app/jobs/sync_publisher_statement_job.rb
+++ b/app/jobs/sync_publisher_statement_job.rb
@@ -1,14 +1,40 @@
 class SyncPublisherStatementJob < ApplicationJob
   queue_as :default
 
-  def perform(publisher_statement_id:)
+  def perform(publisher_statement_id:, first_attempt: nil)
+    if first_attempt
+      time_elapsed = Time.now.to_i - first_attempt
+      if time_elapsed > 3.minutes
+        Raven.capture_message('SyncPublisherStatementJob timed out', publisher_statement_id: publisher_statement_id)
+        return
+      end
+    else
+      first_attempt = Time.now.to_i
+      time_elapsed = 0
+    end
+
     publisher_statement = PublisherStatement.find(publisher_statement_id)
 
     PublisherStatementSyncer.new(publisher_statement: publisher_statement).perform
 
     publisher_statement.reload
+
     unless publisher_statement.contents.present?
-      SyncPublisherStatementJob.set(wait: 3.seconds).perform_later(publisher_statement_id: publisher_statement.id)
+      SyncPublisherStatementJob.set(wait: wait_to_retry(time_elapsed)).perform_later(publisher_statement_id: publisher_statement.id, first_attempt: first_attempt)
+    end
+  end
+
+  private
+
+  def wait_to_retry(time_elapsed)
+    if time_elapsed < 20.seconds
+      3.seconds
+    elsif time_elapsed < 1.minute
+      5.seconds
+    elsif time_elapsed < 2.minutes
+      8.seconds
+    else
+      10.seconds
     end
   end
 end

--- a/test/jobs/sync_publisher_statement_job_test.rb
+++ b/test/jobs/sync_publisher_statement_job_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+require "webmock/minitest"
+
+class SyncPublisherStatementTest < ActiveJob::TestCase
+  def setup
+    @prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    Rails.application.secrets[:api_eyeshade_offline] = false
+  end
+
+  def teardown
+    Rails.application.secrets[:api_eyeshade_offline] = @prev_api_eyeshade_offline
+  end
+
+  test "does nothing if a statement already has contents" do
+    publisher = publishers(:verified)
+
+    publisher_statement = PublisherStatement.new(
+      publisher: publisher,
+      period: :all,
+      source_url: '/report/123',
+      contents: 'abc')
+    publisher_statement.save!
+
+    assert_no_enqueued_jobs do
+      SyncPublisherStatementJob.perform_now(publisher_statement_id: publisher_statement.id)
+    end
+
+    publisher_statement.reload
+    assert_equal 'abc', publisher_statement.contents
+  end
+
+  test "syncs statement and will not reschedule if contents have been set" do
+    stub_request(:get, /report\/123/).
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 200, body: "abc", headers: {})
+
+    publisher = publishers(:verified)
+    publisher_statement = PublisherStatement.new(
+      publisher: publisher,
+      period: :all,
+      source_url: '/report/123')
+    publisher_statement.save!
+
+    assert_no_enqueued_jobs(only: SyncPublisherStatementJob) do
+      SyncPublisherStatementJob.perform_now(publisher_statement_id: publisher_statement.id)
+    end
+
+    publisher_statement.reload
+    assert_equal 'abc', publisher_statement.contents
+  end
+
+  test "syncs statement and will reschedule itself if contents have not been set" do
+    publisher = publishers(:verified)
+    publisher_statement = PublisherStatement.new(
+      publisher: publisher,
+      period: :all,
+      source_url: '/report/123')
+    publisher_statement.save!
+
+    stub_request(:get, /report\/123/).
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 404, headers: {})
+
+    assert_enqueued_jobs(1, only: SyncPublisherStatementJob) do
+      SyncPublisherStatementJob.perform_now(publisher_statement_id: publisher_statement.id)
+    end
+  end
+end

--- a/test/services/publisher_statement_getter_test.rb
+++ b/test/services/publisher_statement_getter_test.rb
@@ -46,4 +46,28 @@ class PublisherStatementGetterTest < ActiveJob::TestCase
       Rails.application.secrets[:api_eyeshade_offline] = prev_offline
     end
   end
+
+  test "when online returns nil if fetching source_url returns a 404" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+
+      stub_request(:get, /report\/123/).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 404, headers: {})
+
+      publisher = publishers(:verified)
+
+      publisher_statement = PublisherStatement.new(
+        publisher: publisher,
+        period: :all,
+        source_url: '/report/123')
+
+      result = PublisherStatementGetter.new(publisher_statement: publisher_statement).perform
+      assert_nil result
+
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+    end
+  end
 end

--- a/test/services/publisher_statement_syncer_test.rb
+++ b/test/services/publisher_statement_syncer_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PublisherStatementSyncerTest < ActiveJob::TestCase
+  def setup
+    @prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    Rails.application.secrets[:api_eyeshade_offline] = false
+  end
+
+  def teardown
+    Rails.application.secrets[:api_eyeshade_offline] = @prev_api_eyeshade_offline
+  end
+
+  test "retrieves and saves the publisher statement contents, and sends a notification email" do
+    stub_request(:get, /report\/123/).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: "abc", headers: {})
+
+    publisher = publishers(:verified)
+
+    publisher_statement = PublisherStatement.new(
+      publisher: publisher,
+      period: :all,
+      source_url: '/report/123')
+    publisher_statement.save!
+
+    perform_enqueued_jobs do
+      PublisherStatementSyncer.new(publisher_statement: publisher_statement).perform
+    end
+
+    publisher_statement.reload
+    assert_equal "abc", publisher_statement.contents
+
+    refute ActionMailer::Base.deliveries.empty?
+    email = ActionMailer::Base.deliveries.last
+    assert_equal [publisher.email], email.to
+    assert_equal I18n.t('publisher_mailer.statement_ready.subject', publication_title: publisher.publication_title), email.subject
+  end
+
+  test "retrieves the publisher statement contents - but does nothing if contents are not retrieved" do
+    stub_request(:get, /report\/123/).
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 404, body: nil, headers: {})
+
+    publisher = publishers(:verified)
+
+    publisher_statement = PublisherStatement.new(
+      publisher: publisher,
+      period: :all,
+      source_url: '/report/123')
+    publisher_statement.save!
+
+    assert_no_enqueued_jobs do
+      PublisherStatementSyncer.new(publisher_statement: publisher_statement).perform
+    end
+
+    publisher_statement.reload
+    assert_nil publisher_statement.contents
+  end
+end


### PR DESCRIPTION
As per @mrose17's instructions in #368, if the `SyncPublisherStatementJob` fails, it will continue to retry itself for 3 minutes, gradually backing off its wait time from 3 seconds to 10 seconds.

Also adds more complete tests for this job and its associated services.

Fixes #368 

/cc @ayumi 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
