### PR TITLE
Add endpoint to notify unverified pubs they have money waiting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,9 +81,9 @@ gem "clipboard-rails"
 gem "rotp", "~> 3.3"
 
 # WHOIS lookup for unverified publishers
-gem "whois", "~> 4.0"
+gem "whois", "~> 4.0", require: false
 
-gem 'whois-parser', '~> 1.0'
+gem "whois-parser", "~> 1.0", require: false
 
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,11 @@ gem "clipboard-rails"
 # One-time passwords for 2fa
 gem "rotp", "~> 3.3"
 
+# WHOIS lookup for unverified publishers
+gem "whois", "~> 4.0"
+
+gem 'whois-parser', '~> 1.0'
+
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,10 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whois (4.0.5)
+    whois-parser (1.0.1)
+      activesupport (>= 4)
+      whois (>= 4.0.0)
     xpath (2.1.0)
       nokogiri (~> 1.3)
 
@@ -425,6 +429,8 @@ DEPENDENCIES
   vanilla-ujs (~> 1.3)
   web-console
   webmock (~> 3.0)
+  whois (~> 4.0)
+  whois-parser (~> 1.0)
 
 RUBY VERSION
    ruby 2.3.6p384

--- a/app/controllers/api/publishers_controller.rb
+++ b/app/controllers/api/publishers_controller.rb
@@ -18,12 +18,12 @@ class Api::PublishersController < Api::BaseController
 
   def notify_unverified
     PublisherNotifierUnverified.new(
-      notification_params: params[:params],
+      publisher_id: params[:publisher_id],
       publisher_type: params[:publisher_type],
     ).perform
     render(json: { message: "success" })
 
-    rescue PublisherNotifierUnverified::InvalidPublisherTypeError => error
+    rescue PublisherNotifierUnverified::InvalidPublisherTypeError, PublisherNotifierUnverified::BlankParamsError => error
       render(json: { message: error.message }, status: 400)
       
     rescue PublisherNotifierUnverified::NoEmailsFoundError => error

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -161,4 +161,26 @@ class PublisherMailer < ApplicationMailer
       template_name: "verified_no_wallet"
     )
   end
+
+  def unverified_domain_reached_threshold(domain, email)
+    @domain = domain
+    @email = email
+    @home_url = root_url
+    mail(
+      to: @email,
+      subject: default_i18n_subject(publication_title: @domain)
+    )
+  end
+
+  def unverified_domain_reached_threshold_internal(domain, email)
+    @domain = domain
+    @email = email
+    @home_url = root_url
+    mail(
+      to: INTERNAL_EMAIL,
+      reply_to: @email,
+      subject: "<Internal> #{I18n.t(:subject, publication_title: @domain, scope: %w(publisher_mailer unverified_domain_reached_threshold))}",
+      template_name: "unverified_domain_reached_threshold"
+    )
+  end
 end

--- a/app/services/get_whois_emails_for_domain.rb
+++ b/app/services/get_whois_emails_for_domain.rb
@@ -5,7 +5,8 @@ class GetWhoisEmailsForDomain < BaseService
   end
 
   def perform    
-    require 'whois-parser'
+    require "whois"
+    require "whois-parser"
     record = Whois.whois(@domain)
     record.parser.contacts
   end

--- a/app/services/get_whois_emails_for_domain.rb
+++ b/app/services/get_whois_emails_for_domain.rb
@@ -1,0 +1,12 @@
+# Get all contact emails from for a domain
+class GetWhoisEmailsForDomain < BaseService
+  def initialize(domain)
+    @domain = domain
+  end
+
+  def perform    
+    require 'whois-parser'
+    record = Whois.whois(@domain)
+    record.parser.contacts
+  end
+end

--- a/app/services/publisher_notifier_unverified.rb
+++ b/app/services/publisher_notifier_unverified.rb
@@ -1,9 +1,7 @@
 class PublisherNotifierUnverified < BaseService
-  attr_reader :notification_params, :notification_type
-
   PUBLISHER_TYPES = %w(domain) # TODO: youtube
 
