### PR TITLE
Link user info in 2FA menu to dashboard

### DIFF
--- a/app/assets/stylesheets/partials/nav.sass
+++ b/app/assets/stylesheets/partials/nav.sass
@@ -73,8 +73,11 @@ $menuGray: #818589
       border-radius: 4px
       box-shadow: 2px 2px 0 0 rgba(47,48,50,0.15)
       .user-info
+        display: block
         position: relative
         padding: 30px 20px 30px 74px
+        color: $menuColor
+        text-decoration: none
         .user-avatar
           left: 20px
           top: 50%

--- a/app/views/application/_nav.html.slim
+++ b/app/views/application/_nav.html.slim
@@ -11,7 +11,7 @@ nav.navbar.navbar-default.navbar-static-top.top-nav-collapse
               .user-lock= render two_factor_enabled?(current_publisher) ? "locked_svg" : "unlocked_svg"
               .user-arrow= render "arrow_svg"
               .user-dropdown
-                .user-info
+                = link_to home_publishers_path, class: "user-info" do
                   .user-avatar= render "avatar_svg"
                   .user-name= current_publisher.name
                   .user-email= current_publisher.email


### PR DESCRIPTION
Resolves #433 by turning the user info (avatar, name, email) contained in the 2FA settings dropdown menu into a link to the home Dashboard page.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
