### PR TITLE
Regress Puma to 3.10 to fix “no implicit conversion of nil into String”

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "phony_rails", "~> 0.14"
 gem "premailer-rails", "~> 1.9.4", require: false
 
 # Puma as app server
-gem "puma", "~> 3.11"
+gem "puma", "3.10"
 
 gem "rails", "~> 5.0.0", ">= 5.0.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
       byebug (~> 9.1)
       pry (~> 0.10)
     public_suffix (3.0.1)
-    puma (3.11.0)
+    puma (3.10.0)
     rack (2.0.3)
     rack-attack (5.0.1)
       rack
@@ -410,7 +410,7 @@ DEPENDENCIES
   premailer-rails (~> 1.9.4)
   pry
   pry-byebug
-  puma (~> 3.11)
+  puma (= 3.10)
   rack-attack (~> 5.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   recaptcha (~> 3.3)
@@ -436,4 +436,4 @@ RUBY VERSION
    ruby 2.3.6p384
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Getting “no implicit conversion of nil into String” messages from puma. Looks like this is an issue introduced in 3.11 per https://github.com/puma/puma/issues/1483, https://github.com/puma/puma/issues/1502

I'm not entirely sure it's causing a real issue, but it is a nuisance.  I propose we regress to 3.10 until this is fixed.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))