-  def initialize(publisher_type:, publisher_id: )
+  def initialize(publisher_type:, publisher_id:)
     @publisher_id = publisher_id
     @publisher_type = publisher_type
 
@@ -15,16 +13,16 @@ class PublisherNotifierUnverified < BaseService
   end
 
   def perform
-    if @publisher_type == "domain"
-      return perform_domain
-    else
-      return perform_youtube
+    case @publisher_type
+    when "domain"
+      perform_domain
     end
+    # TO DO: youtube
   end
 
   def perform_domain
     domain = @publisher_id
-    contacts = GetWhoisEmailsForDomain.new(@domain).perform
+    contacts = GetWhoisEmailsForDomain.new(domain).perform
 
     if contacts.empty?
       raise NoEmailsFoundError.new("No contacts listed on whois info for '#{domain}'")
@@ -48,10 +46,6 @@ class PublisherNotifierUnverified < BaseService
       PublisherMailer.unverified_domain_reached_threshold(domain, email).deliver_later
       PublisherMailer.unverified_domain_reached_threshold_internal(domain, email).deliver_later
     end
-  end
-
-  def perform_youtube
-    # TO DO
   end
 
   class BlankParamsError < RuntimeError; end

--- a/app/services/publisher_notifier_unverified.rb
+++ b/app/services/publisher_notifier_unverified.rb
@@ -1,0 +1,67 @@
+class PublisherNotifierUnverified < BaseService
+  attr_reader :notification_params, :notification_type
+
+  PUBLISHER_TYPES = %w(youtube, domain)
+
+  def initialize(publisher_type:, notification_params: {})
+    @notification_params = (notification_params) || {}
+    @publisher_type = publisher_type
+
+    if !PUBLISHER_TYPES.include?(@publisher_type)
+      raise InvalidPublisherTypeError.new("#{@publisher_type} is an invalid publisher type")
+    end
+  end
+
+  def perform
+    if @publisher_type == "domain"
+      return perform_domain
+    else
+      return perform_youtube
+    end
+  end
+
+  def perform_domain
+    if !@notification_params.key?(:domain)
+      raise InvalidPublisherTypeError.new("No domain supplied")
+    end
+
+    domain = @notification_params[:domain]
+    contacts = GetWhoisEmailsForDomain.new(domain).perform
+
+    if contacts.empty?
+      raise NoEmailsFoundError.new("No contacts listed on whois info for '#{domain}'")
+    end
+
+    # store all distinct valid contact emails available
+    emails = Array.new
+    contacts.each do |contact|
+      email = contact.email
+      if emails.exclude?(email) && is_valid_email?(email)
+        emails.push(email)
+      end
+    end
+
+    if emails.empty?
+      raise NoEmailsFoundError.new("No valid emails found on whois info for '#{domain}'")
+    end
+
+    # send notification to valid emails
+    emails.each do |email|
+      PublisherMailer.unverified_domain_reached_threshold(domain, email).deliver_later
+      PublisherMailer.unverified_domain_reached_threshold_internal(domain, email).deliver_later
+    end
+  end
+
+  def perform_youtube
+    # TO DO
+  end
+
+  class InvalidPublisherTypeError < RuntimeError; end
+  class NoEmailsFoundError < RuntimeError; end
+
+  private
+
+  def is_valid_email?(email)
+    (email =~ Devise.email_regexp) != nil
+  end
+end

--- a/app/views/publisher_mailer/unverified_domain_reached_threshold.html.slim
+++ b/app/views/publisher_mailer/unverified_domain_reached_threshold.html.slim
@@ -1,0 +1,17 @@
+p.salutation= t("publisher_mailer.unverified_domain_reached_threshold.salutation")
+
+== t("publisher_mailer.unverified_domain_reached_threshold.body_html")
+
+div.center= link_to(t("publisher_mailer.unverified_domain_reached_threshold.button"), @home_url, class: "btn-primary btn-login")
+
+== t("publisher_mailer.shared.post_script")
+
+hr
+
+.hint
+  p
+    span= t("publisher_mailer.unverified_domain_reached_threshold.button_not_working")
+    span= link_to(@home_url, @home_url, class: "fallback-link", onMouseOver: "this.style.color='#48494b'", onMouseOut: "this.style.color='#818589'")
+
+  span= t("publisher_mailer.shared.erroneous_email_help")
+  span= mail_to(Rails.application.secrets[:support_email], nil)

