### PR TITLE
Introduce publishers:transform_legacy_data rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ before_script:
 before_install:
   - # start your web application and listen on `localhost`
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+script:
+  - RAILS_ENV=test bin/rails test

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -45,6 +45,8 @@ class Publisher < ApplicationRecord
 
   scope :created_recently, -> { where("created_at > :start_date", start_date: 1.week.ago) }
 
+  scope :email_verified, -> { where.not(email: nil) }
+
   # publishers that have uphold codes that have been sitting for five minutes
   # can be cleared if publishers do not create wallet within 5 minute window
   scope :has_stale_uphold_code, -> {

--- a/db/migrate/20180112150747_rename_recreate_totp_u2f.rb
+++ b/db/migrate/20180112150747_rename_recreate_totp_u2f.rb
@@ -1,0 +1,30 @@
+class RenameRecreateTotpU2f < ActiveRecord::Migration[5.0]
+  def change
+    rename_table :totp_registrations, :legacy_totp_registrations
+    rename_table :u2f_registrations, :legacy_u2f_registrations
+
+    create_table "totp_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+      t.string   "encrypted_secret"
+      t.string   "encrypted_secret_iv"
+      t.uuid     "publisher_id"
+      t.datetime "last_logged_in_at"
+      t.datetime "created_at",          null: false
+      t.datetime "updated_at",          null: false
+      t.index ["publisher_id"], name: "index_totp_registrations_on_publisher_id", using: :btree
+    end
+
+    create_table "u2f_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+      t.text     "certificate"
+      t.string   "key_handle"
+      t.string   "public_key"
+      t.integer  "counter",      null: false
+      t.string   "name"
+      t.uuid     "publisher_id"
+      t.datetime "created_at",   null: false
+      t.datetime "updated_at",   null: false
+      t.index ["key_handle"], name: "index_u2f_registrations_on_key_handle", using: :btree
+      t.index ["publisher_id"], name: "index_u2f_registrations_on_publisher_id", using: :btree
+    end
+
+  end
+end

--- a/db/migrate/20180116180231_rename_recreate_statements.rb
+++ b/db/migrate/20180116180231_rename_recreate_statements.rb
@@ -1,0 +1,17 @@
+class RenameRecreateStatements < ActiveRecord::Migration[5.0]
+  def change
+    rename_table :publisher_statements, :legacy_publisher_statements
+
+    create_table "publisher_statements", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+      t.uuid     "publisher_id",          null: false
+      t.string   "period"
+      t.string   "source_url"
+      t.text     "encrypted_contents"
+      t.string   "encrypted_contents_iv"
+      t.datetime "expires_at"
+      t.datetime "created_at",            null: false
+      t.datetime "updated_at",            null: false
+      t.index ["publisher_id"], name: "index_publisher_statements_on_publisher_id", using: :btree
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,18 @@ ActiveRecord::Schema.define(version: 20180118022455) do
     t.index ["publisher_id"], name: "index_channels_on_publisher_id", using: :btree
   end
 
+  create_table "legacy_publisher_statements", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid     "publisher_id",          null: false
+    t.string   "period"
+    t.string   "source_url"
+    t.text     "encrypted_contents"
+    t.string   "encrypted_contents_iv"
+    t.datetime "expires_at"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.index ["publisher_id"], name: "index_legacy_publisher_statements_on_publisher_id", using: :btree
+  end
+
   create_table "legacy_publishers", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string   "brave_publisher_id"
     t.string   "name"
@@ -73,6 +85,29 @@ ActiveRecord::Schema.define(version: 20180118022455) do
     t.index ["verification_token"], name: "index_legacy_publishers_on_verification_token", using: :btree
     t.index ["verified"], name: "index_legacy_publishers_on_verified", using: :btree
     t.index ["youtube_channel_id"], name: "index_legacy_publishers_on_youtube_channel_id", using: :btree
+  end
+
+  create_table "legacy_totp_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string   "encrypted_secret"
+    t.string   "encrypted_secret_iv"
+    t.uuid     "publisher_id"
+    t.datetime "last_logged_in_at"
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.index ["publisher_id"], name: "index_legacy_totp_registrations_on_publisher_id", using: :btree
+  end
+
+  create_table "legacy_u2f_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.text     "certificate"
+    t.string   "key_handle"
+    t.string   "public_key"
+    t.integer  "counter",      null: false
+    t.string   "name"
+    t.uuid     "publisher_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["key_handle"], name: "index_legacy_u2f_registrations_on_key_handle", using: :btree
+    t.index ["publisher_id"], name: "index_legacy_u2f_registrations_on_publisher_id", using: :btree
   end
 
   create_table "legacy_youtube_channels", id: :string, force: :cascade do |t|

--- a/lib/legacy_data.rb
+++ b/lib/legacy_data.rb
@@ -1,0 +1,61 @@
+module LegacyData
+  class LegacyU2fRegistration < ActiveRecord::Base
+    belongs_to :legacy_publisher, foreign_key: :publisher_id
+  end
+
+  class LegacyTotpRegistration < ActiveRecord::Base
+    belongs_to :legacy_publisher, foreign_key: :publisher_id
+    attr_encrypted :secret, key: :encryption_key
+
+    def totp
+      ROTP::TOTP.new(secret, issuer: totp_issuer)
+    end
+
+    def encryption_key
+      self.class.encryption_key
+    end
+
+    class << self
+      def encryption_key
+        Rails.application.secrets[:attr_encrypted_key]
+      end
+    end
+
+    private
+
+    def totp_issuer
+      issuer = "Brave Payments"
+
+      environment = Rails.env
+      if %w(development staging).include?(environment)
+        issuer += " (#{environment.capitalize})"
+      end
+
+      issuer
+    end
+  end
+
+  class LegacyYoutubeChannel < ActiveRecord::Base
+  end
+
+  class LegacyPublisher < ActiveRecord::Base
+    attr_encrypted :authentication_token, key: :encryption_key
+    attr_encrypted :uphold_code, key: :encryption_key
+    attr_encrypted :uphold_access_parameters, key: :encryption_key
+
+    belongs_to :legacy_youtube_channel, foreign_key: :youtube_channel_id
+    has_many :legacy_u2f_registrations, -> { order("created_at DESC") }, foreign_key: :publisher_id
+    has_one :legacy_totp_registration, foreign_key: :publisher_id
+
+    scope :email_verified, -> {where.not(email: nil)}
+
+    scope :verified_sites, ->(email:) {where(email: email, verified: true, youtube_channel_id: nil).where.not(brave_publisher_id: nil)}
+    scope :unverified_sites, ->(email:) {where(email: email, verified: false, youtube_channel_id: nil).where.not(brave_publisher_id: nil)}
+
+    scope :verified_youtube, ->(email:) {where(email: email, verified: true, brave_publisher_id: nil).where.not(youtube_channel_id: nil)}
+
+    def encryption_key
+      Rails.application.secrets[:attr_encrypted_key]
+    end
+  end
+end

--- a/lib/legacy_data.rb
+++ b/lib/legacy_data.rb
@@ -5,44 +5,12 @@ module LegacyData
 
   class LegacyTotpRegistration < ActiveRecord::Base
     belongs_to :legacy_publisher, foreign_key: :publisher_id
-    attr_encrypted :secret, key: :encryption_key
-
-    def totp
-      ROTP::TOTP.new(secret, issuer: totp_issuer)
-    end
-
-    def encryption_key
-      self.class.encryption_key
-    end
-
-    class << self
-      def encryption_key
-        Rails.application.secrets[:attr_encrypted_key]
-      end
-    end
-
-    private
-
-    def totp_issuer
-      issuer = "Brave Payments"
-
-      environment = Rails.env
-      if %w(development staging).include?(environment)
-        issuer += " (#{environment.capitalize})"
-      end
-
-      issuer
-    end
   end
 
   class LegacyYoutubeChannel < ActiveRecord::Base
   end
 
   class LegacyPublisher < ActiveRecord::Base
-    attr_encrypted :authentication_token, key: :encryption_key
-    attr_encrypted :uphold_code, key: :encryption_key
-    attr_encrypted :uphold_access_parameters, key: :encryption_key
-
     belongs_to :legacy_youtube_channel, foreign_key: :youtube_channel_id
     has_many :legacy_u2f_registrations, -> { order("created_at DESC") }, foreign_key: :publisher_id
     has_one :legacy_totp_registration, foreign_key: :publisher_id
@@ -53,9 +21,5 @@ module LegacyData
     scope :unverified_sites, ->(email:) {where(email: email, verified: false, youtube_channel_id: nil).where.not(brave_publisher_id: nil)}
 
     scope :verified_youtube, ->(email:) {where(email: email, verified: true, brave_publisher_id: nil).where.not(youtube_channel_id: nil)}
-
-    def encryption_key
-      Rails.application.secrets[:attr_encrypted_key]
-    end
   end
 end

--- a/lib/tasks/temp/transform_legacy_data.rake
+++ b/lib/tasks/temp/transform_legacy_data.rake
@@ -1,0 +1,223 @@
+require "legacy_data"
+
+namespace :publishers do
+  desc "Import legacy publishers"
+  task :transform_legacy_data, [:commit] => [:environment] do |t, args|
+
+    extend LegacyData
+
+    unless args[:commit]
+      puts "Performing a trial run. Changes will be rolled back"
+    end
+
+    def separator
+      puts "------------------------------------\n"
+    end
+
+    # `totp_registrations` are a one-to-one relationship
+    # A Publisher/Owner should only have one TOTP active at a time
+    # If more than one per owner we won't import them automatically. Owners will be contacted and registrations will be imported
+    def add_totp_registration(owner, legacy_publisher)
+      totp_registration = legacy_publisher.legacy_totp_registration
+      return unless totp_registration
+
+      count_totp = LegacyData::LegacyTotpRegistration.joins(:legacy_publisher).where("legacy_publishers.email": legacy_publisher.email).count
+      if count_totp > 1
+        puts "Skipping totp import for #{legacy_publisher.email}. #{count_totp} records found."
+        return
+      end
+
+      params = {
+          secret: totp_registration.secret,
+          publisher_id: owner.id,
+          last_logged_in_at: totp_registration.last_logged_in_at,
+          created_at: totp_registration.created_at
+      }
+
+      new_totp_registration = TotpRegistration.new(params)
+      new_totp_registration.save!
+
+      puts "Imported totp registration: #{new_totp_registration.to_json}"
+    end
+
+    # `u2f_registrations` are a one-to-many relationship
+    # A Publisher/Owner may have any number of U2F keys registered. We are capable of de-duplicating U2F keys by `public_key`)
+    def add_u2f_registrations(owner, legacy_publisher)
+      legacy_publisher.legacy_u2f_registrations.each do |u2f_registration|
+        params = {
+            certificate: u2f_registration.certificate,
+            key_handle: u2f_registration.key_handle,
+            public_key: u2f_registration.public_key,
+            counter: u2f_registration.counter,
+            name: u2f_registration.name,
+            publisher_id: owner.id,
+            created_at: u2f_registration.created_at
+        }
+
+        new_u2f_registration = U2fRegistration.new(params)
+        new_u2f_registration.save!
+
+        puts "Imported u2f registration: #{new_u2f_registration.to_json}"
+      end
+    end
+
+    def add_site_channel(owner, legacy_publisher)
+      separator
+
+      if legacy_publisher.verified?
+        puts "Importing Verified site channel Id: #{legacy_publisher.id} Name: #{legacy_publisher.brave_publisher_id}"
+      else
+        puts "Importing Unverified site channel Id: #{legacy_publisher.id} Name: #{legacy_publisher.brave_publisher_id}"
+      end
+
+      existing_verfied_channel = Channel.joins(:site_channel_details).find_by(verified: true, "site_channel_details.brave_publisher_id": legacy_publisher.brave_publisher_id)
+      if existing_verfied_channel
+        puts "An existing verified channel was found for #{legacy_publisher.brave_publisher_id} - skipping"
+        return
+      end
+
+      channel_params = {
+          publisher_id: owner.id,
+          verified: legacy_publisher.verified,
+          created_at: legacy_publisher.created_at
+      }
+
+      detail_params = {
+          brave_publisher_id: legacy_publisher.brave_publisher_id,
+          verification_token: legacy_publisher.verification_token,
+          verification_method: legacy_publisher.verification_method,
+          supports_https: legacy_publisher.supports_https,
+          host_connection_verified: legacy_publisher.host_connection_verified,
+          detected_web_host: legacy_publisher.detected_web_host,
+          created_at: legacy_publisher.created_at
+      }
+
+      new_channel = Channel.new(channel_params)
+      new_channel.details = SiteChannelDetails.new(detail_params)
+      new_channel.save!
+
+      puts "Site channel created: #{new_channel.to_json(include: [:details, :publisher])}"
+    end
+
+    def add_youtube_channel(owner, legacy_publisher)
+      separator
+
+      puts "Importing youtube channel Id: #{legacy_publisher.id} Title: #{legacy_publisher.legacy_youtube_channel.title}"
+
+      existing_verfied_channel = Channel.joins(:youtube_channel_details).find_by(verified: true, "youtube_channel_details.youtube_channel_id": legacy_publisher.youtube_channel_id)
+      if existing_verfied_channel
+        puts "an existing verified channel was found for #{legacy_publisher.youtube_channel_id} - skipping"
+        return
+      end
+
+      channel_params = {
+          publisher_id: owner.id,
+          verified: legacy_publisher.verified,
+          created_at: legacy_publisher.created_at
+      }
+
+      detail_params = {
+          youtube_channel_id: legacy_publisher.youtube_channel_id,
+          auth_provider: legacy_publisher.auth_provider,
+          auth_user_id: legacy_publisher.auth_user_id,
+          auth_email: legacy_publisher.auth_email,
+          auth_name: legacy_publisher.auth_name,
+          title: legacy_publisher.legacy_youtube_channel.title,
+          description: legacy_publisher.legacy_youtube_channel.description,
+          thumbnail_url: legacy_publisher.legacy_youtube_channel.thumbnail_url,
+          subscriber_count: legacy_publisher.legacy_youtube_channel.subscriber_count,
+          created_at: legacy_publisher.created_at
+      }
+
+      new_channel = Channel.new(channel_params)
+      new_channel.details = YoutubeChannelDetails.new(detail_params)
+      new_channel.save!
+
+      puts "Youtube channel created: #{new_channel.to_json(include: [:details, :publisher])}"
+    end
+
+    puts "Going to transform #{LegacyData::LegacyPublisher.email_verified.count} email verified out of #{LegacyData::LegacyPublisher.count} legacy publishers"
+
+    ActiveRecord::Base.transaction do
+      new_owner_count = 0
+      new_verified_site_channel_count = 0
+      new_unverified_site_channel_count = 0
+      new_youtube_channel_count = 0
+
+      # Create or update an Owner for all verified email addresses, rolling up details
+      LegacyData::LegacyPublisher.email_verified.order(created_at: :asc).each_with_index do |legacy_publisher, idx|
+        separator
+        puts "Importing publisher #{idx} Id: #{legacy_publisher.id} Name: #{legacy_publisher.name}"
+
+        # Create the new owner or update an existing owner if it already exists.
+        owner = Publisher.find_by(email: legacy_publisher.email)
+        if owner
+          puts "Found existing owner - using instead"
+        else
+          owner = Publisher.new(email: legacy_publisher.email)
+          new_owner_count = new_owner_count + 1
+        end
+
+        params = {
+            name: owner.name || legacy_publisher.name,
+            phone: owner.phone || legacy_publisher.phone,
+            created_via_api: owner.created_via_api || legacy_publisher.created_via_api,
+            default_currency: owner.default_currency || legacy_publisher.default_currency,
+            uphold_state_token: owner.uphold_state_token || legacy_publisher.uphold_state_token,
+            uphold_verified: owner.uphold_verified || legacy_publisher.uphold_verified,
+            created_at: legacy_publisher.created_at,
+            visible: owner.visible && legacy_publisher.show_verification_status
+        }
+
+        owner.update!(params)
+        puts "Owner: #{owner.to_json}"
+
+        add_u2f_registrations(owner, legacy_publisher)
+        add_totp_registration(owner, legacy_publisher)
+      end
+
+      separator
+      puts "Importing legacy publishers to channels"
+
+      # Loop through all Publishers (owners) and look for legacy channels to import
+      Publisher.email_verified.each_with_index do |owner, idx|
+        # Create a channel for all verified Site Publishers
+
+        LegacyData::LegacyPublisher.verified_sites(email: owner.email).each do |legacy_publisher|
+          add_site_channel(owner, legacy_publisher)
+          new_verified_site_channel_count = new_verified_site_channel_count + 1
+        end
+
+        # Get latest unverified Site Publishers, grouped by email and domain ordered by created_at
+        unverified_sites = LegacyData::LegacyPublisher.unverified_sites(email: owner.email).group([:email, :brave_publisher_id]).pluck(:email, :brave_publisher_id, 'MAX("created_at")')
+
+        unverified_sites.each do |unverfied_site|
+          legacy_publisher = LegacyData::LegacyPublisher.find_by(email: unverfied_site[0], brave_publisher_id: unverfied_site[1], created_at: unverfied_site[2])
+          add_site_channel(owner, legacy_publisher)
+          new_unverified_site_channel_count = new_unverified_site_channel_count + 1
+        end
+
+        # Create a channel for each Youtube publisher
+        LegacyData::LegacyPublisher.joins(:legacy_youtube_channel).verified_youtube(email: owner.email).each do |legacy_publisher|
+          add_youtube_channel(owner, legacy_publisher)
+          new_youtube_channel_count = new_youtube_channel_count + 1
+        end
+      end
+
+      separator
+      puts "#{new_owner_count} Owners created"
+      puts "#{new_verified_site_channel_count} verified Site Channels created"
+      puts "#{new_unverified_site_channel_count} unverified Site Channels created"
+      puts "#{new_youtube_channel_count} Youtube Channels created"
+
+      unless args[:commit]
+        separator
+        puts "Trial Run: Rolling Back"
+
+        raise ActiveRecord::Rollback, "Trial Run: Rolling Back"
+      else
+        puts "Publishers data has been migrated to owners and channels"
+      end
+    end
+  end
+end

--- a/lib/tasks/temp/transform_legacy_data.rake
+++ b/lib/tasks/temp/transform_legacy_data.rake
@@ -1,9 +1,8 @@
-require "legacy_data"
-
 namespace :publishers do
   desc "Import legacy publishers"
   task :transform_legacy_data, [:commit] => [:environment] do |t, args|
 
+    require "legacy_data"
     extend LegacyData
 
     unless args[:commit]
@@ -28,7 +27,8 @@ namespace :publishers do
       end
 
       params = {
-          secret: totp_registration.secret,
+          encrypted_secret: totp_registration.encrypted_secret,
+          encrypted_secret_iv: totp_registration.encrypted_secret_iv,
           publisher_id: owner.id,
           last_logged_in_at: totp_registration.last_logged_in_at,
           created_at: totp_registration.created_at
@@ -163,8 +163,8 @@ namespace :publishers do
             phone: owner.phone || legacy_publisher.phone,
             created_via_api: owner.created_via_api || legacy_publisher.created_via_api,
             default_currency: owner.default_currency || legacy_publisher.default_currency,
-            uphold_state_token: owner.uphold_state_token || legacy_publisher.uphold_state_token,
             uphold_verified: owner.uphold_verified || legacy_publisher.uphold_verified,
+            uphold_updated_at: owner.uphold_updated_at || legacy_publisher.uphold_updated_at,
             created_at: legacy_publisher.created_at,
             visible: owner.visible && legacy_publisher.show_verification_status
         }

--- a/test/tasks/transform_legacy_data_test.rb
+++ b/test/tasks/transform_legacy_data_test.rb
@@ -37,14 +37,12 @@ class TransformLegacyDataTest < ActiveJob::TestCase
             last_sign_in_at: "2017-11-28 12:10:45",
             phone: "6035551212",
             phone_normalized: "\+16035551212",
-            authentication_token: "asdfg",
+            encrypted_authentication_token: "asdfg",
+            encrypted_authentication_token_iv: "asdfg_iv",
             verification_method: "wordpress",
             authentication_token_expires_at: "2017-11-30 10:20:30",
             show_verification_status: false,
             created_via_api: false,
-            uphold_state_token: "UPHOLDSTATETOKEN",
-            uphold_code: nil,
-            uphold_access_parameters: nil,
             uphold_verified: true,
             pending_email: "new_user@company.com",
             supports_https: true,
@@ -67,10 +65,10 @@ class TransformLegacyDataTest < ActiveJob::TestCase
       assert_equal "\+16035551212", pub.phone_normalized
 
       assert_equal Time.zone.parse("2017-11-28 10:11:12"), pub.created_at
-      assert_equal "UPHOLDSTATETOKEN", pub.uphold_state_token
       assert pub.uphold_verified
       assert_equal "BAT",  pub.default_currency
       refute pub.visible
+      assert_equal Time.zone.parse("2017-11-30 20:30:40"), pub.uphold_updated_at
 
       # not carried over
       refute_equal Time.zone.parse("2017-11-28 12:10:45"), pub.updated_at
@@ -80,8 +78,6 @@ class TransformLegacyDataTest < ActiveJob::TestCase
       assert_nil pub.authentication_token
       assert_nil pub.authentication_token_expires_at
       assert_nil pub.pending_email
-      # uphold_updated_at auto set
-      assert pub.uphold_updated_at
       refute pub.created_via_api
       assert_nil pub.uphold_code
       assert_nil pub.uphold_access_parameters
@@ -103,14 +99,12 @@ class TransformLegacyDataTest < ActiveJob::TestCase
             last_sign_in_at: "2017-11-28 12:10:45",
             phone: "6035551212",
             phone_normalized: "\+16035551212",
-            authentication_token: "asdfg",
+            encrypted_authentication_token: "asdfg",
+            encrypted_authentication_token_iv: "asdfg_iv",
             verification_method: "wordpress",
             authentication_token_expires_at: "2017-11-30 10:20:30",
             show_verification_status: true,
             created_via_api: false,
-            uphold_state_token: nil,
-            uphold_code: nil,
-            uphold_access_parameters: nil,
             uphold_verified: false,
             pending_email: "new_user@company.com",
             supports_https: true,
@@ -119,7 +113,7 @@ class TransformLegacyDataTest < ActiveJob::TestCase
             default_currency: "BAT",
             brave_publisher_id_unnormalized: "COMPANY.COM",
             brave_publisher_id_error_code: nil,
-            uphold_updated_at: "2017-11-30 20:30:40"
+            uphold_updated_at: nil
         }
     ).save!
 
