### PR TITLE
Correctly display 'Send me new login link' page

### DIFF
--- a/app/views/publishers/expired_auth_token.html.slim
+++ b/app/views/publishers/expired_auth_token.html.slim
@@ -13,7 +13,6 @@
       .col.col-md-8.col-md-offset-2.text-center.col-center
         p= t("publishers.login_link_expired_message")
         = form_for @publisher, {method: :post, url: create_auth_token_publishers_path} do |f|
-          = f.hidden_field(:brave_publisher_id, :value => @publisher.brave_publisher_id)
           = f.hidden_field(:email, :value => @publisher.email)
           .panel-controls.col-center
             = f.submit(t("publishers.login_link_expired_button"), class: "btn btn-block btn-primary")


### PR DESCRIPTION
* Remove hidden field that looks up the brave_publisher_id, which is no longer required to send login links

Resolves #471

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:
This fix displays the page, and the link triggers a new login link email, which also works.

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
