### PR TITLE
Prompt to reconnect if eyeshade action = authorize

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -86,7 +86,7 @@ class Publisher < ApplicationRecord
     if @_wallet
       # Reset the uphold_verified if eyeshade thinks we need to re-authorize (or authorize for the first time)
       save_needed = false
-      if self.uphold_verified && @_wallet.status['action'] == 're-authorize'
+      if self.uphold_verified && ['re-authorize', 'authorize'].include?(@_wallet.status['action'])
         self.uphold_verified = false
         save_needed = true
       end


### PR DESCRIPTION
Closes #415.

Eyeshade may return an action of `authorize` or `re-authorize`. Both of these actions suggest that the user should be prompted to reconnect to their uphold account.

* The reconnect button in at: https://github.com/brave-intl/publishers/blob/0c497ac13ae10d0aab727980c0296e5d6ae215dd/app/views/publishers/home.html.slim#L295
* It is only shown if `show_uphold_connect?(publisher)` is true. That logic is here: https://github.com/brave-intl/publishers/blob/0c497ac13ae10d0aab727980c0296e5d6ae215dd/app/helpers/publishers_helper.rb#L23. If Eyeshade provides and action of `authorize` we expect `publisher.uphold_status` to be `:unconnected`. Currently it is `:verified`, thus the reconnect button is not shown.
* `publisher.uphold_status` is based on several other properties at https://github.com/brave-intl/publishers/blob/c3b823d68323e7235a26ddbeefd7dc5de1a8fb89/app/models/publisher.rb#L159, but `:unconnected` is based on `publisher.uphold_verified`.
* The change in this PR is to set `publisher.uphold_verified` to false when the Eyeshade action is `authorize`. This changes the `publisher.uphold_status` which changes `show_uphold_connect?(publisher)` which makes the reconnect button appear.