@@ -137,6 +131,7 @@ class TransformLegacyDataTest < ActiveJob::TestCase
       refute pub.uphold_verified
       assert_equal "BAT", pub.default_currency
       assert pub.visible
+      assert_nil pub.uphold_updated_at
 
       # not carried over
       refute_equal Time.zone.parse("2017-11-28 12:10:45"), pub.updated_at
@@ -146,8 +141,6 @@ class TransformLegacyDataTest < ActiveJob::TestCase
       assert_nil pub.authentication_token
       assert_nil pub.authentication_token_expires_at
       assert_nil pub.pending_email
-      # uphold_updated_at auto set
-      assert_nil pub.uphold_updated_at
       refute pub.created_via_api
       assert_nil pub.uphold_code
       assert_nil pub.uphold_access_parameters
@@ -169,14 +162,12 @@ class TransformLegacyDataTest < ActiveJob::TestCase
             last_sign_in_at: "2017-11-28 12:10:45",
             phone: "6035551212",
             phone_normalized: "\+16035551212",
-            authentication_token: "asdfg",
+            encrypted_authentication_token: "asdfg",
+            encrypted_authentication_token_iv: "asdfg_iv",
             verification_method: "wordpress",
             authentication_token_expires_at: "2017-11-30 10:20:30",
             show_verification_status: false,
             created_via_api: false,
