### PR TITLE
Ensure that omniauth failures are properly redirected

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -119,5 +119,15 @@ module Publishers
       sign_out(current_publisher)
       redirect_to '/', notice: t('youtube.oauth_error')
     end
+
+    def after_omniauth_failure_path_for(scope)
+      publisher = current_publisher
+
+      if publisher
+        email_verified_publishers_path
+      else
+        '/'
+      end
+    end
   end
 end


### PR DESCRIPTION
Authenticated publishers should be redirected to the email verified
page, while unauthenticated publishers should be redirected to the
landing page.

Fixes #399 

/cc @nvonpentz @ayumi 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