--- a/app/views/publisher_mailer/verified_no_wallet.html.slim
+++ b/app/views/publisher_mailer/verified_no_wallet.html.slim
@@ -4,7 +4,7 @@ p.salutation= t("publisher_mailer.shared.salutation", name: @publisher.name)
 
 div.center= link_to(t("publisher_mailer.verified_no_wallet.button"), @publisher_dashboard_url, class: "btn-primary btn-login")
 
-== t("publisher_mailer.verified_no_wallet.body_html_2")
+== t("publisher_mailer.shared.post_script")
 
 p= t("publisher_mailer.shared.signature")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,9 @@ en:
       private_access_link_help: "Use this link to continue and manage publisher registration"
       salutation: "Hi %{name},"
       signature: "The Brave Payments Team"
+      post_script: |
+        <p>Got questions? Visit <a href="https://basicattentiontoken.org/">basicattentiontoken.org</a> to learn more about how the micropayments work.
+        <p>We look forward to having you join the thousands of domains already receiving funds from their audience.</p>
       button_not_working: "If the button above doesn't work, paste this link into your web browser: "
       erroneous_email_help: "If you did not make this request, you can ignore this email or contact us at "
       terms_of_service: "Terms of Service"
@@ -223,7 +226,16 @@ en:
       twitter: "Twitter"
       reddit: "Reddit"
       rocketchat: "Rocket.Chat"
-
+    
+    unverified_domain_reached_threshold:
+      subject: "Money is waiting for [%{publication_title}], verify your site with Brave to claim your funds!"
+      salutation: "Hi!"
+      title: "Money waiting for your unverified domain"
+      body_html: |
+        <p>Your site has accumulated quite a bit of fundage and we’d love to hand it over, but first we need you to verify ownership.</p>
+        <p>There are no fees, no gimmicks, we just want you to get paid and keep making awesome content.</p>
+      button: "Verify My Site"
+      button_not_working: "If the button above doesn't work, paste this link into your web browser: "
     uphold_account_changed:
       subject: "[%{publication_title}] Brave Publisher Uphold account changed"
       title: "Publisher Uphold account changed"
@@ -283,9 +295,6 @@ en:
         <p>It will only take a couple clicks and you’ll be receiving funds from us as soon as it is completed.</p>
         <p>Please visit <a href="%{url}">%{formatted_url}</a> to create your wallet.
       button: "Create My Wallet"
-      body_html_2: |
-        <p>Got questions? Visit <a href="https://basicattentiontoken.org/">basicattentiontoken.org</a> to learn more about how the micropayments work.
-        <p>We look forward to having you join the thousands of domains already receiving funds from their audience.</p>
   publisher_statement_periods:
     past_7_days: "Past 7 days"
     past_30_days: "Past 30 days"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,7 +228,7 @@ en:
       rocketchat: "Rocket.Chat"
     
     unverified_domain_reached_threshold:
-      subject: "Money is waiting for [%{publication_title}], verify your site with Brave to claim your funds!"
+      subject: "Money is waiting for %{publication_title}, verify your site with Brave to claim your funds!"
       salutation: "Hi!"
       title: "Money waiting for your unverified domain"
       body_html: |
@@ -237,20 +237,20 @@ en:
       button: "Verify My Site"
       button_not_working: "If the button above doesn't work, paste this link into your web browser: "
     uphold_account_changed:
