### PR TITLE
Require sentry-raven in SyncPublisherStatementJob

### DIFF
--- a/app/jobs/sync_publisher_statement_job.rb
+++ b/app/jobs/sync_publisher_statement_job.rb
@@ -2,6 +2,7 @@ class SyncPublisherStatementJob < ApplicationJob
   queue_as :default
 
   def perform(publisher_statement_id:, first_attempt: nil)
+    require "sentry-raven"
     if first_attempt
       time_elapsed = Time.now.to_i - first_attempt
       if time_elapsed > 3.minutes


### PR DESCRIPTION
We are getting the following transient test failure on our TOTP/2FA branch:

```
Error:
SyncPublisherStatementTest#test_will_stop_retrying_to_sync_statement_after_3_minutes:
NameError: uninitialized constant SyncPublisherStatementJob::Raven
```

I believe this is happening because SyncPublisherStatementJob is sending an error to Sentry here without first requiring `sentry-raven`:
https://github.com/brave-intl/publishers/blob/e35db38558273fb34d9147fdad53bd59396b031d/app/jobs/sync_publisher_statement_job.rb#L8

This PR simply adds the necessary `require "sentry-raven"` line to SyncPublisherStatementJob in line with other Jobs that send errors to Sentry.

cc: @dgeb 