### PR TITLE
Add setup instructions for local eyeshade

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ These steps based on [directions at the omniauth-google-oauth2 gem](https://gith
 1. Follow the [setup instructions](https://github.com/brave-intl/bat-ledger) for bat-ledger
 2. Add `export API_EYESHADE_BASE_URI="http://127.0.0.1:3002"` to your secrets script
 3. Add `export API_EYESHADE_KEY="00000000-0000-4000-0000-000000000000"` to your secrets script
-4. In [config/secrets.yml](https://github.com/brave/publishers/blob/master/config/secrets.yml), under `development:` set `api_eyeshade_offline` to `false`
+
+To stop using Eyeshade locally, set `API_EYESHADE_BASE_URI=""`.
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ You may need to wait up to 10 minutes for the changes to propagate.
 
 These steps based on [directions at the omniauth-google-oauth2 gem](https://github.com/zquestz/omniauth-google-oauth2#google-api-setup).
 
+### Local Eyeshade Setup
+
+1. Follow the [setup instructions](https://github.com/brave-intl/bat-ledger) for bat-ledger
+2. Add `export API_EYESHADE_BASE_URI="http://127.0.0.1:3002"` to your secrets script
+3. Add `export API_EYESHADE_KEY="00000000-0000-4000-0000-000000000000"` to your secrets script
+4. In [config/secrets.yml](https://github.com/brave/publishers/blob/master/config/secrets.yml), under `development:` set `api_eyeshade_offline` to `false`
+
 ### Run
 
 1. Start Postgres and redis.

--- a/app/services/publisher_channel_setter.rb
+++ b/app/services/publisher_channel_setter.rb
@@ -8,7 +8,6 @@ class PublisherChannelSetter < BaseApiClient
 
   def perform
     return perform_offline if Rails.application.secrets[:api_eyeshade_offline]
-
     payload = {
       "authorizer" => {
         "owner" => publisher.owner_identifier,

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -21,7 +21,7 @@ default: &default
   api_eyeshade_key: <%= ENV["API_EYESHADE_KEY"] %>
   api_legacy_eyeshade_key: <%= ENV["API_LEGACY_EYESHADE_KEY"] %>
   # Use offline non-canonical implementation of eyeshade API.
-  api_eyeshade_offline: <%= ENV["API_EYESHADE_OFFLINE"] %>
+  api_eyeshade_offline: <%= ENV["API_EYESHADE_BASE_URI"]=="" ? true : false %>
   # Ledger API used for PublisherUrlNormalizer
   # To develop in offline mode set env API_LEDGER_OFFLINE=1
   api_ledger_base_uri: <%= ENV["API_LEDGER_BASE_URI"] %>
@@ -65,7 +65,6 @@ default: &default
 
 development:
   <<: *default
-  api_eyeshade_offline: true
   api_ledger_offline: true
   host_inspector_offline: true
   internal_email: brave-publishers@localhost.local

--- a/docs/publishers-secrets.example.sh
+++ b/docs/publishers-secrets.example.sh
@@ -6,9 +6,8 @@
 
 #export API_AUTH_TOKEN="" # Enable local API token auth.
 #export API_IP_WHITELIST="1.2.3.4,5.6.7.8" # Enable local API whitelisting.
-#export API_EYESHADE_KEY=""
-#export API_EYESHADE_BASE_URI="" # e.g. https://eyeshade-server.example.com/ or run with API_EYESHADE_OFFLINE_1
-export API_EYESHADE_OFFLINE=1
+#export API_EYESHADE_KEY="" # e.g. 00000000-0000-4000-0000-000000000000
+#export API_EYESHADE_BASE_URI="" # e.g. http://127.0.0.1:3002
 #export API_LEDGER_BASE_URI="" # e.g. https://ledger-server.example.com/ or run with API_LEDGER_OFFLINE=1
 export API_LEDGER_OFFLINE=1
 #export ATTR_ENCRYPTED_KEY="" # Encrypt sensitive things in the DB at rest.


### PR DESCRIPTION
Between these additions and the setup instructions I added to the bat-ledger README, everything should be covered.

In config/secrets.yml, we may want to change  the default for `api_eyeshade_offline` under `development:` from `true`, to instead use `<%= ENV["API_EYESHADE_OFFLINE"] %>`, so we end up toggling the secrets script instead of the config file.  In this case I would replace instruction (4).

Resolves #416.

Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
