### PR TITLE
Add translation string for 2FA confirm

### DIFF
--- a/app/views/two_factor_registrations/index.html.slim
+++ b/app/views/two_factor_registrations/index.html.slim
@@ -35,9 +35,9 @@
                     data: { "js-confirm-with-modal": "disable-totp-prompt" }
                 script#disable-totp-prompt type="text/html"
                   .col.col-center.col-xs-12.col-sm-10.col-md-10.col-lg-10
-                    h4 Disable Authenticator App?
+                    h4 = t(".totp.confirm_disable.header")
                     p
-                      | Your remaining two-factor authentication method:
+                      = t(".totp.confirm_disable.intro")
                       - if current_publisher.u2f_registrations.any?
                         - current_publisher.u2f_registrations.each do |u2f_registration|
                           br
@@ -47,23 +47,16 @@
                           = " (registered #{l(u2f_registration.created_at.to_date, format: :short)})"
                       - else
                         br
-                        strong.error None
+                        strong.error = t(".totp.confirm_disable.none")
                     - if current_publisher.u2f_registrations.any?
-                      p
-                        | Authenticator app provides a good fallback method to log
-                        |  in to your account securely in the case that you lose the
-                        |  hardware security key.
+                      p = t(".totp.confirm_disable.no_totp_warning")
                     - else
-                      p
-                        | Disabling authenticator app will effectively turn off
-                        |  the two-factor authentication for your account.
-                    p
-                      | Are you sure you want to disable authenticator app?
+                      p == t(".totp.confirm_disable.no_2fa_warning_html")
+                    p = t(".totp.confirm_disable.final_confirmation")
                     .row
                       .col.md-confirm-buttons.pull-right
-                        = link_to "Do Not Disable", "#", class: "js-deny btn btn-secondary"
-                        = link_to "Disable it for now", "#", class: "js-confirm btn btn-secondary"
-
+                        = link_to t(".totp.confirm_disable.deny"), "#", class: "js-deny btn btn-secondary"
+                        = link_to t(".totp.confirm_disable.confirm"), "#", class: "js-confirm btn btn-secondary"
 
               - else
                 = link_to t(".totp.button"), new_totp_registration_path, class: "btn btn-block btn-primary"

--- a/app/views/u2f_registrations/_u2f_registration.html.slim
+++ b/app/views/u2f_registrations/_u2f_registration.html.slim
@@ -9,13 +9,13 @@ div
     data: { "js-confirm-with-modal": "disable-u2f-prompt-#{u2f_registration.id}" }
   script id="disable-u2f-prompt-#{u2f_registration.id}" type="text/html"
     .col.col-center.col-xs-12.col-sm-10.col-md-10.col-lg-10
-      h4 Remove Security Key?
+      h4 = t(".confirm_disable.header")
       p
-        | Your remaining two-factor authentication method:
+        = t(".confirm_disable.intro")
         - if current_publisher.totp_registration || current_publisher.u2f_registrations.length > 1
           - if current_publisher.totp_registration
             br
-            strong Authenticator app on your phone
+            strong = t(".confirm_disable.remaining_totp")
           - current_publisher.u2f_registrations.each do |remaining_u2f_registration|
             - if u2f_registration != remaining_u2f_registration
               br
@@ -25,16 +25,12 @@ div
               = " (registered #{l(remaining_u2f_registration.created_at.to_date, format: :short)})"
         - else
           br
-          strong.error None
+          strong.error = t(".confirm_disable.none")
 
       - if !current_publisher.totp_registration && current_publisher.u2f_registrations.length == 1
-        p
-          | Removing this security key will effectively
-          strong = " turn off the two-factor authentication"
-          |  for your account.
-      p
-        | Are you sure you want to remove this security key?
+        p == t(".confirm_disable.no_2fa_warning_html")
+      p = t(".confirm_disable.final_confirmation")
       .row
         .col.md-confirm-buttons.pull-right
-          = link_to "Do Not Remove", "#", class: "js-deny btn btn-secondary"
-          = link_to "Remove Security Key", "#", class: "js-confirm btn btn-secondary"
+          = link_to t(".confirm_disable.deny"), "#", class: "js-deny btn btn-secondary"
+          = link_to t(".confirm_disable.confirm"), "#", class: "js-confirm btn btn-secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,22 @@ en:
         reconfigure: Reconfigure
         button: Set Up
         destroy: Disable
+        confirm_disable:
+          header: Disable Authenticator App?
+          intro: "Your remaining two-factor authentication method:"
+          none: None
+          no_totp_warning: |
+            Authenticator app provides a good fallback method to log
+            in to your account securely in the case that you lose the
+            hardware security key.
+          no_2fa_warning_html: |
+            Disabling authenticator app will effectively
+            <strong>turn off the two-factor authentication</strong>
+            for your account.
+          final_confirmation: |
+            Are you sure you want to disable authenticator app?
+          deny: Do Not Disable
+          confirm: Disable it for now
       u2f:
         heading: Hardware security keys
         intro: |
@@ -439,7 +455,20 @@ en:
     u2f_registration:
       delete_action: Remove
       name_default: Anonymous Key
-  youtube:
+      confirm_disable:
+        header: Remove Security Key?
+        intro: "Your remaining two-factor authentication method:"
+        remaining_totp: Authenticator app on your phone
+        none: None
+        no_2fa_warning_html: |
+          Removing this security key will effectively
+          <strong>turn off the two-factor authentication</strong>
+          for your account.
+        final_confirmation: Are you sure you want to remove this security key?
+        deny: Do Not Remove
+        confirm: Remove Security Key
+          
+  youtubed:
     authenticate_with_youtube: "Authenticate with YouTube"
     account_not_found: "Couldn't find a matching publisher record"
     channel_not_found: "Channel not found"


### PR DESCRIPTION
This is a followup to https://github.com/brave-intl/publishers/pull/424. I mistakingly left out the translation strings work in that PR.