### PR TITLE
Regress minitest to 5.10.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,9 @@ group :test do
   # Clean state in-between tests which modify the DB
   gem "database_cleaner"
 
+  # Locking to 5.10.3 to workaround issue in 5.11.1 (https://github.com/seattlerb/minitest/issues/730)
+  gem 'minitest', '5.10.3'
+
   gem "webmock", "~> 3.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     method_source (0.9.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    minitest (5.11.1)
+    minitest (5.10.3)
     minitest-capybara (0.8.2)
       capybara (~> 2.2)
       minitest (~> 5.0)
@@ -398,6 +398,7 @@ DEPENDENCIES
   i18n-tasks (~> 0.9.12)
   listen (~> 3.0.5)
   lograge (~> 0.4)
+  minitest (= 5.10.3)
   minitest-rails-capybara
   mocha
   newrelic_rpm (~> 3.16)


### PR DESCRIPTION
Works around issue https://github.com/seattlerb/minitest/issues/730 by setting minitest to 5.10.3 in the Gemfile.lock. I don't like to edit Gemfile.lock, but this seems to be running correctly (and it's only for testing).

closes #455

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))