-            uphold_state_token: "UPHOLDSTATETOKEN",
-            uphold_code: nil,
-            uphold_access_parameters: nil,
             uphold_verified: true,
             pending_email: "new_user@company.com",
             supports_https: true,
@@ -215,14 +206,12 @@ class TransformLegacyDataTest < ActiveJob::TestCase
             last_sign_in_at: "2017-11-28 12:10:45",
             phone: "6035551212",
             phone_normalized: "\+16035551212",
-            authentication_token: "asdfg",
+            encrypted_authentication_token: "asdfg",
+            encrypted_authentication_token_iv: "asdfg_iv",
             verification_method: "wordpress",
             authentication_token_expires_at: "2017-11-30 10:20:30",
             show_verification_status: false,
             created_via_api: false,
-            uphold_state_token: "UPHOLDSTATETOKEN",
-            uphold_code: nil,
-            uphold_access_parameters: nil,
             uphold_verified: true,
             pending_email: "new_user@company.com",
             supports_https: true,
@@ -277,12 +266,10 @@ class TransformLegacyDataTest < ActiveJob::TestCase
             last_sign_in_at: "2017-11-28 12:10:45",
             phone: "6035551212",
             phone_normalized: "\+16035551212",
-            authentication_token: "asdfg",
+            encrypted_authentication_token: "asdfg",
+            encrypted_authentication_token_iv: "asdfg_iv",
             authentication_token_expires_at: "2017-11-30 10:20:30",
             created_via_api: false,
