### PR TITLE
Custom navbar for adding site channels

### DIFF
--- a/app/assets/stylesheets/application/site_channels.sass
+++ b/app/assets/stylesheets/application/site_channels.sass
@@ -47,6 +47,11 @@ $progress-train-active: #333
         .inner-circle
           fill: $progress-train-fill
 
+.navbar-brand.page-title
+  color: $progress-train-fill
+  &:hover
+    color: $progress-train-fill
+
 body
   &[data-action="verification_choose_method"]
     .content-panel

--- a/app/views/site_channels/_nav.html.slim
+++ b/app/views/site_channels/_nav.html.slim
@@ -1,0 +1,12 @@
+nav.navbar.navbar-default.navbar-static-top.top-nav-collapse
+  .container-fluid
+    .menu-container
+      .nav.pull-right
+        = link_to(I18n.t("shared.cancel"), home_publishers_path, class: 'btn btn-secondary btn-highlight btn-cancel pull-right')
+
+      .nav.pull-left
+        / = link_to(root_path) do
+        .navbar-brand.page-title= t "publishers.add_channel"
+
+      .text-center
+        = yield(:navbar_content)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
       security: Security
       log_out: Log Out
   publishers:
+    add_channel: "Add Channel"
     add_channel_cta: "Add a website or YouTube channel to see how much your fans on Brave have contributed so far."
     app_title: "Brave Payments"
     already_logged_in: "You can't do that because you have an active session. Please exit or clear your cookies."


### PR DESCRIPTION
Reworks the navbar in accordance with @jenn-rhim’s requests in #383:

* Show `Add Channel` on the left in place of `Brave Payments`. This is now text and not a link.
* Removes the login panel on the right in place of a `Cancel` button that returns you to the dashboard.

Does not attempt to rework the progress train settings because more clarification is needed. There are unspecified states in #383 during the verification process.

![screen shot 2018-01-19 at 4 56 03 pm](https://user-images.githubusercontent.com/29122/35173991-a8553104-fd3b-11e7-92b7-70dbcd33bc1d.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