-      subject: "[%{publication_title}] Brave Publisher Uphold account changed"
+      subject: "%{publication_title} Brave Publisher Uphold account changed"
       title: "Publisher Uphold account changed"
       body: "This message confirms that you've updated your Uphold account through the Brave Payments website."
     login_email:
       body_html: |
         Click the private access link below to log in to your account with <strong>Brave Payments</strong>. This link can only be used once.
-      subject: "[%{publication_title}] Brave Publisher login link"
+      subject: "%{publication_title} Brave Publisher login link"
       title: "Brave Publisher login link"
       button: "Log in to Brave Payments"
     welcome:
       erroneous_email_help: "If you believe you received this message in error, you may safely ignore it."
       intro: "We've received a request to register a website with Brave Payments:"
       private_email_notice: "NOTE: This email contains a private access link. Anyone with it can manage private publisher info, including payment information. Before forwarding this email, ensure you trust the recipient."
-      subject: "[%{publication_title}] Brave Publisher registration"
+      subject: "%{publication_title} Brave Publisher registration"
       title: "Publisher registration"
     verify_email:
       body_html: |
@@ -260,12 +260,12 @@ en:
       button: "Verify Email"
     verification_done:
       intro: "Congratulations! You are now a verified Brave publisher Brave users will see a verified symbol next to your website domain."
-      subject: "[%{publication_title}] Publisher website verified"
+      subject: "%{publication_title} Publisher website verified"
       title: "Verification complete"
       claim_funds_header: "Ready to claim your funds?"
       claim_funds_body: "To claim your funds please visit the Publishers website to submit your payment information using the link below."
     confirm_email_change:
-      subject: "[%{publication_title}] Confirm your Brave Publisher email change"
+      subject: "%{publication_title} Confirm your Brave Publisher email change"
       title: "Confirm email change"
       erroneous_email_help: "If you believe you received this message in error, you may safely ignore it."
       intro: "We've received a request to update your email address with Brave Payments:"
@@ -277,13 +277,13 @@ en:
       confirmation_link: "Confirm your email change"
       confirmation_link_help: "Use this link to confirm that you would like to proceed with this change"
     notify_email_change:
-      subject: "[%{publication_title}] Notification of Brave Publisher email change"
+      subject: "%{publication_title} Notification of Brave Publisher email change"
       title: "Notification of email change"
       intro: "We're notifying you of an update made to your email address with Brave Payments:"
       change_ok: "If you made this change, check your new email account for a link to confirm it."
       contact_support: "If you did not make this change yourself, please contact support ASAP"
     statement_ready:
-      subject: "[%{publication_title}] Brave Publisher statement is ready to view"
+      subject: "%{publication_title} Brave Publisher statement is ready to view"
       title: "Publisher statement is ready to view"
       body: "The following statement has recently been generated:"
       expiration_note: "This statement must be downloaded within the next 24 hours."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
         post "/", action: :create, as: :create
         get "/:brave_publisher_id", action: :index_by_brave_publisher_id, constraints: { brave_publisher_id: %r{[^\/]+} }
         post "/:brave_publisher_id/notifications", action: :notify, constraints: { brave_publisher_id: %r{[^\/]+} }
+        post "/notify_unverified", action: :notify_unverified
         delete "/:brave_publisher_id", action: :destroy, as: :destroy, constraints: { brave_publisher_id: %r{[^\/]+} }
       end
     end

--- a/test/controllers/api/publishers_controller_test.rb
+++ b/test/controllers/api/publishers_controller_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "shared/mailer_test_helper"
+require "whois-parser"
 
 class Api::PublishersControllerTest < ActionDispatch::IntegrationTest
   include ActionMailer::TestHelper

--- a/test/controllers/api/publishers_controller_test.rb
+++ b/test/controllers/api/publishers_controller_test.rb
@@ -23,9 +23,7 @@ class Api::PublishersControllerTest < ActionDispatch::IntegrationTest
 
   UNVERIFIED_DOMAIN_PUBLISHER_PARAMS = {
     publisher_type: "domain",
-    params: {
-      domain: "default.org"      
-    }
+    publisher_id: "default.org"
   }.freeze
 
   test "can create Publishers" do
