### PR TITLE
travis: add sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 bundler_args: --jobs=3 --retry=3 --without production --without staging
 dist: trusty
+sudo: required
 addons:
   postgresql: "9.6"
   chrome: "stable"


### PR DESCRIPTION
try to fix tests chromedriver crashes

the release to master #470 isn't stoked on travis https://travis-ci.org/brave-intl/publishers/jobs/327791908

this is me attempting to fix it (see https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356004275)

auditors: @lgebhardt @nvonpentz 