### PR TITLE
Explain why we need Google access on choose verification type page

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -739,6 +739,13 @@ body[data-controller="u2f_registrations"]
       background: url(asset-path("img-indi-creator@1x.png")) center 66px no-repeat
       &::before
         content: 'YOUTUBE CREATOR'
+      .choice-description
+        p
+          margin-bottom: 5px
+      p.text-center.note-text
+        line-height: 17px
+        width: 350px
+        margin: auto
 
     #taken_youtube_channel_modal
       width: 650px

--- a/app/views/publishers/email_verified.html.slim
+++ b/app/views/publishers/email_verified.html.slim
@@ -73,3 +73,4 @@
         .choice-description
           h3.text-center= t("publishers.pub_type_site_individual_creator")
           p.text-center= t("publishers.pub_type_site_individual_creator_description_html")
+        p.text-center.note-text= t("publishers.pub_type_site_individual_creator_note_html")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
     pub_type_site_operator_description_html: "I have my own site and have access to the domain directory."
     pub_type_site_individual_creator: "INDIVIDUAL CREATOR"
     pub_type_site_individual_creator_description_html: "I use other platforms to publish my content (currently <strong>YouTube</strong> only)."
+    pub_type_site_individual_creator_note_html: "You will need to authenticate with Google to demonstrate that you own the channel."
     youtube_channel_taken_dialog:
       title: "Channel already registered!"
       leadin: "The following YouTube channel has already been registered."


### PR DESCRIPTION
Resolves #409.

#409 specified that we add the explanation in both choose verification page, as well as the google oauth consent screen.  This covers only the verification screen, as it is not possible to add a message to the consent screen as we previously thought.

![image](https://user-images.githubusercontent.com/12549658/34132963-5805749a-e420-11e7-8d10-5f925d002856.png)


### Changes
* Add new translation for the note
* Add the note to email_verified.html.slim
* Add the styles to publishers.sass

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
