### PR TITLE
[Multichannel] Move `visible` flag from channels to publishers

### DIFF
--- a/app/assets/stylesheets/application/publishers.sass
+++ b/app/assets/stylesheets/application/publishers.sass
@@ -282,12 +282,24 @@ body[data-controller="publishers"]
   &[data-action="email_verified"],
   &[data-action="complete_signup"]
     .process-panel
-      padding: 80px 200px 80px 100px
+      padding: 80px 200px 80px 80px
       background: #fff url(asset-path("img-brands.png")) top right no-repeat
+      .content-panel form
+        width: 350px
+        .form-check-input
+          vertical-align: top
+          margin-top: 5px
+        .form-check-label
+          padding-left: 15px
+          width: 330px
+          font-size: 14px
+          font-weight: 300
+        .panel-controls
+          margin-top: 45px
       h1
         color: #ff3f3f
       .tos
-        margin-bottom: 20px
+        margin-top: 20px
         font-size: 14px
         color: $gray
 
@@ -384,6 +396,19 @@ body[data-controller="publishers"]
           background-repeat: no-repeat
           background-size: 42px
           background-image: url(asset-path("icn-warning@1x.png"))
+      #update_publisher_visible_form
+        margin-top: 40px
+        margin-left: -30px
+        width: 370px
+        .form-check-input
+          vertical-align: top
+          margin-top: 5px
+        .form-check-label
+          padding-left: 15px
+          width: 350px
+          font-size: 15px
+          font-weight: 300
+
       .balance
         font-size: $font-size-base
         vertical-align: top
@@ -449,33 +474,9 @@ body[data-controller="publishers"]
               font-size: 12px
               color: $gray
           .channel-status
-            margin: -24px -40px -24px 0
-            padding: 36px 20px
-            min-width: 350px
-            background: #f2f4f7
-            border-radius: 0 8px 8px 0
-            .list-label
-              display: block
-              width: 67%
-              white-space: nowrap
-            .inline-controls
-              padding: 0
-            .onoffswitch
-              display: inline-block
-              margin-top: 8px
-            .value-label
-              display: inline-block
-              float: right
-              margin-left: 12px
-              margin-top: 4px
-              font-size: 12px
-              font-weight: 500
-            .update-show-verification-status-form.checked .value-label:after
-              color: #4fbad6
-              content: "ON"
-            .update-show-verification-status-form.unchecked .value-label:after
-              color: $gray
-              content: "OFF"
+            background: url(asset-path("icn-verified.png")) no-repeat center left
+            padding: 12px 0 12px 38px
+
       #default_currency_code
         font-weight: 600
       .payment-info
@@ -649,8 +650,6 @@ body[data-controller="publishers"]
         border-radius: 0
 
     @media (max-width: $screen-md-max)
-      .publisher-panel
-        max-width: 400px
       .site-operator
         margin-bottom: 32px
     @media (min-width: $screen-md-min)

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -5,20 +5,12 @@ class ChannelsController < ApplicationController
   before_action :setup_current_channel
   attr_reader :current_channel
 
-  def update
-    current_channel.update(channel_update_params)
-  end
-
   def destroy
     current_channel.destroy
     redirect_to(home_publishers_path, alert: t("channel.channel_removed"))
   end
 
   private
-
-  def channel_update_params
-    params.require(:channel).permit(:show_verification_status)
-  end
 
   def setup_current_channel
     @current_channel = current_publisher.channels.find(params[:id])

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -333,11 +333,11 @@ class PublishersController < ApplicationController
   end
 
   def publisher_complete_signup_params
-    params.require(:publisher).permit(:name)
+    params.require(:publisher).permit(:name, :visible)
   end
 
   def publisher_update_params
-    params.require(:publisher).permit(:pending_email, :phone, :name, :default_currency)
+    params.require(:publisher).permit(:pending_email, :phone, :name, :default_currency, :visible)
   end
 
   def publisher_create_auth_token_params

