### PR TITLE
Allow users to connect with uphold when the state has stalled

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -78,7 +78,7 @@ module PublishersHelper
   end
 
   def uphold_authorization_description(publisher)
-    if publisher_status(publisher) == :uphold_reauthorize
+    if publisher_status(publisher) == :uphold_reauthorize || publisher_status(publisher) == :uphold_processing
       t("publishers.reconnect_to_uphold")
     else
       t("publishers.create_uphold_wallet")

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -21,7 +21,7 @@ module PublishersHelper
   end
 
   def show_uphold_connect?(publisher)
-    publisher.uphold_status == :unconnected || publisher.uphold_status == :code_acquired
+    publisher.uphold_status == :unconnected || publisher.uphold_status == :code_acquired || publisher.uphold_status == :access_parameters_acquired
   end
 
   def show_uphold_dashboard?(publisher)

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -223,6 +223,7 @@ javascript:
               var publisherStatus = document.getElementById('publisher_status');
               publisherStatus.innerText = body.status_description;
               publisherStatus.className = body.status;
+              document.getElementById('uphold_connect').style.display = 'none';
               var upholdDashboard = document.getElementById('uphold_dashboard');
               upholdDashboard.style.display = '';
               dynamicEllipsis.stop('publisher_status');
@@ -292,7 +293,7 @@ noscript
           div#uphold_connect
             .panel-section= link_to(uphold_authorization_description(current_publisher),
                     uphold_authorization_endpoint(current_publisher), class: "btn btn-primary")
-        - else
+        - if current_publisher.uphold_status == :access_parameters_acquired || current_publisher.uphold_status == :verified
           .panel-section#uphold_dashboard style=(show_uphold_dashboard?(current_publisher) ? '' : 'display: none')
             .panel-section
               = form_for(current_publisher, url: publishers_path, html: { id: "update_default_currency_form" }) do |f|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
       Phone Number <span class="optional">(optional)</span>
     phone_number_validation: "Phone numbers should only include numbers, dashes, periods, plus (+), and/or parentheses."
     status_uphold_processing: "Your Uphold wallet is being connected to your account.  If this takes more than a few minutes, please reconnect with Uphold."
-    status_uphold_processing_timeout: "We are having trouble connecting to your Uphold wallet. Please check back later."
+    status_uphold_processing_timeout: "We are having trouble connecting to your Uphold wallet. Please reconnect to Uphold."
     status_unverified: "Your account has not been verified"
     uphold_status_verified: "Your Uphold wallet is ready to receive Brave Payments."
     uphold_status_access_parameters_acquired: "Connecting your Uphold account."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,7 +106,7 @@ en:
     verified_phone_html: |
       Phone Number <span class="optional">(optional)</span>
     phone_number_validation: "Phone numbers should only include numbers, dashes, periods, plus (+), and/or parentheses."
-    status_uphold_processing: "Your Uphold wallet is being connected to your account"
+    status_uphold_processing: "Your Uphold wallet is being connected to your account.  If this takes more than a few minutes, please reconnect with Uphold."
     status_uphold_processing_timeout: "We are having trouble connecting to your Uphold wallet. Please check back later."
     status_unverified: "Your account has not been verified"
     uphold_status_verified: "Your Uphold wallet is ready to receive Brave Payments."


### PR DESCRIPTION
As outlined in #224, there are two cases we have to deal with:
> 1. If the Uphold code has not been exchanged for access parameters within the 5 minute window
> 2. If the access parameters have been acquired but not successfully sent to eyeshade

This PR proposes changes in the UI so it is more obvious to the user how/when to reset the connection for (1) and (2)

Last week we encountered an instance of (1).

(1) can be reproduced by commenting out `ExchangeUpholdCodeForAccessTokenJob#perform`, signing up a new publisher, and clicking "Create Uphold Wallet".  When returned to the publisher dashboard, the user was stuck on this (old) screen:

![image](https://user-images.githubusercontent.com/12549658/34687088-b8d8c55e-f47b-11e7-96d3-cd9da98be493.png)

However, they still had the option to "Create Uphold Wallet".  If they were to click this button, it would reset the Uphold connection without problems - we do not need to do any more to clear the uphold codes.

In this PR we simply change the "Create Uphold Wallet" button to "Reconnect to Uphold", and also change the message.  The (new) screen:
![image](https://user-images.githubusercontent.com/12549658/34686878-02485386-f47b-11e7-89e8-04c80aa109fc.png)

(2) can be reproduced by commenting out the call to [UploadUpholdAccessParametersJob](https://github.com/brave-intl/publishers/blob/9aae7b40f8a4637c015d71d1b9412ea7739067d3/app/jobs/exchange_uphold_code_for_access_token_job.rb#L17) in `ExchangeUpholdCodeForAccessTokenJob#perform`.  When returned to the dashboard from uphold, the JavaScript will continuously check if the uphold connection is complete for ~30 seconds.  After failure it will display (old):
![image](https://user-images.githubusercontent.com/12549658/34687030-7ff173a8-f47b-11e7-97fc-0aa2b5fd5fe6.png)

The proposed change would include a "Reconnect to Uphold" in this (new) view:
![image](https://user-images.githubusercontent.com/12549658/34691662-54e8d844-f48b-11e7-80dc-ba093e7942c4.png)

Resolves #439 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
