### PR TITLE
Introduce new styles for errors in the header of U2F

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -72,12 +72,8 @@ body[data-controller="u2f_registrations"]
     .content-panel
       padding: 0 30px
 
-  .login-panel
-    margin-top: 46px
-    .row
-      padding: 0 40px
-    .site-login, .youtube-login
-      padding: 30px 0
+  .site-login, .youtube-login
+    padding: 30px 20px
 
   .expired-token-panel
     max-width: 710px
@@ -98,18 +94,12 @@ body[data-controller="u2f_registrations"]
           width: 448px
 
   @media (max-width: $screen-sm-max)
-    .login-panel
-      margin-top: 0px
-      max-width: 500px
     .process-panel
-      padding-bottom: 15px
+      padding-bottom: 57px
       .panel-controls
         margin-top: 15px
       h3
         margin-bottom: 23px
-    .login-penal
-      .site-login
-        padding: 10px 0
     .expired-token-panel
       .sub-panel
         width: 448px
@@ -120,12 +110,13 @@ body[data-controller="u2f_registrations"]
               width: 250px
         p
           padding: 0px
-
-  @media (max-width: $screen-xxs-max)
-    .process-panel
+    .site-login, .youtube-login
       padding-left: 0
       padding-right: 0
       padding-bottom: 0
+
+  @media (max-width: $screen-xxs-max)
+    .process-panel
       h3
         margin-bottom: 18px
 

--- a/app/assets/stylesheets/shared/error-group.sass
+++ b/app/assets/stylesheets/shared/error-group.sass
@@ -1,5 +1,19 @@
-.error-group > div
+/*
+ * .error-group--wrapper is manipulated by JavaScript in the ErrorManager
+ * class. A child element can be promoted to visible by adding .show. If
+ * a child element has .error-group--no-error it will be visible regardless,
+ * but will not be displayed when the modifier .error-group--wrapper--has-error
+ * is present on the .error-group--wrapper.
+ */
+
+.error-group--wrapper > div
   display: none
 
-.error-group > div.show
+.error-group--wrapper > div.show
   display: block
+
+.error-group--wrapper .error-group--no-error
+  display: block
+
+.error-group--wrapper.error-group--wrapper--has-error .error-group--no-error
+  display: none

--- a/app/assets/stylesheets/shared/sub-panel.sass
+++ b/app/assets/stylesheets/shared/sub-panel.sass
@@ -2,7 +2,10 @@
  * .sub-panel is a box with rounded corners.
  */
 
-/* This is the panel itself */
+/*
+ * This is the panel itself. This class diverged from BEM naming to match
+ * legacy usage.
+ */
 .sub-panel
   background-color: white
   border: none
@@ -12,45 +15,109 @@
   .md-content
     background: transparent
 
+/*
+ * In a BEM style, the following are variants of the .sub-panel class. All are
+ * on the .sub-panel--panel element.
+ */
+
+/*
+ * Modifier for modals, when .sub-panel is used in a pop-over.
+ */
 .sub-panel--panel--modal
   padding: 54px 20px 46px
 
-.sub-panel--panel--top
+/*
+ * These modifiers are for a blue-background top (info) and red background
+ * top (error). If you use these modifiers you likely want to the following
+ * .sub-panel to have .sub-panel--panel--bottom so the rounded corners line
+ * up.
+ */
+.sub-panel--panel--info-top, .sub-panel--panel--error-top
   padding-top: 28px
   padding-bottom: 25px
+  padding-left: 37px
+  padding-right: 37px
   border-bottom-left-radius: 0
   border-bottom-right-radius: 0
+
+.sub-panel--panel--info-top
   background: #eefbfd
   color: #00BCD6
   border-bottom: 1px solid #e7ebee
 
+.sub-panel--panel--error-top
+  background: #feedf0
+  color: #dd0529
+  border-bottom: 0
+  padding-left: 44px
+  padding-right: 44px
+
+/*
+ * This filler top complements .sub-panel--panel--bottom to complete its
+ * rounded corners. Can be useful if the info or error modifiers are swapped
+ * out by JavaScript.
+ */
+.sub-panel--panel--filler-top
+  height: 39px
+  padding: 0
+  border-bottom-left-radius: 0
+  border-bottom-right-radius: 0
+  border-bottom: 0
+
+/*
+ * The bottom of a two-part sub panel.
+ */
 .sub-panel--panel--bottom
   padding-top: 30px
   border-top-left-radius: 0
   border-top-right-radius: 0
 