--- a/app/serializers/channel_serializer.rb
+++ b/app/serializers/channel_serializer.rb
@@ -1,9 +1,5 @@
 class ChannelSerializer < ActiveModel::Serializer
-  attributes :id, :verified, :show_verification_status, :created_at, :updated_at
+  attributes :id, :verified, :created_at, :updated_at
 
   belongs_to :details, polymorphic: true
-
-  def show_verification_status
-    object.show_verification_status?
-  end
 end

--- a/app/services/publisher_channel_setter.rb
+++ b/app/services/publisher_channel_setter.rb
@@ -13,8 +13,7 @@ class PublisherChannelSetter < BaseApiClient
       {
           "channelId" => channel.details.channel_identifier,
           "authorizerEmail" => channel.details.try(:auth_email),
-          "authorizerName" => channel.details.try(:auth_name),
-          "visible" => channel.show_verification_status?
+          "authorizerName" => channel.details.try(:auth_name)
       }.compact
     end
 

--- a/app/views/publishers/email_verified.html.slim
+++ b/app/views/publishers/email_verified.html.slim
@@ -7,10 +7,15 @@
 
       = form_for @publisher, { method: :patch, url: complete_signup_publishers_path,
               html: { id: "update_contact_info" }} do |f|
-        fieldset
-          .form-group
-            = f.label(:name, class: "control-label")
-            = f.text_field(:name, autofocus: true, class: "form-control", placeholder: "Alice Bloglette", required: true)
+        .form-group
+          = f.label(:name, class: "control-label")
+          = f.text_field(:name, autofocus: true, class: "form-control", placeholder: t("publishers.contact_name_placeholder"), required: true)
+        .form-group
+          = f.check_box(:visible, class: "form-check-input")
+          = f.label(:visible, class: "form-check-label", for: "publisher_visible")
         .panel-controls
-          .tos=t("publishers.complete_signup_tos_html", tos_link: link_to(t("shared.terms_of_service"), '/terms_of_service'))
           = f.submit(t("publishers.complete_signup_submit"), class: "btn btn-primary")
+
+      .tos=t("publishers.complete_signup_tos_html",
+              tos_link: link_to(t("shared.terms_of_service"),
+                                'https://basicattentiontoken.org/publisher-terms-of-service/'))

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -45,22 +45,11 @@ javascript:
       modal.classList.remove('md-show');
     }
 
