### PR TITLE
Add modal confirmation for 2FA changes

### DIFF
--- a/app/assets/javascripts/modal_shared.js
+++ b/app/assets/javascripts/modal_shared.js
@@ -1,0 +1,142 @@
+;(function() {
+  'use strict';
+
+  /*
+   * Implement a simple confirm/deny modal system on top of the md- modal
+   * classes. This relies on the .js-shared-modal div in the application
+   * layout.
+   *
+   * To use this system you'll need a template and a trigger. For example:
+   *
+   * ```html
+   * <script type="text/html" id="my-template">
+   *   <h3>This headline appears in a modal!</h3>
+   * </script>
+   * <a href="/some-destination" data-js-confirm-with-modal="my-template">
+   *   Visit /some-destination, but first confirm
+   * </a>
+   * ```
+   *
+   * When the trigger is clicked the value of `data-js-confirm-with-modal` is
+   * used to find a template. That template is rendered in the modal popup.
+   * Any default behavior or other click event handlers on the trigger do
+   * not fire. This means you can use the confirmable trigger not only with
+   * plain href links, but also with Rails deletion links.
+   *
+   * Add handlers with the classes `js-confirm` and `js-deny` to allow the
+   * user to accept or reject a proposed action. Popups always have a close
+   * button on the top right which is equivilent to `js-deny`.
+   *
+   * For example, this modal offer the user the chance to confirm a disable
+   * action:
+   *
+   * ```slim
+   * = link_to \
+   *     "Disable Wobble",
+   *     wobble_path,
+   *     method: :delete,
+   *     data: { "js-confirm-with-modal": "disable-wobble" }
+   * script#disable-wobble type="text/html"
+   *   h4 Disable Wobble?
+   *   p Are you sure?
+   *   p
+   *     = link_to "Do Not Disable", "#", class: "js-deny"
+   *     = link_to "Disable it for now", "#", class: "js-confirm"
+   * ```
+   *
+   * Using string interpolation in the template `id` field can be useful when
+   * a list of confirmations must be created. For exmaple:
+   *
+   * ```slim
+   * - @widgets.each do |widget|
+   *   = link_to \
+   *       "Delete Widget #{widget.name}",
+   *       widget_path(widget),
+   *       method: :delete,
+   *       data: { "js-confirm-with-modal": "delete-widget-#{widget.id}" }
+   *   script id="delete-widget-#{widget.id} type="text/html"
+   *     h4 = "Delete Widget #{widget.name}?"
+   *     p Are you sure?
+   *     p
+   *       = link_to "No", "#", class: "js-deny"
+   *       = link_to "Yes", "#", class: "js-confirm"
+   * ```
+   *
+   */
+
+  var MODAL_SHOW_CLASS = 'md-show';
+
+  /*
+   * On demand open a modal.
+   */
+  function openModal(html, confirmCallback, denyCallback) {
+    var modalElement = document.querySelector('.js-shared-modal');
+    var contentElement = modalElement.querySelector('.md-content');
+    var containerElement = modalElement.querySelector('.md-container');
+
+    contentElement.innerHTML = html;
+    containerElement.classList.add(MODAL_SHOW_CLASS);
+
+    function confirmationEventDelegate(event) {
+      var target = event.target;
+
+      while (target.parentNode && target.tagName.toLowerCase() !== 'a') {
+        target = target.parentNode;
+      }
+
+      if (target === document) {
+        return;
+      }
+
+      if (target.classList.contains('js-confirm')) {
+        event.preventDefault();
+        confirmCallback();
+      } else if (target.classList.contains('js-deny')) {
+        modalElement.removeEventListener('click', confirmationEventDelegate);
+        contentElement.innerHTML = '';
+        containerElement.classList.remove(MODAL_SHOW_CLASS);
+        event.preventDefault();
+
+        denyCallback();
+      }
+    }
+
+    // Always attempt to remove the listener, ensuring that two
+    // calls to openModal don't create duplicate listeners.
+    modalElement.removeEventListener('click', confirmationEventDelegate);
+    modalElement.addEventListener('click', confirmationEventDelegate);
+  }
+
+  /*
+   * Open a modal based on the template specified by the confirmed link
+   */
+  function confirmWithModal(confirmableLink) {
+    var template = document.getElementById(confirmableLink.getAttribute('data-js-confirm-with-modal'));
+
+    openModal(template.innerHTML, function() {
+      confirmableLink.setAttribute('data-user-verified', '');
+      confirmableLink.click();
+    }, function() {
+      confirmableLink.blur();
+    });
+  }
+
+  /*
+   * Setup the DOM event listeners on links requesting confirmation.
+   */
+  document.addEventListener('DOMContentLoaded', function() {
+    var confirmableLinks = document.querySelectorAll('[data-js-confirm-with-modal]');
+    var confirmableLink;
+    for (var i=0;i<confirmableLinks.length;i++) {
+      confirmableLink = confirmableLinks[i];
+      confirmableLink.addEventListener('click', function(event) {
+        var userVerified = event.target.getAttribute('data-user-verified');
+        if (userVerified === null) {
+          event.preventDefault();
+          event.stopPropagation();
+          confirmWithModal(event.target);
+        }
+      });
+    }
+  });
+})();

