### PR TITLE
Add timestamp for when publishers agree to the TOS

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -100,6 +100,10 @@ class PublishersController < ApplicationController
     @publisher = current_publisher
     update_params = publisher_complete_signup_params
 
+    if @publisher.agreed_to_tos.nil?
+      update_params[:agreed_to_tos] = Time.now
+    end
+
     if @publisher.update(update_params)
       # let eyeshade know about the new Publisher
       begin

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -97,7 +97,7 @@ class Publisher < ApplicationRecord
   end
 
   def verified?
-    email_verified? && name.present?
+    email_verified? && name.present? && agreed_to_tos.present?
   end
 
   def to_s

--- a/db/migrate/20180118022455_add_agreed_to_tos_to_publishers.rb
+++ b/db/migrate/20180118022455_add_agreed_to_tos_to_publishers.rb
@@ -1,0 +1,5 @@
+class AddAgreedToTosToPublishers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :publishers, :agreed_to_tos, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116200817) do
+ActiveRecord::Schema.define(version: 20180118022455) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 20180116200817) do
     t.datetime "updated_at",                                            null: false
     t.datetime "two_factor_prompted_at"
     t.boolean  "visible",                               default: true
+    t.datetime "agreed_to_tos"
     t.index ["created_at"], name: "index_publishers_on_created_at", using: :btree
     t.index ["email"], name: "index_publishers_on_email", unique: true, using: :btree
     t.index ["pending_email"], name: "index_publishers_on_pending_email", using: :btree

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -7,6 +7,7 @@ default: &default
   phone: "4159001420"
   phone_normalized: "+14159001420"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 verified:
@@ -15,6 +16,7 @@ verified:
   phone: "4159001421"
   phone_normalized: "+14159001421"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 # A publisher that has received an authentication email
@@ -32,6 +34,7 @@ completed:
     iv: salt
   ) %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 unprompted:
@@ -40,6 +43,7 @@ unprompted:
   phone: "4159001421"
   phone_normalized: "+14159001421"
   # two_factor_prompted_at: nil
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 stale:
@@ -47,6 +51,7 @@ stale:
   name: "Alice the Stale"
   phone: "4159001422"
   phone_normalized: "+14159001422"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 fake1:
@@ -54,6 +59,7 @@ fake1:
   name: "Fake Alice"
   phone: "4155551212"
   phone_normalized: "+14155551212"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 fake2:
@@ -61,6 +67,7 @@ fake2:
   name: "Fake Bob"
   phone: "4155551234"
   phone_normalized: "+14155551234"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 uphold_connected:
@@ -69,6 +76,7 @@ uphold_connected:
   phone: "4159001421"
   phone_normalized: "+14159001421"
   uphold_verified: true
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 youtube_initial:
@@ -76,6 +84,7 @@ youtube_initial:
   name: "Alice the Youtuber"
   phone: "4159001420"
   phone_normalized: "+14159001420"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 youtube_new:
@@ -83,6 +92,7 @@ youtube_new:
   name: "Alice the Youtuber"
   phone: "4159001420"
   phone_normalized: "+14159001420"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 google_verified:
@@ -90,6 +100,7 @@ google_verified:
   name: "Alice the Verified"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 global_media_group:
@@ -97,6 +108,7 @@ global_media_group:
   name: "Global Media Group"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
 small_media_group:
@@ -104,5 +116,6 @@ small_media_group:
   name: "Small Media Group"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -6,7 +6,7 @@ class PublisherTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
   include MailerTestHelper
 
-  test "verified publishers have both a name and email" do
+  test "verified publishers have both a name and email and have agreed to the TOS" do
     publisher = Publisher.new
     refute publisher.email_verified?
     refute publisher.verified?
@@ -16,6 +16,9 @@ class PublisherTest < ActiveSupport::TestCase
     refute publisher.verified?
 
     publisher.name = "Jane"
+    refute publisher.verified?
+
+    publisher.agreed_to_tos = 1.minute.ago
     assert publisher.verified?
   end
 


### PR DESCRIPTION
The `agreed_to_tos` timestamp marks the first time that a publisher has completed signup and thus explicitly agreed to the site’s TOS.

Publisher verification, and thus access to the dashboard, will be blocked on the presence of `agreed_to_tos`. Thus, all returning publishers will be presented with the complete signup page.

Closes #379 

attn: @ayumi 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