-    function verificationStatusUpdated(channelId) {
-      var form = document.getElementById('update_show_verification_status_' + channelId);
-      var input = document.getElementById('show_verification_status_' + channelId);
-      form.classList.remove(input.checked ? 'unchecked' : 'checked');
-      form.classList.add(input.checked ? 'checked' : 'unchecked');
-    }
-
     window.addEventListener('load', function() {
-      var showChannelVerificationStatusInputs = document.querySelectorAll('input.show-channel-verification-status');
-      for (var i = 0, l = showChannelVerificationStatusInputs.length; i < l; i++) {
-        showChannelVerificationStatusInputs[i].addEventListener('click', function(event) {
-          var channelId = event.target.getAttribute('data-channel-id');
-          submitForm('update_show_verification_status_' + channelId, 'PATCH', true);
-          verificationStatusUpdated(channelId);
-        }, false);
-      }
+      var publisherVisibleCheckbox = document.getElementById('publisher_visible');
+      publisherVisibleCheckbox.addEventListener('click', function(event) {
+        window.submitForm('update_publisher_visible_form', 'PATCH', true);
+      }, false);
 
       var defaultCurrencySelect = document.getElementById('publisher_default_currency');
       if (defaultCurrencySelect) {
@@ -334,6 +323,10 @@ noscript
               = t("shared.cancel")
         p#pending_email_notice style="display: none" class="note"
 
+        = form_for(current_publisher, url: publishers_path, html: { id: "update_publisher_visible_form" }) do |f|
+          = f.check_box(:visible, class: "form-check-input")
+          = f.label(:visible, class: "form-check-label", for: "publisher_visible")
+
 - if current_publisher.channels.empty?
   .row
     .col.col-details.col-md-12.col-xs-10
@@ -349,22 +342,7 @@ noscript
               .channel-details
                 = t("publishers.dashboard_channel_added", date: channel.created_at.to_date.iso8601)
             .channel-status.pull-right
-              = form_for(channel, url: channel_path(channel),
-                      html: { id: "update_show_verification_status_" + channel.id,
-                              class: 'update-show-verification-status-form ' + (channel.show_verification_status? ? 'checked' : 'unchecked') }) do |f|
-                .panel-header.panel-header-h4
-                  .inline-controls.pull-right
-                    .onoffswitch
-                      = f.check_box(:show_verification_status,
-                                    id: "show_verification_status_" + channel.id,
-                                    class: "show-channel-verification-status onoffswitch-checkbox",
-                                    "data-piwik-action": "ShowStatusToggleClicked", "data-piwik-name": "Clicked", "data-piwik-value": "Dashboard",
-                                    "data-channel-id": channel.id)
-                      = f.label(:show_verification_status, class: "onoffswitch-label", for: "show_verification_status_" + channel.id) do
-                        span.onoffswitch-inner
-                        span.onoffswitch-switch
-                    .value-label
-                  .list-label= t("publishers.dashboard_list_in_verified_publishers")
+              = t("publishers.dashboard_channel_verified")
           -else
             .channel-summary.pull-left
               h3= channel.publication_title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,8 +24,8 @@ en:
     attributes:
       publisher:
         phone_normalized: "Phone Number"
-        show_verification_status: "List my site in Brave's verified publisher site once verified."
-        name: "Contact Name"
+        visible: "Yes, help me increase contributor awareness by listing my site in Brave’s marketing channels."
+        name: "Your Name"
       site_channel_details:
         brave_publisher_id: "Website Domain"
         brave_publisher_id_unnormalized: "Website Domain"
@@ -60,6 +60,7 @@ en:
     balance_pending_approximate: "Approximately %{amount} %{code}"
     contact_person: "Contact person"
     contact: "Contact"
+    contact_name_placeholder: "First and last name"
     sign_up_header: "Join Brave Payments"
     create_done_header: "An email is on its way!"
     create_done_body_html: |
@@ -79,6 +80,7 @@ en:
     dashboard_channel_added: "added %{date}"
     dashboard_channel_one_more_step: "One more step to complete..."
     dashboard_channel_lets_finish: "Let's Finish"
+    dashboard_channel_verified: "Verified"
     current_deposit_currency: "Current deposit currency: BAT to "
     edit_contact: "Edit Contact"
     uphold_check_balance: "Check Balance"
@@ -125,7 +127,7 @@ en:
     verification_uphold_state_token_does_not_match: "There was a problem connecting with Uphold. Please try again."
     verify_button: "Verify"
     complete_signup_welcome: "One last thing..."
-    complete_signup_leadin: "Finish signup by entering below."
+    complete_signup_leadin: "Finish signing up by entering below."
     complete_signup_tos_html: "By clicking 'Sign Up', you're agreeing to our %{tos_link}"
     complete_signup_submit: "Sign Up"
     pub_type_welcome: "Add Channel"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,9 +38,9 @@ Rails.application.routes.draw do
   end
   devise_for :publishers, only: :omniauth_callbacks, controllers: { omniauth_callbacks: "publishers/omniauth_callbacks" }
 
-  resources :channels, only: %i(update destroy) do
+  resources :channels, only: %i(destroy) do
     member do
-      patch :update
+      delete :destroy
     end
   end
 

--- a/db/migrate/20180116200817_add_visible_to_publishers.rb
+++ b/db/migrate/20180116200817_add_visible_to_publishers.rb
@@ -1,0 +1,11 @@
+class AddVisibleToPublishers < ActiveRecord::Migration[5.0]
+  def up
+    add_column :publishers, :visible, :boolean, default: true
+    remove_column :channels, :show_verification_status
+  end
+
+  def down
+    add_column :channels, :show_verification_status, :boolean, default: true
+    remove_column :publishers, :visible
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180109221848) do
+ActiveRecord::Schema.define(version: 20180116200817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,13 +18,12 @@ ActiveRecord::Schema.define(version: 20180109221848) do
 
   create_table "channels", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid     "publisher_id"
-    t.boolean  "created_via_api",          default: false, null: false
-    t.boolean  "show_verification_status"
-    t.boolean  "verified",                 default: false
+    t.boolean  "created_via_api", default: false, null: false
+    t.boolean  "verified",        default: false
     t.string   "details_type"
     t.uuid     "details_id"
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.index ["details_type", "details_id"], name: "index_channels_on_details_type_and_details_id", unique: true, using: :btree
     t.index ["publisher_id"], name: "index_channels_on_publisher_id", using: :btree
   end
@@ -124,6 +123,7 @@ ActiveRecord::Schema.define(version: 20180109221848) do
     t.datetime "created_at",                                            null: false
     t.datetime "updated_at",                                            null: false
     t.datetime "two_factor_prompted_at"
+    t.boolean  "visible",                               default: true
     t.index ["created_at"], name: "index_publishers_on_created_at", using: :btree
     t.index ["email"], name: "index_publishers_on_email", unique: true, using: :btree
     t.index ["pending_email"], name: "index_publishers_on_pending_email", using: :btree

--- a/test/controllers/api/channels_controller_test.rb
+++ b/test/controllers/api/channels_controller_test.rb
@@ -35,26 +35,6 @@ class Api::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_match /#{channel.id}/, response.body
   end
 
-  test "show_verification_status returns as false if nil" do
-    channel = channels(:google_verified)
-    assert_nil channel.show_verification_status
-
-    get "/api/channels/#{URI.escape(channel.details.channel_identifier)}"
-
-    assert_equal(200, response.status)
-    refute_nil JSON.parse(response.body)['show_verification_status']
-  end
-
-  test "show_verification_status returns as true if true" do
-    channel = channels(:uphold_connected)
-    assert channel.show_verification_status
-
-    get "/api/channels/#{URI.escape(channel.details.channel_identifier)}"
-
-    assert_equal(200, response.status)
-    assert JSON.parse(response.body)['show_verification_status']
-  end
-
   test "verifies a channel" do
     channel = channels(:small_media_group_to_verify)
     publisher = channel.publisher

--- a/test/controllers/channels_controller_test.rb
+++ b/test/controllers/channels_controller_test.rb
@@ -8,61 +8,6 @@ class ChannelsControllerTest < ActionDispatch::IntegrationTest
   include MailerTestHelper
   include PublishersHelper
 
-  test "update a channel belonging to logged in owner succeeds" do
-    publisher = publishers(:verified)
-
-    sign_in publishers(:verified)
-
-    channel = channels(:verified)
-    assert channel.show_verification_status
-
-    update_params = {
-        channel: {
-          show_verification_status: false
-        }
-    }
-    url = channel_url(channel.id)
-
-    perform_enqueued_jobs do
-      patch(url,
-            params: update_params,
-            headers: { 'HTTP_ACCEPT' => "application/json" })
-      assert_response 204
-    end
-
-    channel.reload
-
-    refute channel.show_verification_status
-  end
-
-  test "update a channel that doesn't belong to logged in owner fails" do
-    publisher = publishers(:verified)
-
-    sign_in publishers(:verified)
-
-    channel = channels(:google_verified)
-    refute channel.show_verification_status
-
-    update_params = {
-        channel: {
-            show_verification_status: true
-        }
-    }
-    url = channel_url(channel.id)
-
-    perform_enqueued_jobs do
-      patch(url,
-            params: update_params,
-            headers: { 'HTTP_ACCEPT' => "application/json" })
-      assert_response 302
-      assert_redirected_to home_publishers_path
-    end
-
-    channel.reload
-
-    refute channel.show_verification_status
-  end
-
   test "delete removes a channel and associated details" do
     publisher = publishers(:small_media_group)
     channel = channels(:small_media_group_to_delete)
@@ -90,35 +35,6 @@ class ChannelsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # ToDo:
-  # test "a channel's show_verification_status can be updated via an ajax patch" do
-  #   perform_enqueued_jobs do
-  #     post(publishers_path, params: SIGNUP_PARAMS)
-  #   end
-  #   publisher = Publisher.order(created_at: :asc).last
-  #   url = publisher_url(publisher, token: publisher.authentication_token)
-  #   get(url)
-  #   follow_redirect!
-  #   perform_enqueued_jobs do
-  #     patch(update_unverified_publishers_path, params: PUBLISHER_PARAMS)
-  #   end
-  #
-  #   publisher.show_verification_status = false
-  #   publisher.verified = true
-  #   publisher.save!
-  #
-  #   assert_equal false, publisher.show_verification_status
-  #
-  #   url = publishers_path
-  #   patch(url,
-  #         params: { publisher: { show_verification_status: 1, pending_email: 'joeblow@example.com', name: 'Joseph Blow' } },
-  #         headers: { 'HTTP_ACCEPT' => "application/json" })
-  #   assert_response 204
-  #
-  #   publisher.reload
-  #   assert_equal true, publisher.show_verification_status
-  #   assert_equal 'joeblow@example.com', publisher.pending_email
-  #   assert_equal 'Joseph Blow', publisher.name
-  # end
   #
   # test "a channel's domain status can be polled via ajax" do
   #   perform_enqueued_jobs do

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -14,7 +14,8 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
   COMPLETE_SIGNUP_PARAMS = {
     publisher: {
-      name: "Alice the Pyramid"
+      name: "Alice the Pyramid",
+      visible: true
     }
   }.freeze
 

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -1,24 +1,20 @@
 default: &default
   publisher: default
-  show_verification_status: true
   details: default_details (SiteChannelDetails)
   verified: false
 
 new_site:
   publisher: default
-  show_verification_status: true
   details: new_site_details (SiteChannelDetails)
   verified: false
 
 verified:
   publisher: verified
-  show_verification_status: true
   details: verified_details (SiteChannelDetails)
   verified: true
 
 completed:
   publisher: completed
-  show_verification_status: false
   details: completed_details (SiteChannelDetails)
   verified: true
 
@@ -41,7 +37,6 @@ fake2:
 
 uphold_connected:
   publisher: uphold_connected
-  show_verification_status: true
   details: uphold_connected_details (SiteChannelDetails)
   verified: true
 
@@ -72,13 +67,11 @@ global_yt2:
 
 global_verified:
   publisher: global_media_group
-  show_verification_status: true
   details: global_verified_details (SiteChannelDetails)
   verified: true
 
 global_inprocess:
   publisher: global_media_group
-  show_verification_status: true
   details: global_inprocess_details (SiteChannelDetails)
   verified: false
 
@@ -86,13 +79,11 @@ global_abandoned:
   publisher: global_media_group
   created_at: <%= Time.now - 20.weeks %>
   updated_at: <%= Time.now - 20.weeks %>
-  show_verification_status: true
   details: global_abandoned_details (SiteChannelDetails)
   verified: false
 
 small_media_group_to_delete:
   publisher: small_media_group
-  show_verification_status: true
   details: to_delete_details (SiteChannelDetails)
   verified: true
 
@@ -100,6 +91,5 @@ small_media_group_to_verify:
   publisher: small_media_group
   created_at: <%= Time.now - 20.weeks %>
   updated_at: <%= Time.now - 20.weeks %>
-  show_verification_status: true
   details: to_verify_details (SiteChannelDetails)
   verified: false

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -7,6 +7,7 @@ default: &default
   phone: "4159001420"
   phone_normalized: "+14159001420"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+  visible: true
 
 verified:
   email: "alice@verified.org"
@@ -14,6 +15,7 @@ verified:
   phone: "4159001421"
   phone_normalized: "+14159001421"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+  visible: true
 
 # A publisher that has received an authentication email
 #
@@ -30,6 +32,7 @@ completed:
     iv: salt
   ) %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+  visible: true
 
 unprompted:
   email: "alice@unprompted.org"
@@ -37,24 +40,28 @@ unprompted:
   phone: "4159001421"
   phone_normalized: "+14159001421"
   # two_factor_prompted_at: nil
+  visible: true
 
 stale:
   email: "alice@stale.org"
   name: "Alice the Stale"
   phone: "4159001422"
   phone_normalized: "+14159001422"
+  visible: true
 
 fake1:
   email: "alice@fake.org"
   name: "Fake Alice"
   phone: "4155551212"
   phone_normalized: "+14155551212"
+  visible: true
 
 fake2:
   email: "bob@fake.org"
   name: "Fake Bob"
   phone: "4155551234"
   phone_normalized: "+14155551234"
+  visible: true
 
 uphold_connected:
   email: "alice@upholdconnected.org"
@@ -62,33 +69,40 @@ uphold_connected:
   phone: "4159001421"
   phone_normalized: "+14159001421"
   uphold_verified: true
+  visible: true
 
 youtube_initial:
   email: "alice@spud.com"
   name: "Alice the Youtuber"
   phone: "4159001420"
   phone_normalized: "+14159001420"
+  visible: true
 
 youtube_new:
   email: "alice2@spud.com"
   name: "Alice the Youtuber"
   phone: "4159001420"
   phone_normalized: "+14159001420"
+  visible: true
 
 google_verified:
   email: "alice2@verified.org"
   name: "Alice the Verified"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  visible: true
 
 global_media_group:
   email: "fred@vglobal.org"
   name: "Global Media Group"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  visible: true
 
 small_media_group:
   email: "fred@small.org"
   name: "Small Media Group"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  visible: true
+

--- a/test/jobs/upload_uphold_access_parameters_job_test.rb
+++ b/test/jobs/upload_uphold_access_parameters_job_test.rb
@@ -11,16 +11,19 @@ class UploadUpholdAccessParametersJobTest < ActiveJob::TestCase
       publisher.uphold_access_parameters = '{"access_token":"abc123","token_type":"bearer"}'
       publisher.save!
 
-      stub_request(:put, /v1\/owners\/#{publisher.owner_identifier}\/wallet/)
-          .with(body:
-            <<~BODY
-              {
-                "provider": "uphold", 
-                "parameters": {"access_token":"abc123","token_type":"bearer","server":"#{Rails.application.secrets[:uphold_api_uri]}"}, 
-                "verificationId": "#{publisher.id}"
-              }
-            BODY
-          )
+      stub_request(:put, /v1\/owners\/#{publisher.owner_identifier}\/wallet/).
+        with(headers: {'Accept'=>'*/*',
+                       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                       'Authorization'=>"Bearer #{Rails.application.secrets[:api_eyeshade_key]}",
+                       'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'},
+             body:
+               <<~BODY
+                {
+                  "provider": "uphold", 
+                  "parameters": {"access_token":"abc123","token_type":"bearer","server":"#{Rails.application.secrets[:uphold_api_uri]}"}
+                }
+               BODY
+        )
 
       UploadUpholdAccessParametersJob.perform_now(publisher_id: publisher.id)
 


### PR DESCRIPTION
This flag controls whether channels can be listed as Brave Verified Publishers. Instead of setting this flag on individual channels, it should now be set once per publisher.

A checkbox has been added to both the complete registration step and the dashboard.

Closes #403

/cc @ayumi @jenn-rhim 

The updated "complete registration" panel:

![screen shot 2018-01-17 at 12 25 16 pm](https://user-images.githubusercontent.com/29122/35056985-8b4c7d26-fb81-11e7-9d55-da4ad263ee26.png)

The updated dashboard (note the new "Verified" label on the channel - this is just a first attempt):

![screen shot 2018-01-17 at 12 24 25 pm](https://user-images.githubusercontent.com/29122/35056987-8f92f036-fb81-11e7-8189-cb197c64f276.png)

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