-            uphold_state_token: "UPHOLDSTATETOKEN",
-            uphold_code: nil,
-            uphold_access_parameters: nil,
             uphold_verified: true,
             pending_email: "new_user@company.com",
             default_currency: "BAT",
@@ -432,7 +419,8 @@ class TransformLegacyDataTest < ActiveJob::TestCase
     LegacyData::LegacyTotpRegistration.new(
         {
             publisher_id: leg_pub.id,
-            secret: "this is a secret",
+            encrypted_secret: "this is a secret",
+            encrypted_secret_iv: "this is a secret_iv",
             last_logged_in_at: "2017-11-30 10:20:30"
         }
     ).save!
@@ -444,7 +432,8 @@ class TransformLegacyDataTest < ActiveJob::TestCase
       publisher = Publisher.find_by(email: "user@company.com")
 
       registration = publisher.totp_registration
-      assert_equal "this is a secret", registration.secret
+      assert_equal "this is a secret", registration.encrypted_secret
+      assert_equal "this is a secret_iv", registration.encrypted_secret_iv
       assert_equal Time.zone.parse("2017-11-30 10:20:30"), registration.last_logged_in_at
     end
   end
@@ -456,7 +445,8 @@ class TransformLegacyDataTest < ActiveJob::TestCase
     LegacyData::LegacyTotpRegistration.new(
         {
             publisher_id: leg_pub.id,
-            secret: "this is a secret",
+            encrypted_secret: "this is a secret",
+            encrypted_secret_iv: "this is a secret_iv",
             last_logged_in_at: "2017-11-30 10:20:30"
         }
     ).save!
