### PR TITLE
Add sentry log when sending verification email to blank address

### DIFF
--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -66,6 +66,17 @@ class PublisherMailer < ApplicationMailer
   def verify_email(publisher)
     @publisher = publisher
     @private_reauth_url = generate_publisher_private_reauth_url(@publisher)
+
+    if @publisher.pending_email.blank?
+      begin
+        raise "SMTP To address must not be blank for PublisherMailer#verify_email"
+      rescue => e
+        require 'sentry-raven'
+        Raven.capture_exception(e,
+                                publisher: @publisher,
+                                publication_type: @publisher.publication_type)
+      end
+    end
     mail(
         to: @publisher.pending_email,
         subject: default_i18n_subject(publication_title: @publisher.publication_title)

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -65,4 +65,25 @@ class PublisherMailerTest < ActionMailer::TestCase
     assert_equal ['brave-publishers@localhost.local'], email.from
     assert_equal [publisher.pending_email], email.to
   end
+
+  test "verify_email raises error if there is no send address" do
+    publisher = publishers(:default)
+    publisher.pending_email = ""
+    publisher.email = ""
+    publisher.save
+
+    # verify error raised if no pending email
+    assert_raises do
+      PublisherMailer.verify_email(publisher).deliver_now
+    end
+
+    publisher.pending_email = "alice@default.org"
+    publisher.email = "alice@default.org"
+    publisher.save
+    
+    # verify nothing raised if pending email exists
+    assert_nothing_raised do
+      PublisherMailer.verify_email(publisher).deliver_now
+    end
+  end
 end


### PR DESCRIPTION
When we attempt to send a verification email with a blank recipient, we now will raise an error, and log the exception on sentry.  The publisher information, and publication type is also logged.

This should help us pin down why we are attempting to send blank verification emails in the first place.

Refs #404 

### Changes
* Raise if "To" address is blank in PublisherMailer#verify_email, send to sentry
* Add corresponding test to PublisherMailerTest

Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