--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -28,6 +28,8 @@ body[data-controller="u2f_registrations"]
     padding: 64px 20px 55px 20px
     border-radius: 8px
     box-shadow: 2px 2px 0px 0px rgba(47,48,50,0.15)
+    .md-content
+      background: transparent
   .publisher-panel
     max-width: 880px
   .publisher-main-panel
@@ -85,6 +87,10 @@ body[data-controller="u2f_registrations"]
     .site-login, .youtube-login
       padding: 30px 0
 
+  .md-container
+    .sub-panel
+      padding: 54px 20px 46px
+
   @media (max-width: $screen-sm-max)
     .login-panel
       margin-top: 0px
@@ -98,6 +104,11 @@ body[data-controller="u2f_registrations"]
     .login-penal
       .site-login
         padding: 10px 0
+    .sub-panel
+      padding: 32px 20px 22px
+    .md-container
+      .sub-panel
+        padding: 42px 15px 32px
 
   @media (max-width: $screen-xxs-max)
     .process-panel
@@ -106,6 +117,9 @@ body[data-controller="u2f_registrations"]
       padding-bottom: 0
       h3
         margin-bottom: 18px
+    .md-container
+      .sub-panel
+        padding: 18px 10px 12px
 
   .signup-panel
     .col
@@ -255,6 +269,7 @@ body[data-controller="u2f_registrations"]
           .inner-circle
             fill: $progress-train-fill
 
+body[data-controller="publishers"]
   &[data-action="verify"]
     .info-panel
       padding-top: 100px

--- a/app/assets/stylesheets/application/two_factor_registrations.sass
+++ b/app/assets/stylesheets/application/two_factor_registrations.sass
@@ -16,3 +16,5 @@ body[data-controller="two_factor_registrations"]
     color: $braveRed
   span.green
     color: $braveGreen
+  .warning
+    color: $braveRed

--- a/app/assets/stylesheets/shared/modal.sass
+++ b/app/assets/stylesheets/shared/modal.sass
@@ -11,14 +11,15 @@
   z-index: 9001
   visibility: hidden
   backface-visibility: hidden
-  .md-content
-    position: relative
-    margin: 0 auto
-    transform: scale(0.7)
-    opacity: 0
-    transition: all 200ms
-    background: #fff
-    padding: 10px
+
+.md-content
+  position: relative
+  margin: 0 auto
+  transform: scale(0.7)
+  opacity: 0
+  transition: all 200ms
+  background: #fff
+  padding: 10px
 
 .md-overlay
   background: rgba(64, 64, 64, 0.7)