@@ -467,7 +457,8 @@ class TransformLegacyDataTest < ActiveJob::TestCase
     LegacyData::LegacyTotpRegistration.new(
         {
             publisher_id: leg_pub.id,
-            secret: "this is secret two",
+            encrypted_secret: "this is secret two",
+            encrypted_secret_iv: "this is secret two_iv",
             last_logged_in_at: "2017-12-30 10:20:30"
         }
     ).save!

--- a/test/tasks/transform_legacy_data_test.rb
+++ b/test/tasks/transform_legacy_data_test.rb
@@ -1,0 +1,484 @@
+require "test_helper"
+require "rake/testtask"
+require "legacy_data"
+
+class TransformLegacyDataTest < ActiveJob::TestCase
+  extend LegacyData
+
+  before do
+    require 'rake'
+    load File.expand_path("../../../lib/tasks/temp/transform_legacy_data.rake", __FILE__)
+
+    Rake::Task.define_task :environment
+
+    # Redirect stdout to silence output
+    @original_stdout = $stdout
+    $stdout = File.open(File::NULL, "w")
+  end
+
+  after do
+    Rake::Task.clear
+    # Reenable output
+    $stdout = @original_stdout
+  end
+
+  test "imports publishers - uphold verified" do
+    LegacyData::LegacyPublisher.new(
+        {
+            brave_publisher_id: "company.com",
+            name: "NAME",
+            email: "user@company.com",
+            verification_token: "VERIFICATION_TOKEN",
+            verified: true,
+            created_at: "2017-11-28 10:11:12",
+            updated_at: "2017-11-28 12:10:45",
+            sign_in_count: 123,
+            current_sign_in_at: "2017-11-28 12:10:45",
+            last_sign_in_at: "2017-11-28 12:10:45",
+            phone: "6035551212",
+            phone_normalized: "\+16035551212",
+            authentication_token: "asdfg",
+            verification_method: "wordpress",
+            authentication_token_expires_at: "2017-11-30 10:20:30",
+            show_verification_status: false,
+            created_via_api: false,
+            uphold_state_token: "UPHOLDSTATETOKEN",
+            uphold_code: nil,
+            uphold_access_parameters: nil,
+            uphold_verified: true,
+            pending_email: "new_user@company.com",
+            supports_https: true,
+            host_connection_verified: true,
+            detected_web_host: "wordpress",
+            default_currency: "BAT",
+            brave_publisher_id_unnormalized: "COMPANY.COM",
+            brave_publisher_id_error_code: nil,
+            uphold_updated_at: "2017-11-30 20:30:40"
+        }
+    ).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      pub = Publisher.find_by(email: "user@company.com")
+      assert_equal "NAME", pub.name
+      assert_equal "user@company.com", pub.email
+      assert_equal "6035551212", pub.phone
+      assert_equal "\+16035551212", pub.phone_normalized
+
+      assert_equal Time.zone.parse("2017-11-28 10:11:12"), pub.created_at
+      assert_equal "UPHOLDSTATETOKEN", pub.uphold_state_token
+      assert pub.uphold_verified
+      assert_equal "BAT",  pub.default_currency
+      refute pub.visible
+
+      # not carried over
+      refute_equal Time.zone.parse("2017-11-28 12:10:45"), pub.updated_at
+      assert_equal 0, pub.sign_in_count
+      assert_nil pub.current_sign_in_at
+      assert_nil pub.last_sign_in_at
+      assert_nil pub.authentication_token
+      assert_nil pub.authentication_token_expires_at
+      assert_nil pub.pending_email
+      # uphold_updated_at auto set
+      assert pub.uphold_updated_at
+      refute pub.created_via_api
+      assert_nil pub.uphold_code
+      assert_nil pub.uphold_access_parameters
+    end
+  end
+
+  test "imports publishers - NOT uphold verified" do
+    LegacyData::LegacyPublisher.new(
+        {
+            brave_publisher_id: "company.com",
+            name: "NAME",
+            email: "user@company.com",
+            verification_token: "VERIFICATION_TOKEN",
+            verified: true,
+            created_at: "2017-11-28 10:11:12",
+            updated_at: "2017-11-28 12:10:45",
+            sign_in_count: 123,
+            current_sign_in_at: "2017-11-28 12:10:45",
+            last_sign_in_at: "2017-11-28 12:10:45",
+            phone: "6035551212",
+            phone_normalized: "\+16035551212",
+            authentication_token: "asdfg",
+            verification_method: "wordpress",
+            authentication_token_expires_at: "2017-11-30 10:20:30",
+            show_verification_status: true,
+            created_via_api: false,
+            uphold_state_token: nil,
+            uphold_code: nil,
+            uphold_access_parameters: nil,
+            uphold_verified: false,
+            pending_email: "new_user@company.com",
+            supports_https: true,
+            host_connection_verified: true,
+            detected_web_host: "wordpress",
+            default_currency: "BAT",
+            brave_publisher_id_unnormalized: "COMPANY.COM",
+            brave_publisher_id_error_code: nil,
+            uphold_updated_at: "2017-11-30 20:30:40"
+        }
+    ).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      pub = Publisher.find_by(email: "user@company.com")
+      assert_equal "NAME", pub.name
+      assert_equal "user@company.com", pub.email
+      assert_equal "6035551212", pub.phone
+      assert_equal "\+16035551212", pub.phone_normalized
+
+      assert_equal Time.zone.parse("2017-11-28 10:11:12"), pub.created_at
+      assert_nil pub.uphold_state_token
+      refute pub.uphold_verified
+      assert_equal "BAT", pub.default_currency
+      assert pub.visible
+
+      # not carried over
+      refute_equal Time.zone.parse("2017-11-28 12:10:45"), pub.updated_at
+      assert_equal 0, pub.sign_in_count
+      assert_nil pub.current_sign_in_at
+      assert_nil pub.last_sign_in_at
+      assert_nil pub.authentication_token
+      assert_nil pub.authentication_token_expires_at
+      assert_nil pub.pending_email
+      # uphold_updated_at auto set
+      assert_nil pub.uphold_updated_at
+      refute pub.created_via_api
+      assert_nil pub.uphold_code
+      assert_nil pub.uphold_access_parameters
+    end
+  end
+
+  test "imports channel" do
+    LegacyData::LegacyPublisher.new(
+        {
+            brave_publisher_id: "company.com",
+            name: "NAME",
+            email: "user@company.com",
+            verification_token: "VERIFICATION_TOKEN",
+            verified: true,
+            created_at: "2017-11-28 10:11:12",
+            updated_at: "2017-11-28 12:10:45",
+            sign_in_count: 123,
+            current_sign_in_at: "2017-11-28 12:10:45",
+            last_sign_in_at: "2017-11-28 12:10:45",
+            phone: "6035551212",
+            phone_normalized: "\+16035551212",
+            authentication_token: "asdfg",
+            verification_method: "wordpress",
+            authentication_token_expires_at: "2017-11-30 10:20:30",
+            show_verification_status: false,
+            created_via_api: false,
+            uphold_state_token: "UPHOLDSTATETOKEN",
+            uphold_code: nil,
+            uphold_access_parameters: nil,
+            uphold_verified: true,
+            pending_email: "new_user@company.com",
+            supports_https: true,
+            host_connection_verified: true,
+            detected_web_host: "wordpress",
+            default_currency: "BAT",
+            brave_publisher_id_unnormalized: "COMPANY.COM",
+            brave_publisher_id_error_code: nil,
+            uphold_updated_at: "2017-11-30 20:30:40"
+        }
+    ).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      pub = Publisher.find_by(email: "user@company.com")
+      channel = pub.channels[0]
+
+      assert_equal true, channel.verified
+      assert_equal Time.zone.parse("2017-11-28 10:11:12"), channel.created_at
+    end
+  end
+
+  test "imports site channel details" do
+    LegacyData::LegacyPublisher.new(
+        {
+            brave_publisher_id: "company.com",
+            name: "NAME",
+            email: "user@company.com",
+            verification_token: "VERIFICATION_TOKEN",
+            verified: true,
+            created_at: "2017-11-28 10:11:12",
+            updated_at: "2017-11-28 12:10:45",
+            sign_in_count: 123,
+            current_sign_in_at: "2017-11-28 12:10:45",
+            last_sign_in_at: "2017-11-28 12:10:45",
+            phone: "6035551212",
+            phone_normalized: "\+16035551212",
+            authentication_token: "asdfg",
+            verification_method: "wordpress",
+            authentication_token_expires_at: "2017-11-30 10:20:30",
+            show_verification_status: false,
+            created_via_api: false,
+            uphold_state_token: "UPHOLDSTATETOKEN",
+            uphold_code: nil,
+            uphold_access_parameters: nil,
+            uphold_verified: true,
+            pending_email: "new_user@company.com",
+            supports_https: true,
+            host_connection_verified: true,
+            detected_web_host: "wordpress",
+            default_currency: "BAT",
+            brave_publisher_id_unnormalized: "COMPANY.COM",
+            brave_publisher_id_error_code: nil,
+            uphold_updated_at: "2017-11-30 20:30:40"
+        }
+    ).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      pub = Publisher.find_by(email: "user@company.com")
+      details = pub.channels[0].details
+
+      assert details.is_a?(SiteChannelDetails)
+      assert_equal "company.com", details.brave_publisher_id
+      assert_equal "VERIFICATION_TOKEN", details.verification_token
+      assert_equal "wordpress", details.verification_method
+      assert details.supports_https
+      assert details.host_connection_verified
+      assert_equal "wordpress", details.detected_web_host
+      assert_equal Time.zone.parse("2017-11-28 10:11:12"), details.created_at
+    end
+  end
+
+  test "imports youtube channel details" do
+    LegacyData::LegacyYoutubeChannel.new(
+        {
+            id: "YTC1289",
+            title: "Funny Cats",
+            description: "More funny cats than you can stand",
+            thumbnail_url: "http://icons.com/cats.jpg",
+            subscriber_count: 4500000
+        }
+    ).save!
+
+    LegacyData::LegacyPublisher.new(
+        {
+            # brave_publisher_id: "company.com",
+            name: "NAME",
+            email: "user@company.com",
+            # verification_token: "VERIFICATION_TOKEN",
+            verified: true,
+            created_at: "2017-11-28 10:11:12",
+            updated_at: "2017-11-28 12:10:45",
+            sign_in_count: 123,
+            current_sign_in_at: "2017-11-28 12:10:45",
+            last_sign_in_at: "2017-11-28 12:10:45",
+            phone: "6035551212",
+            phone_normalized: "\+16035551212",
+            authentication_token: "asdfg",
+            authentication_token_expires_at: "2017-11-30 10:20:30",
+            created_via_api: false,
+            uphold_state_token: "UPHOLDSTATETOKEN",
+            uphold_code: nil,
+            uphold_access_parameters: nil,
+            uphold_verified: true,
+            pending_email: "new_user@company.com",
+            default_currency: "BAT",
+            auth_provider: "google_oauth2",
+            auth_user_id: "105659544661947994134",
+            auth_name: "Some Name",
+            auth_email: "random.email@google.com",
+            youtube_channel_id: "YTC1289",
+            uphold_updated_at: "2017-11-30 20:30:40"
+        }
+    ).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      pub = Publisher.find_by(email: "user@company.com")
+      details = pub.channels[0].details
+
+      assert details.is_a?(YoutubeChannelDetails)
+      assert pub.channels[0].verified
+      assert_equal "google_oauth2", details.auth_provider
+      assert_equal "105659544661947994134", details.auth_user_id
+      assert_equal "Some Name", details.auth_name
+      assert_equal "random.email@google.com", details.auth_email
+      assert_equal "YTC1289", details.youtube_channel_id
+      assert_equal "Funny Cats", details.title
+      assert_equal "More funny cats than you can stand", details.description
+      assert_equal "http://icons.com/cats.jpg", details.thumbnail_url
+      assert_equal 4500000, details.subscriber_count
+    end
+  end
+
+  test "converts email_verified publishers to unique owners and many channels" do
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site1.com"}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site2.com"}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site3.com"}).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      assert_equal 3, Publisher.find_by(email: "user@company.com").channels.count
+    end
+  end
+
+  test "consolidates site and youtube channels" do
+    LegacyData::LegacyYoutubeChannel.new({id: "123456", title: "My Channel", thumbnail_url: "http://foo.com"}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, youtube_channel_id: "123456",
+                                     auth_user_id: "asdfg", auth_name: "fred", auth_provider: "google_oauth2", auth_email: "a@a.com"}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site2.com"}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site3.com"}).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      assert_equal 3, Publisher.find_by(email: "user@company.com").channels.count
+      channel_details = YoutubeChannelDetails.find_by(youtube_channel_id: "123456")
+      publisher = Publisher.find_by(email: "user@company.com")
+      assert_equal publisher.id, channel_details.channel.publisher.id
+    end
+  end
+
+  test "when consolidating many channels visible is true if all channels show_verification_status" do
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site1.com", show_verification_status: true}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site2.com", show_verification_status: true}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site3.com", show_verification_status: true}).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      assert Publisher.find_by(email: "user@company.com").visible
+    end
+  end
+
+  test "when consolidating many channels visible is false if any channels do not show_verification_status" do
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site1.com", show_verification_status: true}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site2.com", show_verification_status: false}).save!
+    LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site3.com", show_verification_status: true}).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      refute Publisher.find_by(email: "user@company.com").visible
+    end
+  end
+
+  test "brings over a u2f_registration" do
+    leg_pub = LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site1.com"})
+    leg_pub.save!
+
+    LegacyData::LegacyU2fRegistration.new(
+        {
+            publisher_id: leg_pub.id,
+            name: "aa",
+            certificate: "cert",
+            counter: 1,
+            key_handle: "KEYHANDLE",
+            public_key: "PUBLICKEY"
+
+        }).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      publisher = Publisher.find_by(email: "user@company.com")
+      assert_equal 1, publisher.u2f_registrations.count
+      registration = publisher.u2f_registrations[0]
+
+      assert_equal "aa", registration.name
+      assert_equal "cert", registration.certificate
+      assert_equal 1, registration.counter
+      assert_equal "KEYHANDLE", registration.key_handle
+      assert_equal "PUBLICKEY", registration.public_key
+    end
+  end
+
+  test "brings over u2f_registrations from multiple publishers" do
+    leg_pub = LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site1.com"})
+    leg_pub.save!
+    LegacyData::LegacyU2fRegistration.new({publisher_id: leg_pub.id, name: "aa", certificate: "cert", counter: 1}).save!
+    leg_pub = LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site2.com"})
+    leg_pub.save!
+
+    LegacyData::LegacyU2fRegistration.new({publisher_id: leg_pub.id, name: "bb", certificate: "cert2", counter: 2}).save!
+    LegacyData::LegacyU2fRegistration.new({publisher_id: leg_pub.id, name: "cc", certificate: "cert3", counter: 3}).save!
+
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      assert_equal 2, Publisher.find_by(email: "user@company.com").channels.count
+
+      publisher = Publisher.find_by(email: "user@company.com")
+      assert_equal 3, publisher.u2f_registrations.count
+    end
+  end
+
+  test "brings over a totp_registration" do
+    leg_pub = LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site1.com"})
+    leg_pub.save!
+
+    LegacyData::LegacyTotpRegistration.new(
+        {
+            publisher_id: leg_pub.id,
+            secret: "this is a secret",
+            last_logged_in_at: "2017-11-30 10:20:30"
+        }
+    ).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      publisher = Publisher.find_by(email: "user@company.com")
+
+      registration = publisher.totp_registration
+      assert_equal "this is a secret", registration.secret
+      assert_equal Time.zone.parse("2017-11-30 10:20:30"), registration.last_logged_in_at
+    end
+  end
+
+  test "does not bring over any totp_registrations if more than one is found for an owner" do
+    leg_pub = LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site1.com"})
+    leg_pub.save!
+
+    LegacyData::LegacyTotpRegistration.new(
+        {
+            publisher_id: leg_pub.id,
+            secret: "this is a secret",
+            last_logged_in_at: "2017-11-30 10:20:30"
+        }
+    ).save!
+
+    leg_pub = LegacyData::LegacyPublisher.new({email: "user@company.com", verified: true, brave_publisher_id: "site2.com"})
+    leg_pub.save!
+
+    LegacyData::LegacyTotpRegistration.new(
+        {
+            publisher_id: leg_pub.id,
+            secret: "this is secret two",
+            last_logged_in_at: "2017-12-30 10:20:30"
+        }
+    ).save!
+
+    Rake::Task["publishers:transform_legacy_data"].invoke("[:commit]")
+
+    Rake::TestTask.new do
+      assert_equal 1, Publisher.where(email: "user@company.com").count
+      publisher = Publisher.find_by(email: "user@company.com")
+
+      assert_nil publisher.totp_registration
+    end
+  end
+end


