### PR TITLE
Fixes problem checking for https after initial failure

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -288,10 +288,10 @@ class PublishersController < ApplicationController
     redirect_to(publisher_last_verification_method_path(@publisher), alert: t("shared.api_error"))
   end
 
-  # TODO: Rate limit
+  # TODO: Rate limit and perform async
   def check_for_https
     @publisher = current_publisher
-    @publisher.inspect_brave_publisher_id
+    PublisherDomainSetter.new(publisher: @publisher).perform
     @publisher.save!
     redirect_to(publisher_last_verification_method_path(@publisher), alert: t("publishers.https_inspection_complete"))
   end

--- a/app/services/publisher_domain_setter.rb
+++ b/app/services/publisher_domain_setter.rb
@@ -6,7 +6,7 @@ class PublisherDomainSetter < BaseService
   end
 
   def perform
-    normalize_domain
+    normalize_domain if @publisher.brave_publisher_id_unnormalized
     inspect_host unless @publisher.brave_publisher_id_error_code
   end
 

--- a/test/jobs/sync_publisher_statement_job_test.rb
+++ b/test/jobs/sync_publisher_statement_job_test.rb
@@ -67,6 +67,8 @@ class SyncPublisherStatementTest < ActiveJob::TestCase
   end
 
   test "will stop retrying to sync statement after 3 minutes" do
+    require "sentry-raven"
+
     publisher = publishers(:verified)
     publisher_statement = PublisherStatement.new(
       publisher: publisher,


### PR DESCRIPTION
When a site does not support https, the option to re-check for https is provided to the publisher as part of the trusted file verification step. The method to perform this check was calling a previously removed method on the Publisher model. 

This PR fixes this method and adds tests to prevent regressions.

This is an urgent fix that should be applied to production ASAP.

Fixes #397 

/cc @ayumi @nvonpentz 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