@@ -41,3 +42,15 @@
 .md-show ~ .md-overlay
   opacity: 1
   visibility: visible
+
+.md-close
+  position: absolute
+  right: 30px
+  top: 24px
+
+.pull-right.md-confirm-buttons a.btn
+  margin-left: 15px
+
+@media (max-width: $screen-xs-max)
+  .md-container
+    width: 100%

--- a/app/assets/stylesheets/shared/text.sass
+++ b/app/assets/stylesheets/shared/text.sass
@@ -18,3 +18,6 @@
 
 .space-around
   margin: 25px 0
+
+strong.error
+  color: $braveRed

--- a/app/assets/stylesheets/variables/colors.scss
+++ b/app/assets/stylesheets/variables/colors.scss
@@ -41,6 +41,7 @@ $loadTimeColor: $highlightBlue;
 $activeTabDefaultColor: $chromePrimary;
 $buttonColor: #5a5a5a;
 $braveOrange: rgb(255, 80, 0);
+$braveRed: #E2052A;
 $braveLightOrange: #FF7A1D;
 $braveMediumOrange: rgb(232, 72, 0);
 $braveDarkOrange: #D44600;

--- a/app/views/application/_icon_x.html
+++ b/app/views/application/_icon_x.html
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 15 15">
+  <polygon fill="#A7ACB2" fill-rule="evenodd" points="7.5 8.076 .577 15 0 14.422 6.924 7.5 0 .577 .577 0 7.5 6.922 14.423 0 15 .577 8.077 7.5 15 14.422 14.423 15"/>
+</svg>

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -37,3 +37,13 @@ html
       = content_for?(:content) ? yield(:content) : yield
 
       = render("footer")
+
+    / This block of HTML is used by modal_shared.js to trigger modal
+    / boxes. See that JavaScript file for more details.
+    .js-shared-modal
+      .md-container.container
+        .col.col-10.col-md-8.col-sm-10.col-xs-12.col-center.sub-panel
+          .md-content
+          = link_to "#", class: "md-close js-deny"
+            = render "application/icon_x"
+      .md-overlay

--- a/app/views/two_factor_registrations/index.html.slim
+++ b/app/views/two_factor_registrations/index.html.slim
@@ -27,14 +27,54 @@
                   em= t ".totp.disabled"
             .col.col-md-2.text-right
               - if totp_enabled?(current_publisher)
-                = link_to t(".totp.destroy"), totp_registration_path(current_publisher.totp_registration), method: :delete, class: "btn btn-block btn-secondary"
+                = link_to \
+                    t(".totp.destroy"),
+                    totp_registration_path(current_publisher.totp_registration),
+                    method: :delete,
+                    class: "btn btn-block btn-secondary",
+                    data: { "js-confirm-with-modal": "disable-totp-prompt" }
+                script#disable-totp-prompt type="text/html"
+                  .col.col-center.col-xs-12.col-sm-10.col-md-10.col-lg-10
+                    h4 Disable Authenticator App?
+                    p
+                      | Your remaining two-factor authentication method:
+                      - if current_publisher.u2f_registrations.any?
+                        - current_publisher.u2f_registrations.each do |u2f_registration|
+                          br
+                          strong
+                            | Security key
+                            = " \"#{u2f_registration.name.presence || t(".name_default")}\""
+                          = " (registered #{l(u2f_registration.created_at.to_date, format: :short)})"
+                      - else
+                        br
+                        strong.error None
+                    - if current_publisher.u2f_registrations.any?
+                      p
+                        | Authenticator app provides a good fallback method to log
+                        |  in to your account securely in the case that you lose the
+                        |  hardware security key.
+                    - else
+                      p
+                        | Disabling authenticator app will effectively turn off
+                        |  the two-factor authentication for your account.
+                    p
+                      | Are you sure you want to disable authenticator app?
+                    .row
+                      .col.md-confirm-buttons.pull-right
+                        = link_to "Do Not Disable", "#", class: "js-deny btn btn-secondary"
+                        = link_to "Disable it for now", "#", class: "js-confirm btn btn-secondary"
+
+
               - else
                 = link_to t(".totp.button"), new_totp_registration_path, class: "btn btn-block btn-primary"
 
           .row
             .col.col-md-8.col-md-offset-1
               h5= t ".u2f.heading"