+/*
+ * In info or error panes it is common to have an icon on the left and a body
+ * of text on the right. This wrapper goes around .sub-panel--top-icon and
+ * .sub-panel--top-body to create a responsive UI for that layout.
+ */
+.sub-panel--top-wrapper
+  display: flex
+  justify-content: flex-start
+  flex-direction: row
+  flex-wrap: nowrap
+
 .sub-panel--top-icon
-  float: left
+  flex: 0 0 58px
+  align-self: center
 
 .sub-panel--top-body
-  margin-left: 63px
+  flex: 1 1 100%
 
 .sub-panel--list
   padding-left: 0
   list-style-position: inside
 
+/*
+ * Modifications for small screens (tablet-ish)
+ */
 @media (max-width: $screen-sm-max)
   .sub-panel
     padding-top: 32px
     padding-bottom: 22px
   .sub-panel--panel--modal
     padding: 42px 15px 32px
-  .sub-panel--panel--top
+  .sub-panel--panel--info-top, .sub-panel--panel--error-top, .sub-panel--panel--filler-top
     padding-top: 18px
     padding-bottom: 15px
   .sub-panel--panel--bottom
     padding-top: 20px
 
+/*
+ * Modifications for very small screens (mobile-ish)
+ */
 @media (max-width: $screen-xxs-max)
   .sub-panel--panel--modal
     padding: 18px 10px 12px
+
+  .sub-panel--top-icon
+    display: none
+
+  .sub-panel--top-body
+    margin-left: 0

--- a/app/javascript/u2f/authenticationPage.js
+++ b/app/javascript/u2f/authenticationPage.js
@@ -1,13 +1,10 @@
 import './u2f-api';
-import {
-  clearErrors,
-  showError
-} from './shared';
+import { ErrorManager } from './shared';
 
 /*
  * Register a u2f device
  */