### PR DESCRIPTION
This rake task transforms the legacy publishers data to owners and channels. Legacy publishers which share an email address are consolidated to a single Publisher (Owner) record.

Each legacy publisher is also migrated to a channel associated with the common Owner created above. Channel type is either site or youtube.

* Sessions are being dropped.

* U2F registrations from all channels owned by the same owner are recreated with the owner.

* Existing Totp registrations are moved over only if there is a single one across the owner space.

An Owner's `visible` status is set to true if all the rolled up legacy publishers `show_verification_status` flags were true.

The rake task runs in a dry run mode unless the `commit` flag is provided:
```bash
bin/rake publishers:transform_legacy_data

Performing a trial run. Changes will be rolled back
Going to transform 46 email verified out of 155 legacy publishers
------------------------------------
Importing publisher 0 Id: 01b64ade-b5d1-4f75-8916-686da52c8a00 Name: 
...
------------------------------------
16 Owners created
10 verified Site Channels created
5 unverified Site Channels created
13 Youtube Channels created
------------------------------------
Trial Run: Rolling Back

```

```bash
bin/rake publishers:transform_legacy_data[commit]

Going to transform 46 email verified out of 155 legacy publishers
------------------------------------
Importing publisher 0 Id: 01b64ade-b5d1-4f75-8916-686da52c8a00 Name: 
...
------------------------------------
16 Owners created
10 verified Site Channels created
5 unverified Site Channels created
13 Youtube Channels created
------------------------------------
Publishers data has been migrated to owners and channels

```

JSON representations of the objects being created is output during the run to aid in troubleshooting.

Fixes #477

Ideally this will be run against a copy of the production data and results should be carefully inspected.

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