-              p= t ".u2f.intro"
+              p
+                = t ".u2f.intro"
+                br
+                span.warning= t ".u2f.intro_warning"
               - if @u2f_registrations.any?
                 p= render @u2f_registrations
               - else

--- a/app/views/u2f_registrations/_u2f_registration.html.slim
+++ b/app/views/u2f_registrations/_u2f_registration.html.slim
@@ -2,4 +2,39 @@ div
   strong= "#{u2f_registration.name.presence || t(".name_default")}:"
   = " registered on #{l(u2f_registration.created_at.to_date, format: :long)}"
   = " | "
-  = link_to t(".delete_action"), u2f_registration_path(u2f_registration), method: :delete
+  = link_to \
+    t(".delete_action"),
+    u2f_registration_path(u2f_registration),
+    method: :delete,
+    data: { "js-confirm-with-modal": "disable-u2f-prompt-#{u2f_registration.id}" }
+  script id="disable-u2f-prompt-#{u2f_registration.id}" type="text/html"
+    .col.col-center.col-xs-12.col-sm-10.col-md-10.col-lg-10
+      h4 Remove Security Key?
+      p
+        | Your remaining two-factor authentication method:
+        - if current_publisher.totp_registration || current_publisher.u2f_registrations.length > 1
+          - if current_publisher.totp_registration
+            br
+            strong Authenticator app on your phone
+          - current_publisher.u2f_registrations.each do |remaining_u2f_registration|
+            - if u2f_registration != remaining_u2f_registration
+              br
+              strong
+                | Security key
+                = " \"#{remaining_u2f_registration.name.presence || t(".name_default")}\""
+              = " (registered #{l(remaining_u2f_registration.created_at.to_date, format: :short)})"
+        - else
+          br
+          strong.error None
+
+      - if !current_publisher.totp_registration && current_publisher.u2f_registrations.length == 1
+        p
+          | Removing this security key will effectively
+          strong = " turn off the two-factor authentication"
+          |  for your account.
+      p
+        | Are you sure you want to remove this security key?
+      .row
+        .col.md-confirm-buttons.pull-right
+          = link_to "Do Not Remove", "#", class: "js-deny btn btn-secondary"
+          = link_to "Remove Security Key", "#", class: "js-confirm btn btn-secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -389,7 +389,9 @@ en:
           Security key is a small device that connects to your computer via a
           USB port and works with FIDO Universal 2nd Factor (U2F).
           You will be asked to insert and press the key instead of typing in a
-          code (currently limited in browser support).
+          code.
+        intro_warning: |
+          Currently, security key is supported by Google Chrome and Opera.
         disabled: No keys have been added
         button: Add Key
   totp_registrations:

--- a/test/features/two_factor_registrations_test.rb
+++ b/test/features/two_factor_registrations_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class TwoFactorRegistrationsTest < Capybara::Rails::TestCase
+  include Devise::Test::IntegrationHelpers
+
+  test "Disabling TOTP prompts for confirmation" do
+    publisher = publishers(:verified)
+    sign_in publisher
+
+    visit two_factor_registrations_path
+    assert_content page, "Enabled"
+    refute_content page, "Set Up" # TOTP setup is not available
+
+    click_link('Disable') # Disable TOTP
+
+    assert_content page, "Disable Authenticator App?"
+
+    click_link("Do Not Disable")
+
+    refute_content page, "Disable Authenticator App?"
+
+    click_link('Disable') # Disable TOTP
+
+    assert_content page, "Disable Authenticator App?"
+
+    click_link("Disable it for now")
+
+    assert_content page, "Set Up" # TOTP setup is available
+  end
+
+  test "Disabling U2F prompts for confirmation" do
+    publisher = publishers(:verified)
+    sign_in publisher
+
+    visit two_factor_registrations_path
+    assert_content page, "Enabled"
+    assert_content page, "My U2F Key" # Key is present
+    refute_content page, "No keys have been added" # "No key" warning is not visible
+
+    click_link('Remove') # Disable TOTP
+
+    assert_content page, "Remove Security Key?"
+
+    click_link("Do Not Remove")
+
+    refute_content page, "Remove Security Key?"
+
+    click_link('Remove') # Disable TOTP
+
+    assert_content page, "Remove Security Key?"
+
+    click_link("Remove Security Key")
+
+    refute_content page, "My U2F Key" # Key is not present
+    assert_content page, "No keys have been added" # "No key" warning is visible
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,8 @@ end
 
 module ActionDispatch
   class IntegrationTest