-function authenticate(formElement, responseInput) {
+function authenticate(formElement, responseInput, errorManager) {
   formElement.classList.add('js-u2f-working');
 
   let appId = formElement.querySelector('[name=u2f_app_id]').value;
@@ -23,28 +20,28 @@ function authenticate(formElement, responseInput) {
         return;
 
       case 1: // OTHER_ERROR:
-        showError('u2f-error-other-error');
+        errorManager.show('u2f-error-other-error');
         break;
       case 2: // BAD_REQUEST:
-        showError('u2f-error-bad-request');
+        errorManager.show('u2f-error-bad-request');
         break;
       case 3: // CONFIGURATION_UNSUPPORTED:
-        showError('u2f-error-configuration-unsupported');
+        errorManager.show('u2f-error-configuration-unsupported');
         break;
       case 4: // DEVICE_INELIGIBLE:
-        showError('u2f-error-device-ineligible');
+        errorManager.show('u2f-error-device-ineligible');
         break;
       case 5: // TIMEOUT
-        showError('u2f-error-timeout');
+        errorManager.show('u2f-error-timeout');
         break;
       case 99900: // IMPLEMENTATION_INCOMPLETE
-        showError('u2f-error-implementation-incomplete');
+        errorManager.show('u2f-error-implementation-incomplete');
         break;
     }
 
     formElement.classList.remove('js-u2f-working');
     // Reset the form after an error to permit a second attempt
-    let submit = formElement.querySelector('input[type=submit][disabled=disabled]');
+    let submit = formElement.querySelector('input[type=submit][disabled]');
     if (submit) {
       submit.removeAttribute('disabled');
       submit.blur();
@@ -61,13 +58,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
   if (formElement && window.u2f) {
     let responseInput = formElement.querySelector('[name=u2f_response]');
+    let errorManager = new ErrorManager('authenticate-u2f-error');
     formElement.addEventListener('submit', function(event) {
-      clearErrors('register-u2f-error');
+      errorManager.clear();
       if (!responseInput.value) {
         event.preventDefault();
-        authenticate(formElement, responseInput);
+        authenticate(formElement, responseInput, errorManager);
       }
     });
-    authenticate(formElement, responseInput);
+    authenticate(formElement, responseInput, errorManager);
   }
 });

--- a/app/javascript/u2f/registrationPage.js
+++ b/app/javascript/u2f/registrationPage.js
@@ -1,19 +1,16 @@
 import './u2f-api';
-import {
-  clearErrors,
-  showError
-} from './shared';
+import { ErrorManager } from './shared';
 
 /*
  * Register a u2f device
  */
-function registerU2fDevice(formElement, responseInput) {
+function registerU2fDevice(formElement, responseInput, errorManager) {
+  formElement.classList.add('js-u2f-working');
+
   let appId = formElement.querySelector('[name=u2f_app_id]').value;
   let registrationRequests = JSON.parse(formElement.querySelector('[name=u2f_registration_requests]').value);
   let registeredKeys = JSON.parse(formElement.querySelector('[name=u2f_sign_requests]').value);
   window.u2f.register(appId, registrationRequests, registeredKeys, function(registerResponse) {
-    clearErrors('register-u2f-waiting');
-
     switch(registerResponse.errorCode) {
 
       case undefined: // OK
@@ -23,27 +20,28 @@ function registerU2fDevice(formElement, responseInput) {
         return;
 
       case 1: // OTHER_ERROR:
-        showError('u2f-error-other-error');
+        errorManager.show('u2f-error-other-error');
         break;
       case 2: // BAD_REQUEST:
-        showError('u2f-error-bad-request');
+        errorManager.show('u2f-error-bad-request');
         break;
       case 3: // CONFIGURATION_UNSUPPORTED:
-        showError('u2f-error-configuration-unsupported');
+        errorManager.show('u2f-error-configuration-unsupported');
         break;
       case 4: // DEVICE_INELIGIBLE:
-        showError('u2f-error-device-ineligible');
+        errorManager.show('u2f-error-device-ineligible');
         break;
       case 5: // TIMEOUT
-        showError('u2f-error-timeout');
+        errorManager.show('u2f-error-timeout');
         break;
       case 99900: // IMPLEMENTATION_INCOMPLETE
-        showError('u2f-error-implementation-incomplete');
+        errorManager.show('u2f-error-implementation-incomplete');
         break;
     }
 
+    formElement.classList.remove('js-u2f-working');
     // Reset the form after an error to permit a second attempt
-    let submit = formElement.querySelector('input[type=submit][disabled=disabled]');
+    let submit = formElement.querySelector('input[type=submit][disabled]');
     if (submit) {
       submit.removeAttribute('disabled');
       submit.blur();
@@ -58,13 +56,13 @@ function registerU2fDevice(formElement, responseInput) {
 document.addEventListener('DOMContentLoaded', function() {
   let formElement = document.querySelector('.js-register-u2f');
   if (formElement) {
+    let errorManager = new ErrorManager('register-u2f-error');
     formElement.addEventListener('submit', function(event) {
-      clearErrors('register-u2f-error');
+      errorManager.clear();
       let responseInput = formElement.querySelector('[name=u2f_response]');
       if (!responseInput.value) {
         event.preventDefault();
-        showError('u2f-waiting');
-        registerU2fDevice(formElement, responseInput);
+        registerU2fDevice(formElement, responseInput, errorManager);
       }
     });
   }

--- a/app/javascript/u2f/shared.js
+++ b/app/javascript/u2f/shared.js
@@ -1,11 +1,38 @@
-export function clearErrors(errorGroupClassName) {
-  var errorElements = document.querySelectorAll('.js-'+errorGroupClassName+' > div');
-  var i;
-  for (i=0;i<errorElements.length;i++) {
-    errorElements[i].classList.remove('show');
+export class ErrorManager {
+  constructor(errorGroupName) {
+    this._errorGroupName = errorGroupName;
   }
-}
 
-export function showError(errorClassName) {
-  document.querySelector('.js-'+errorClassName).classList.add('show');
+  get _errorGroupClassName() {
+    return `js-${this._errorGroupName}`;
+  }
+
+  show(errorClassName) {
+    /*
+     * Set class of `show` on all error objects.
+     */
+    let selector = `.${this._errorGroupClassName} > .js-${errorClassName}`;
+    document.querySelector(selector).classList.add('show');
+
+    /*
+     * Set class of `has-error` on the group element.
+     */
+    document.querySelector(`.${this._errorGroupClassName}`).classList.add('error-group--wrapper--has-error');
+  }
+
+  clear() {
+    /*
+     * Clear the class of `show` from all error objects.
+     */
+    let selector = `.${this._errorGroupClassName} > div`;
+    let errorElements = document.querySelectorAll(selector);
+    for (let i=0;i<errorElements.length;i++) {
+      errorElements[i].classList.remove('show');
+    }
+
+    /*
+     * Clear the class of `has-error` from the group element.
+     */
+    document.querySelector(`.${this._errorGroupClassName}`).classList.remove('error-group--wrapper--has-error');
+  }
 }

--- a/app/views/application/_icon_circled_x.html
+++ b/app/views/application/_icon_circled_x.html
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 42 42">
+  <g fill="none" fill-rule="evenodd" transform="translate(1 1)">
+    <circle cx="20" cy="20" r="20" stroke="#E2052A"/>
+    <g fill="#E2052A" transform="rotate(45 -.485 28.485)">
+      <rect width="2.087" height="16" x="6.957"/>
+      <rect width="2.087" height="16" x="6.957" transform="rotate(90 8 8)"/>
+    </g>
+  </g>
+</svg>

--- a/app/views/publishers/create_auth_token.html.slim
+++ b/app/views/publishers/create_auth_token.html.slim
@@ -1,10 +1,9 @@
 - content_for(:navbar_content) do
 
-.publisher-panel.login-panel.col-center
-  .sub-panel
-    .row
-      .col
-        h3.text-center= t("publishers.create_auth_token")
-    .row
-      .col.site-login
-        p.text-center= t("publishers.create_auth_token_body")
+.publisher-panel.col-center.sub-panel.col-lg-6.col-md-8.col-sm-10.col-xs-12
+  .row
+    .col
+      h3.text-center= t("publishers.create_auth_token")
+  .row
+    .col.site-login
+      p.text-center= t("publishers.create_auth_token_body")

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -1,28 +1,26 @@
 - content_for(:navbar_content) do
 
-.publisher-panel.login-panel.col-center
-  .sub-panel.process-panel
-    .row
-      .col
-        h3.text-center= t("publishers.new_auth_token")
-    .row
-      .col.col-md-5.site-login
-        = form_for(@publisher, url: create_auth_token_publishers_path) do |f|
-          fieldset
-            p= t("publishers.log_in_for_site")
+.publisher-panel.col-center.sub-panel.process-panel.clearfix.col-md-10
+  div
+    h3.text-center= t("publishers.new_auth_token")
+  div
+    .col.col-md-6.site-login
+      = form_for(@publisher, url: create_auth_token_publishers_path) do |f|
+        fieldset
+          p= t("publishers.log_in_for_site")
+          .form-group
+            = f.label(:brave_publisher_id, class: "control-label")
+            = f.text_field(:brave_publisher_id, autofocus: true, class: "form-control", placeholder: "example.com", required: true)
+          .form-group
+            = f.label(:email, t("publishers.new_auth_token_email_html"), class: "control-label")
+            = f.email_field(:email, class: "form-control", placeholder: "alice@example.com")
+            - if params[:captcha]
+              = hidden_field_tag(:captcha)
+          - if @should_throttle
             .form-group
-              = f.label(:brave_publisher_id, class: "control-label")
-              = f.text_field(:brave_publisher_id, autofocus: true, class: "form-control", placeholder: "example.com", required: true)
-            .form-group
-              = f.label(:email, t("publishers.new_auth_token_email_html"), class: "control-label")
-              = f.email_field(:email, class: "form-control", placeholder: "alice@example.com")
-              - if params[:captcha]
-                = hidden_field_tag(:captcha)
-            - if @should_throttle
-              .form-group
-                = recaptcha_tags
-          .panel-controls
-            = f.submit(t("publishers.new_auth_token_button"), class: "btn btn-primary")
-      .col.col-md-5.col-md-offset-2.youtube-login
-        p= t("publishers.log_in_for_youtube")
-        = link_to(t("publishers.log_in_with_google_button"), publisher_google_oauth2_omniauth_authorize_path, class: "btn btn-primary")
+              = recaptcha_tags
+        .panel-controls
+          = f.submit(t("publishers.new_auth_token_button"), class: "btn btn-primary")
+    .col.col-md-6.youtube-login
+      p= t("publishers.log_in_for_youtube")
+      = link_to(t("publishers.log_in_with_google_button"), publisher_google_oauth2_omniauth_authorize_path, class: "btn btn-primary")

--- a/app/views/totp_registrations/new.html.slim
+++ b/app/views/totp_registrations/new.html.slim
@@ -3,9 +3,9 @@
     .row
       .col.col-details.col-md-8.col-center
         - if totp_enabled?(current_publisher)
-          .sub-panel.sub-panel--panel--top
+          .sub-panel.sub-panel--panel--info-top
             .row
-              .col-md-10.col-md-offset-1
+              .sub-panel--top-wrapper
                 .sub-panel--top-icon
                   = render 'icon_circled_i'
                 .sub-panel--top-body

--- a/app/views/two_factor_authentications/_u2f.html.slim
+++ b/app/views/two_factor_authentications/_u2f.html.slim
@@ -11,14 +11,6 @@ div.js-feature-u2f-available
         p = t ".body"
         .text-center
           = render "application/usb_with_lines"
-    .col.col-xs-12.col-sm-10.col-center.text-center
-      .error-group.js-register-u2f-error
-        .alert.alert-warning.js-u2f-error-bad-request = t ".u2f-error.bad-request"
-        .alert.alert-warning.js-u2f-error-configuration-unsupported = t ".u2f-error.configuration-unsupported"
-        .alert.alert-warning.js-u2f-error-device-ineligible = t ".u2f-error.device-ineligible"
-        .alert.alert-warning.js-u2f-error-other-error = t ".u2f-error.other-error"
-        .alert.alert-warning.js-u2f-error-timeout = t ".u2f-error.timeout"
-        .alert.alert-warning.js-u2f-error-implementation-incomplete = t ".u2f-error.implementation-incomplete"
     .col.col-xs-10.col-sm-8.col-center.text-center
       .js-u2f-is-prompting.text-center
         .text-center

--- a/app/views/two_factor_authentications/index.html.slim
+++ b/app/views/two_factor_authentications/index.html.slim
@@ -1,9 +1,69 @@
 .container
   .row
-    .sub-panel.login-panel.col-center.col-xs-12.col-sm-10.col-md-8.col-lg-6
+    .col-center.col-xs-12.col-sm-10.col-md-8.col-lg-6
+      .error-group--wrapper.js-authenticate-u2f-error
 
-      - if @u2f_authentication_attempt
-        = render partial: "u2f", locals: @u2f_authentication_attempt
+        .js-u2f-error-bad-request
+          .sub-panel.sub-panel--panel--error-top
+            .row
+              .sub-panel--top-wrapper
+                .sub-panel--top-icon
+                  = render 'icon_circled_x'
+                .sub-panel--top-body
+                  = t ".u2f-error.bad-request"
 
-      - elsif @totp_enabled
-        = render "totp"
+        .js-u2f-error-configuration-unsupported
+          .sub-panel.sub-panel--panel--error-top
+            .row
+              .sub-panel--top-wrapper
+                .sub-panel--top-icon
+                  = render 'icon_circled_x'
+                .sub-panel--top-body
+                  = t ".u2f-error.configuration-unsupported"
+
+        .js-u2f-error-device-ineligible
+          .sub-panel.sub-panel--panel--error-top
+            .row
+              .sub-panel--top-wrapper
+                .sub-panel--top-icon
+                  = render 'icon_circled_x'
+                .sub-panel--top-body
+                  = t ".u2f-error.device-ineligible"
+
+        .js-u2f-error-other-error
+          .sub-panel.sub-panel--panel--error-top
+            .row
+              .sub-panel--top-wrapper
+                .sub-panel--top-icon
+                  = render 'icon_circled_x'
+                .sub-panel--top-body
+                  = t ".u2f-error.other-error"
+
+        .js-u2f-error-timeout
+          .sub-panel.sub-panel--panel--error-top
+            .row
+              .sub-panel--top-wrapper
+                .sub-panel--top-icon
+                  = render 'icon_circled_x'
+                .sub-panel--top-body
+                  = t ".u2f-error.timeout"
+
+        .js-u2f-error-implementation-incomplete
+          .sub-panel.sub-panel--panel--error-top
+            .row
+              .sub-panel--top-wrapper
+                .sub-panel--top-icon
+                  = render 'icon_circled_x'
+                .sub-panel--top-body
+                  = t ".u2f-error.implementation-incomplete"
+
+        .error-group--no-error.js-no-error
+          .sub-panel.sub-panel--panel--filler-top
+
+      .sub-panel.sub-panel--panel--bottom
+
+        - if @u2f_authentication_attempt
+          = render partial: "u2f", locals: @u2f_authentication_attempt
+
+        - elsif @totp_enabled
+          = render "totp"

--- a/app/views/u2f_registrations/new.html.slim
+++ b/app/views/u2f_registrations/new.html.slim
@@ -1,42 +1,91 @@
 .main-content
   .container
     .row
-      .col.col-details.col-md-8.col-center
-        .sub-panel
+      .col.col-details.col-xs-12.col-sm-10.col-md-8.col-lg-6.col-center
 
-          .row
-            .col-md-10.col-md-offset-1
+        .error-group--wrapper.js-register-u2f-error
 
-              h3 = t ".heading"
+          .js-u2f-error-bad-request
+            .sub-panel.sub-panel--panel--error-top
+              .row
+                .sub-panel--top-wrapper
+                  .sub-panel--top-icon
+                    = render 'icon_circled_x'
+                  .sub-panel--top-body
+                    = t ".u2f-error.bad-request"
 
-              .error-group.js-register-u2f-error
-                .alert.alert-warning.js-u2f-error-bad-request = t ".u2f-error.bad-request"
-                .alert.alert-warning.js-u2f-error-configuration-unsupported = t ".u2f-error.configuration-unsupported"
-                .alert.alert-warning.js-u2f-error-device-ineligible = t ".u2f-error.device-ineligible"
-                .alert.alert-warning.js-u2f-error-other-error = t ".u2f-error.other-error"
-                .alert.alert-warning.js-u2f-error-timeout = t ".u2f-error.timeout"
-                .alert.alert-warning.js-u2f-error-implementation-incomplete = t ".u2f-error.implementation-incomplete"
+          .js-u2f-error-configuration-unsupported
+            .sub-panel.sub-panel--panel--error-top
+              .row
+                .sub-panel--top-wrapper
+                  .sub-panel--top-icon
+                    = render 'icon_circled_x'
+                  .sub-panel--top-body
+                    = t ".u2f-error.configuration-unsupported"
 
-              = form_for @u2f_registration, html: { class: "js-register-u2f js-feature-u2f-available" } do |f|
-                input type="hidden" name="u2f_app_id" value=(@app_id)
-                input type="hidden" name="u2f_registration_requests" value=(@registration_requests.as_json.to_json)
-                input type="hidden" name="u2f_sign_requests" value=(@sign_requests.as_json.to_json)
-                input type="hidden" name="u2f_response"
+          .js-u2f-error-device-ineligible
+            .sub-panel.sub-panel--panel--error-top
+              .row
+                .sub-panel--top-wrapper
+                  .sub-panel--top-icon
+                    = render 'icon_circled_x'
+                  .sub-panel--top-body
+                    = t ".u2f-error.device-ineligible"
 
-                div.form-group
-                  = f.label :name
-                  = f.text_field :name, class: "form-control", placeholder: t(".name_placeholder")
+          .js-u2f-error-other-error
+            .sub-panel.sub-panel--panel--error-top
+              .row
+                .sub-panel--top-wrapper
+                  .sub-panel--top-icon
+                    = render 'icon_circled_x'
+                  .sub-panel--top-body
+                    = t ".u2f-error.other-error"
 
-                .row
-                  .col-md-6
-                    = f.submit t(".submit_value"), class: "btn btn-primary"
-                  .col-md-6.text-right
-                    = link_to t(".cancel"), two_factor_registrations_path, class: "btn btn-link"
+          .js-u2f-error-timeout
+            .sub-panel.sub-panel--panel--error-top
+              .row
+                .sub-panel--top-wrapper
+                  .sub-panel--top-icon
+                    = render 'icon_circled_x'
+                  .sub-panel--top-body
+                    = t ".u2f-error.timeout"
 
-                .error-group.js-register-u2f-waiting
-                  .js-u2f-waiting
-                    h5= t ".waiting_heading"
-                    p= t ".waiting_description"
+          .js-u2f-error-implementation-incomplete
+            .sub-panel.sub-panel--panel--error-top
+              .row
+                .sub-panel--top-wrapper
+                  .sub-panel--top-icon
+                    = render 'icon_circled_x'
+                  .sub-panel--top-body
+                    = t ".u2f-error.implementation-incomplete"
 
-              div.warning.js-feature-u2f-unavailable
-                p.alert.alert-warning = t ".u2f-unavailable"
+          .error-group--no-error.js-no-error
+            .sub-panel.sub-panel--panel--filler-top
+
+
+        .sub-panel.sub-panel--panel--bottom
+
+          h3 = t ".heading"
+
+          = form_for @u2f_registration, html: { class: "js-register-u2f js-feature-u2f-available" } do |f|
+            input type="hidden" name="u2f_app_id" value=(@app_id)
+            input type="hidden" name="u2f_registration_requests" value=(@registration_requests.as_json.to_json)
+            input type="hidden" name="u2f_sign_requests" value=(@sign_requests.as_json.to_json)
+            input type="hidden" name="u2f_response"
+
+            div.form-group
+              = f.label :name
+              = f.text_field :name, class: "form-control", placeholder: t(".name_placeholder")
+
+            div
+              .col.pull-left
+                = f.submit t(".submit_value"), class: "btn btn-primary"
+              .col.text-right
+                = link_to t(".cancel"), two_factor_registrations_path, class: "btn btn-link"
+
+            .js-u2f-is-working
+              h5= t ".waiting_heading"
+              p= t ".waiting_description"
+
+          div.warning.js-feature-u2f-unavailable
+            p.alert.alert-warning = t ".u2f-unavailable"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,6 +362,7 @@ en:
           Your browser doesn't support security key, the only two-factor
           authentication method your account has configured. Please use
           Google Chrome to authenticate with your security key.
+    index:
       u2f-error:
         bad-request: |
           There was an unexpected error in the authentication request made by


### PR DESCRIPTION
This PR closes https://github.com/brave-intl/publishers/issues/393 and closes https://github.com/brave-intl/publishers/issues/394. It introduces a new error style in the header of sub panels.

**Login page**

![localhost_3000_publishers_log_in](https://user-images.githubusercontent.com/8752/35007374-5b1cd71e-faae-11e7-8cfc-36b20461836c.png)

**Login confirmation**

![localhost_3000_publishers_log_in 1](https://user-images.githubusercontent.com/8752/35007373-5b068d38-faae-11e7-85e3-2b0de19c9603.png)

**Pending authentication via U2F**

![localhost_3000_publishers_two_factor_authentications 2](https://user-images.githubusercontent.com/8752/35007371-5ad11590-faae-11e7-8543-bdd8fa0003cd.png)

**Errored authentication via U2F**

![localhost_3000_publishers_two_factor_authentications 1](https://user-images.githubusercontent.com/8752/35007372-5ae80642-faae-11e7-80a4-935e2fab45b5.png)

**Warning on TOTP  re-registration**

![localhost_3000_publishers_totp_registrations_new 6](https://user-images.githubusercontent.com/8752/35007370-5ab97660-faae-11e7-8f90-111d98cb42b7.png)

**Error on U2F registration**

![localhost_3000_publishers_u2f_registrations_new 1](https://user-images.githubusercontent.com/8752/35007368-5a58824c-faae-11e7-803c-449dc9a14bd2.png)

**Error on U2F registration, mobile**. The other pages also adapt in this way: Less padding and no icon.

![localhost_3000_publishers_u2f_registrations_new](https://user-images.githubusercontent.com/8752/35007369-5a9e540c-faae-11e7-9c03-b97a255ca646.png)

**GIF to illustrate flow, responsiveness**

![screencast 2018-01-16 11-23-22](https://user-images.githubusercontent.com/8752/35008045-2bebd54c-fab0-11e7-9c05-5fbf81315553.gif)

TODO:

* [x] Final sanity checks of altered pages, and pages maybe altered by these changes
* [x] Some screenshots
* [x] Add further inline documentation in CSS for sub-panel
* [x] Add further inline documentation in JS for error manager