@@ -214,7 +212,8 @@ class Api::PublishersControllerTest < ActionDispatch::IntegrationTest
   test "#notify_unverified returns 400 when invalid publisher type given" do
     # verify returns 400 if publisher_type is unknown
     invalid_publisher_params = {
-      publisher_type: "medium"
+      publisher_type: "medium",
+      publisher_id: "medium.com/alice"
     }
 
     assert_enqueued_emails 0 do
@@ -227,7 +226,7 @@ class Api::PublishersControllerTest < ActionDispatch::IntegrationTest
     # verify returns 400 if only publisher_type is supplied and not the domain
     invalid_publisher_params = {
       publisher_type: "domain",
-      params: {}
+      publisher_id: ""
     }
 
     assert_enqueued_emails 0 do

--- a/test/controllers/api/publishers_controller_test.rb
+++ b/test/controllers/api/publishers_controller_test.rb
@@ -20,6 +20,13 @@ class Api::PublishersControllerTest < ActionDispatch::IntegrationTest
     }
   ).freeze
 
+  UNVERIFIED_DOMAIN_PUBLISHER_PARAMS = {
+    publisher_type: "domain",
+    params: {
+      domain: "default.org"      
+    }
+  }.freeze
+
   test "can create Publishers" do
     assert_difference("Publisher.count", 1) do
       post(create_api_publishers_path, params: PUBLISHER_PARAMS)
@@ -150,5 +157,91 @@ class Api::PublishersControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_equal 200, response.status
+  end
+
+  test "#notify_unverified returns 500 when no whois contacts found for domain" do
+    contacts = []
+    # we can't test this because whois gem does not support
+    GetWhoisEmailsForDomain.any_instance.stubs(:perform).returns(contacts)
+
+    assert_enqueued_emails 0 do
+      post(notify_unverified_api_publishers_path, params: UNVERIFIED_DOMAIN_PUBLISHER_PARAMS)
+    end
+
+    assert_equal 500, response.status    
+    assert_match "No contacts listed on whois info for 'default.org'", response.body
+  end
+
+  test "#notify_unverified returns 500 when contact found but email blank" do
+    contacts = [Whois::Parser::Contact.new(email: "")]
+    GetWhoisEmailsForDomain.any_instance.stubs(:perform).returns(contacts)
+
+    assert_enqueued_emails 0 do
+      post(notify_unverified_api_publishers_path, params: UNVERIFIED_DOMAIN_PUBLISHER_PARAMS)
+    end
+
+    assert_equal 500, response.status
+    assert_match "No valid emails found on whois info for 'default.org'", response.body
+  end
+
+  test "#notify_unverified returns 500 when contact found but email malformed" do
+    contacts = [Whois::Parser::Contact.new(email: "default.org")]
+    GetWhoisEmailsForDomain.any_instance.stubs(:perform).returns(contacts)
+
+    assert_enqueued_emails 0 do
+      post(notify_unverified_api_publishers_path, params: UNVERIFIED_DOMAIN_PUBLISHER_PARAMS)
+    end
+
+    assert_equal 500, response.status
+    assert_match "No valid emails found on whois info", response.body
+  end
+
+  test "#notify_unverified returns 200 when valid whois contacts found, sends emails" do
+    admin_contact = Whois::Parser::Contact.new(email: "admin@default.org")
+    tech_contact = Whois::Parser::Contact.new(email: "tech@default.org")
+    contacts = [admin_contact, tech_contact]
+    GetWhoisEmailsForDomain.any_instance.stubs(:perform).returns(contacts)
+
+    # enqueue 2 emails for both valid addresses
+    assert_enqueued_emails 4 do
+      post(notify_unverified_api_publishers_path, params: UNVERIFIED_DOMAIN_PUBLISHER_PARAMS)
+    end
+
+    assert_equal 200, response.status
+  end
+
+  test "#notify_unverified returns 400 when invalid publisher type given" do
+    # verify returns 400 if publisher_type is unknown
+    invalid_publisher_params = {
+      publisher_type: "medium"
+    }
+
+    assert_enqueued_emails 0 do
+      post(notify_unverified_api_publishers_path, params: invalid_publisher_params)
+    end
+
+    assert_equal 400, response.status
+    assert_match "medium is an invalid publisher type", response.body
+
+    # verify returns 400 if only publisher_type is supplied and not the domain
+    invalid_publisher_params = {
+      publisher_type: "domain",
+      params: {}
+    }
+
+    assert_enqueued_emails 0 do
+      post(notify_unverified_api_publishers_path, params: invalid_publisher_params)
+    end
+    
+    assert_equal 400, response.status
+
+    # verify returns 400 if no params are supplied
+    invalid_publisher_params = {}
+
+    assert_enqueued_emails 0 do
+      post(notify_unverified_api_publishers_path, params: invalid_publisher_params)
+    end
+    
+    assert_equal 400, response.status
   end
 end

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -357,7 +357,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     # verify brave gets an internal email copy of confirmation email
     email = ActionMailer::Base.deliveries.find do |message|
       message.to == Rails.application.secrets[:internal_email]