+    self.use_transactional_tests = false
+
     setup do
       WebMock.disable_net_connect!
       DatabaseCleaner.start


### PR DESCRIPTION
Per mocks in https://github.com/brave-intl/publishers/issues/414 and https://github.com/brave-intl/publishers/issues/394 prompt the user to confirm their action when removing a 2FA registration. This flow is triggered by clicking "Disable" when a TOTP registration exists or "Remove" for any one U2F device. In each case the copy the users sees may vary, however they are always provided a list of what 2FA methods will exist after confirmation.

A technical summary:

* I've added an abstraction which allows developers to create contents for possible modals in tags `<script id="my-modal-content" type="text/html">`. To open these modals add the attribute`data-js-confirm-with-modal` on any link to specify what `id` to look for. For example to open the example script tag above: `<a data-js-confirm-with-modal="my-modal-content">`. Only when the user confirms the action will the `a` tag be permitted to perform other event handlers or its default action. Further documentation is in the source.
* Scope a large amount of publishers CSS which was being applied to the 2FA pages back to only the publishers controller.
* Add `.warning` and `strong.error` that sets `color` to a newly added `$braveRed`.
* There are feature test for the popup. I've changed the test runner to use truncation for fixtures instead of transaction during feature tests. This is requisite for DB mutations in feature tests not to leak out of the test.

Screenshots of the UI follow.

**/publishers/two_factor_registrations page with TOTP and a U2F key**

![screen shot 2017-12-21 at 1 47 29 pm](https://user-images.githubusercontent.com/8752/34276325-c3688ec0-e655-11e7-913a-dd78357fadb9.png)

**Confirmation to delete TOTP when a U2F key exists**

![screen shot 2017-12-21 at 1 47 33 pm](https://user-images.githubusercontent.com/8752/34276324-c350eaa4-e655-11e7-8ccb-ada4bb49a731.png)

**Confirmation to delete a U2F key when TOTP key exists**

![screen shot 2017-12-21 at 1 47 39 pm](https://user-images.githubusercontent.com/8752/34276323-c3399bb0-e655-11e7-8b7a-8e7049bd540b.png)

**Confirmation to delete TOTP when it is the last 2FA**

![screen shot 2017-12-21 at 1 47 46 pm](https://user-images.githubusercontent.com/8752/34276322-c323747a-e655-11e7-8455-ab09b273d0a7.png)

**Confirmation to delete a U2F key when it is the last 2FA**

![screen shot 2017-12-21 at 1 48 05 pm](https://user-images.githubusercontent.com/8752/34276321-c30c0466-e655-11e7-94c9-fbeaeedebcd6.png)

**A confirmation screen on iPhone X**

<img width="372" alt="screen shot 2017-12-21 at 1 48 47 pm" src="https://user-images.githubusercontent.com/8752/34276320-c2f3e0ca-e655-11e7-8bcd-eb800ff188fa.png">

TODO:

* [x] Brush up  some of the modal documentation in source
* [x] Add strings to the translations file
* [x] Update this PR with screenshots

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
