### PR TITLE
Add a new "incomplete implemenation" error for U2F

### DIFF
--- a/app/assets/javascripts/u2f_authentications.js
+++ b/app/assets/javascripts/u2f_authentications.js
@@ -34,6 +34,9 @@
         case 5: // TIMEOUT
           window.U2FShared.showError('u2f-error-timeout');
           break;
+        case 99900: // IMPLEMENTATION_INCOMPLETE
+          window.U2FShared.showError('u2f-error-implementation-incomplete');
+          break;
       }
 
       formElement.classList.remove('js-u2f-working');

--- a/app/assets/javascripts/u2f_registrations.js
+++ b/app/assets/javascripts/u2f_registrations.js
@@ -34,6 +34,9 @@
         case 5: // TIMEOUT
           window.U2FShared.showError('u2f-error-timeout');
           break;
+        case 99900: // IMPLEMENTATION_INCOMPLETE
+          window.U2FShared.showError('u2f-error-implementation-incomplete');
+          break;
       }
 
       // Reset the form after an error to permit a second attempt

--- a/app/views/two_factor_authentications/_u2f.html.slim
+++ b/app/views/two_factor_authentications/_u2f.html.slim
@@ -18,6 +18,7 @@ div.js-feature-u2f-available
         .alert.alert-warning.js-u2f-error-device-ineligible = t ".u2f-error.device-ineligible"
         .alert.alert-warning.js-u2f-error-other-error = t ".u2f-error.other-error"
         .alert.alert-warning.js-u2f-error-timeout = t ".u2f-error.timeout"
+        .alert.alert-warning.js-u2f-error-implementation-incomplete = t ".u2f-error.implementation-incomplete"
     .col.col-xs-10.col-sm-8.col-center.text-center
       .js-u2f-is-prompting.text-center
         .text-center

--- a/app/views/u2f_registrations/new.html.slim
+++ b/app/views/u2f_registrations/new.html.slim
@@ -15,6 +15,7 @@
                 .alert.alert-warning.js-u2f-error-device-ineligible = t ".u2f-error.device-ineligible"
                 .alert.alert-warning.js-u2f-error-other-error = t ".u2f-error.other-error"
                 .alert.alert-warning.js-u2f-error-timeout = t ".u2f-error.timeout"
+                .alert.alert-warning.js-u2f-error-implementation-incomplete = t ".u2f-error.implementation-incomplete"
 
               = form_for @u2f_registration, html: { class: "js-register-u2f js-feature-u2f-available" } do |f|
                 input type="hidden" name="u2f_app_id" value=(@app_id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -355,15 +355,20 @@ en:
         configuration-unsupported: |
           Client configuration is not supported. (CONFIGURATION_UNSUPPORTED)
         device-ineligible: |
-          The presented device is not eligible for authentication. This may mean
-          that you are using the incorrect device. (DEVICE_INELIGIBLE)
+          The presented security key is not eligible for authentication. This may mean
+          that you are using the incorrect security key. (DEVICE_INELIGIBLE)
         other-error: |
-          There was an unexpected error authenticating your device. Re-attempting
+          There was an unexpected error authenticating your security key. Re-attempting
           2FA may resolve this issue. (OTHER_ERROR)
         timeout: |
-          There was an unexpected timeout waiting your device to respond to
+          There was an unexpected timeout waiting for your security key to respond to
           the authentication request. Please re-attempt authentication and activate
-          the device when it is blinking. (TIMEOUT)
+          the security key when it is blinking. (TIMEOUT)
+        implementation-incomplete: |
+          Please insert your security key and re-attempt authentication. Some
+          browsers (like Brave) have an incomplete implementation of this
+          protocol. Please use a current release of Google Chrome or Opera.
+          (IMPLEMENTATION_INCOMPLETE)
   two_factor_registrations:
     index:
       heading: Two-factor Authentication
@@ -448,15 +453,20 @@ en:
         configuration-unsupported: |
           Client configuration is not supported. (CONFIGURATION_UNSUPPORTED)
         device-ineligible: |
-          The presented device is not eligible for registration. This may mean
+          The presented security key is not eligible for registration. This may mean
           that the token is already registered. (DEVICE_INELIGIBLE)
         other-error: |
-          There was an unexpected error registering your device. Re-attempting
+          There was an unexpected error registering your security key. Re-attempting
           registration may resolve this issue. (OTHER_ERROR)
         timeout: |
-          There was an unexpected timeout waiting your device to respond to
+          There was an unexpected timeout waiting for your security key to respond to
           the registration request. Please re-attempt registration and activate
-          the device when it is blinking. (TIMEOUT)
+          the security key when it is blinking. (TIMEOUT)
+        implementation-incomplete: |
+          Please insert your security key and re-attempt registration. Some
+          browsers (like Brave) have an incomplete implementation of this
+          protocol. Please use a current release of Google Chrome or Opera.
+          (IMPLEMENTATION_INCOMPLETE)
     u2f_registration:
       delete_action: Remove
       name_default: Anonymous Key


### PR DESCRIPTION
This error will throw for Brave, it shouldn't appear for any other known browser. Currently the timeout is three seconds, which seems generous enough for a browser like Chrome or Opera to open the iframe to the U2F extension.

Fixes #389

Examples of the error:

**Failing to register a U2F device in Brave**

<img width="1215" alt="screen shot 2018-01-03 at 2 44 08 pm" src="https://user-images.githubusercontent.com/8752/34543313-1d4215ee-f095-11e7-8ece-f6c8bedd9fc0.png">

**Failing to authenticate with a U2F device in Brave**

<img width="1216" alt="screen shot 2018-01-03 at 2 42 24 pm" src="https://user-images.githubusercontent.com/8752/34543311-183cf500-f095-11e7-8e2b-99a0c98aa179.png">

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