-      message.subject == "<Internal> #{I18n.t('publisher_mailer.confirm_email_change.subject', publication_title: '')}"
+      message.subject == "<Internal>#{I18n.t('publisher_mailer.confirm_email_change.subject', publication_title: '')}"
     end
     assert_not_nil(email)
 

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -86,4 +86,39 @@ class PublisherMailerTest < ActionMailer::TestCase
       PublisherMailer.verify_email(publisher).deliver_now
     end
   end
+
+  test "unverified_domain_reached_threshold" do
+    domain = "default.org"
+    email_address = "alice@default.org"
+    email = PublisherMailer.unverified_domain_reached_threshold(domain, email_address)
+    
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ['brave-publishers@localhost.local'], email.from
+    assert_equal [email_address], email.to
+
+    # verify the domain is in the subject
+    assert_match "#{domain}", email.subject
+  end
+
+  test "unverified_domain_reached_threshold_internal" do
+    domain = "default.org"
+    email_address = "alice@default.org"
+    email = PublisherMailer.unverified_domain_reached_threshold_internal(domain, email_address)
+    
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ['brave-publishers@localhost.local'], email.from
+    assert_equal ['brave-publishers@localhost.local'], email.from
+
+    # verify the domain is in the subject
+    assert_match "#{domain}", email.subject
+
+    # verify email is marked as internal
+    assert_match "<Internal>", email.subject
+  end
 end


### PR DESCRIPTION
A `POST` to `/api/publishers/notify_unverified` with the params:
````
publisher_type: "domain",
params: {
    domain: "<domain>"
}
````
Will scrape the WHOIS information for `<domain>` and send a notification email to each distinct valid email address found.  Currently, `publisher_type` can only be `"domain"` until we determine a solution for #372.  I chose this format for the params above because it matches those in the existing `PublisherNotifier` service class for verified publisher notifications.

I chose not to use the existing `PublisherNotifier` service class for this endpoint because that endpoint required an existing publisher record.  We would have to create a publisher record for each valid email address found for the unverified publisher, or refactor the `PublisherNotifier` class to not take a publisher record at all.  The requirements of these two seem different enough that they require their own endpoint and service class.

If we can't scrape any valid emails, no notification emails are sent and we return a 500.  If the params in the POST are malformed or incomplete, no emails are sent and we return a 400.

This is the notification email:
![image](https://user-images.githubusercontent.com/12549658/34304783-2756a9fe-e709-11e7-9ab3-54e82537183b.png)

Resolves #375.
References #372

Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:
Because the 'whois' gem does not support mocking, I separated the whois lookup into a service, `GetWhoisEmailsForDomain`.  The tests in `Api::PublishersControllerTest` mock the response from this service and perform some validations to make sure we do not send duplicate emails, or attempt to send to malformed email addresses.

There are also test for both new emails, `unverified_reached_threshold` and `unverified_reached_threshold_internal`.

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
