### PR TITLE
Use data-test instead of obscure css selector

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -292,7 +292,7 @@ noscript
         - if show_uphold_connect?(current_publisher)
           div#uphold_connect
             .panel-section= link_to(uphold_authorization_description(current_publisher),
-                    uphold_authorization_endpoint(current_publisher), class: "btn btn-primary")
+                    uphold_authorization_endpoint(current_publisher), class: "btn btn-primary", :"data-test" => "reconnect-button")
         - if current_publisher.uphold_status == :access_parameters_acquired || current_publisher.uphold_status == :verified
           .panel-section#uphold_dashboard style=(show_uphold_dashboard?(current_publisher) ? '' : 'display: none')
             .panel-section

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -648,7 +648,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     end
 
     # verify button says 'reconnect to uphold' not 'create uphold wallet'
-    assert_select("div#uphold_connect div.panel-section a.btn.btn-primary") do |element|
+    assert_select("[data-test=reconnect-button]") do |element|
       assert_equal element.text, I18n.t("publishers.reconnect_to_uphold")
     end
   end


### PR DESCRIPTION
Resolves #449 
Refs #439, #448 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
