### PR TITLE
Turn on 2FA and hide U2F

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -297,7 +297,6 @@ module PublishersHelper
   end
 
   def show_nav_menu?(publisher)
-    # TODO: [2FA] remove the two_factor_enabled? check below to publicly enable 2FA menu
-    publisher.verified? && two_factor_enabled?(publisher)
+    publisher.verified?
   end
 end

--- a/app/views/two_factor_registrations/index.html.slim
+++ b/app/views/two_factor_registrations/index.html.slim
@@ -69,32 +69,35 @@
                 p= link_to t(".totp.button"), new_totp_registration_path, class: "btn btn-block btn-primary"
               p.text-center= render "smartphone_with_code"
 
-          .row
-            .col.col-md-8.col-md-offset-1
-              h5= t ".u2f.heading"
-              p
-                = t ".u2f.intro"
-                br
-                span.warning= t ".u2f.intro_warning"
-                '
-                span.tf-tooltip
-                  = render "help_svg"
-                  span.tf-tooltip-content
-                    span.tf-tooltip-content-heading= t ".u2f.browser.heading"
-                    span.tf-tooltip-content-content== t ".u2f.browser.content_html"
-                br
-                | *
-                span.tf-tooltip.link-color
-                  = t ".u2f.device.tooltip"
-                  span.tf-tooltip-content
-                    span.tf-tooltip-content-heading= t ".u2f.device.heading"
-                    span.tf-tooltip-content-content== t ".u2f.device.content_html"
-              - if @u2f_registrations.any?
-                p= render @u2f_registrations
-              - else
-                p.disabled
-                  == "&bull; "
-                  = t ".u2f.disabled"
-            .col.col-md-2.text-right
-              p= link_to t(".u2f.button"), new_u2f_registration_path, class: "btn btn-block btn-primary"
-              p.text-center= render "usb"
+          / FIXME: U2F is dark launched, and you need to specify params[:u2f]
+          / We will enable it when Brave is ready. See issue #442
+          - if @u2f_registrations.any? || params[:u2f].present?
+            .row
+              .col.col-md-8.col-md-offset-1
+                h5= t ".u2f.heading"
+                p
+                  = t ".u2f.intro"
+                  br
+                  span.warning= t ".u2f.intro_warning"
+                  '
+                  span.tf-tooltip
+                    = render "help_svg"
+                    span.tf-tooltip-content
+                      span.tf-tooltip-content-heading= t ".u2f.browser.heading"
+                      span.tf-tooltip-content-content== t ".u2f.browser.content_html"
+                  br
+                  | *
+                  span.tf-tooltip.link-color
+                    = t ".u2f.device.tooltip"
+                    span.tf-tooltip-content
+                      span.tf-tooltip-content-heading= t ".u2f.device.heading"
+                      span.tf-tooltip-content-content== t ".u2f.device.content_html"
+                - if @u2f_registrations.any?
+                  p= render @u2f_registrations
+                - else
+                  p.disabled
+                    == "&bull; "
+                    = t ".u2f.disabled"
+              .col.col-md-2.text-right
+                p= link_to t(".u2f.button"), new_u2f_registration_path, class: "btn btn-block btn-primary"
+                p.text-center= render "usb"

--- a/test/features/two_factor_registrations_test.rb
+++ b/test/features/two_factor_registrations_test.rb
@@ -52,7 +52,10 @@ class TwoFactorRegistrationsTest < Capybara::Rails::TestCase
     click_link("Remove Security Key")
 
     refute_content page, "My U2F Key" # Key is not present
-    assert_content page, "No keys have been added" # "No key" warning is visible
+
+    # FIXME: U2F is dark launched, and only appears when you have it enabled
+    # or provide params[:u2f]. See issue #442
+    # assert_content page, "No keys have been added" # "No key" warning is visible
   end
 
 end


### PR DESCRIPTION
Fix #442

This enables 2FA, and enables TOTP but hides U2F. U2F is accessible if the user visits `/publishers/two_factor_registrations?u2f=1` or has any U2F devices setup.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
