### PR TITLE
Add Bootstrap 4 styling for login alert

### DIFF
--- a/app/assets/stylesheets/_bootstrap-config.scss
+++ b/app/assets/stylesheets/_bootstrap-config.scss
@@ -13,13 +13,16 @@ $gray-800: $braveGray-3;
 $gray-900: $braveGray-2;
 $black:    $braveGray-1;
 
+$primary: $braveBrand;
+
+// Body
+
+$body-color: $braveGray-3;
+
 // Fonts
 
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $font-family-base: "Muli", $font-family-sans-serif;
-$body-color: $braveGray-3;
-
-$link-color: $braveAction;
 
 $font-weight-light:  400;
 $font-weight-normal: 400;
@@ -29,11 +32,21 @@ $headings-font-family: "Poppins", $font-family-sans-serif;
 $headings-font-weight: 400;
 $headings-color: #212222;
 
-$primary: $braveBrand;
+// Links
+
+$link-color: $braveAction;
+
+// Buttons
 
 $btn-border-radius: 1.5rem;
+
+// Forms
+
+$input-color: $braveGray-2;
 
 $input-focus-border-color: $braveAction;
 $input-btn-focus-box-shadow: 0;
 
-$input-color: $braveGray-2;
+// Alerts
+
+$alert-margin-bottom: 0;

--- a/app/assets/stylesheets/_bootstrap-custom.scss
+++ b/app/assets/stylesheets/_bootstrap-custom.scss
@@ -29,7 +29,7 @@
 // @import "bootstrap/pagination";
 // @import "bootstrap/badge";
 // @import "bootstrap/jumbotron";
-// @import "bootstrap/alert";
+@import "bootstrap/alert";
 // @import "bootstrap/progress";
 // @import "bootstrap/media";
 // @import "bootstrap/list-group";

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -177,7 +177,7 @@ class PublishersController < ApplicationController
       # Success shown in view #create_auth_token
     else
       # Failed to find publisher
-      flash.now[:login_link] = "" # Uses login_link partial instead of explicit message
+      flash[:alert] = t('.unfound_alert_html', link: sign_up_publishers_path)
       render(:new_auth_token)
     end
   end

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -177,7 +177,7 @@ class PublishersController < ApplicationController
       # Success shown in view #create_auth_token
     else
       # Failed to find publisher
-      flash[:alert] = t('.unfound_alert_html', link: sign_up_publishers_path)
+      flash[:alert_html_safe] = t('.unfound_alert_html', link: sign_up_publishers_path)
       render(:new_auth_token)
     end
   end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,7 +36,11 @@ html
 
       .notifications.navbar-static-top#flash
         - if flash[:alert]
-          .alert.alert-warning.flash== flash[:alert]
+          .alert.alert-warning.flash= flash[:alert]
+        - if flash[:alert_html_safe]
+          / This should only be used in cases where we know the flash content is NOT user-provided
+          / (such as translation strings that include minor formatting or links)
+          .alert.alert-warning.flash== flash[:alert_html_safe]
         - if flash[:notice]
           .alert.alert-success.flash= flash[:notice]
         - if content_for(:content_form_errors)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -36,9 +36,7 @@ html
 
       .notifications.navbar-static-top#flash
         - if flash[:alert]
-          .alert.alert-warning.flash= flash[:alert]
-        - if flash[:login_link]
-          = render partial: "publishers/login_link"
+          .alert.alert-warning.flash== flash[:alert]
         - if flash[:notice]
           .alert.alert-success.flash= flash[:notice]
         - if content_for(:content_form_errors)

--- a/app/views/publishers/_login_link.html.slim
+++ b/app/views/publishers/_login_link.html.slim
@@ -1,3 +1,0 @@
-.alert.alert-warning.flash
-		= t('publishers.new_auth_token_publisher_not_found_part_one')
-		= link_to(t('publishers.new_auth_token_publisher_not_found_part_two'), root_path)

--- a/app/views/publishers/create_auth_token.html.slim
+++ b/app/views/publishers/create_auth_token.html.slim
@@ -4,8 +4,8 @@
 .single-panel--wrapper
   .single-panel--content
     .row
-      h3.single-panel--headline = t("publishers.create_auth_token")
+      h3.single-panel--headline= t ".heading"
 
     .row
       .col-small-centered
-        p.text-center= t("publishers.create_auth_token_body")
+        p.text-center= t ".body"

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -6,6 +6,7 @@
 
     h3.single-panel--headline= t(".log_in")
 
+    .col-small-centered
       = form_for(@publisher, url: create_auth_token_publishers_path) do |f|
         div.form-group
           = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email")

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -4,20 +4,19 @@
 .single-panel--wrapper
   .single-panel--content
 
-    h3.single-panel--headline = t("publishers.log_in")
+    h3.single-panel--headline= t(".log_in")
 
-    .col-small-centered
-      = form_for @publisher, url: create_auth_token_publishers_path do |f|
-        .form-group
-          = f.email_field(:email, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email"))
-        - if params[:captcha]
-          = hidden_field_tag(:captcha)
-        - if @should_throttle
-          .form-group
-            = recaptcha_tags
-        = f.submit(t("publishers.log_in"), class: "btn btn-block btn-primary")
+      = form_for(@publisher, url: create_auth_token_publishers_path) do |f|
+        div.form-group
+          = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email")
+        div.form-group
+          - if params[:captcha]
+            = hidden_field_tag(:captcha)
+          - if @should_throttle
+            .form-group
+              = recaptcha_tags
+        = f.submit t(".log_in"), class: "btn btn-block btn-primary"
 
     .single-panel--footer
-      = t("static.landing_signup_prompt")
-      = " "
-      = link_to(t("static.landing_signup"), sign_up_publishers_path)
+      ' #{t(".signup.prompt")}
+      = link_to t(".signup.link"), sign_up_publishers_path

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -7,10 +7,10 @@
     h3.single-panel--headline= t(".log_in")
 
     .col-small-centered
-      = form_for(@publisher, url: create_auth_token_publishers_path) do |f|
-        div.form-group
+      = form_for @publisher, url: create_auth_token_publishers_path do |f|
+        .form-group
           = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email")
-        div.form-group
+        .form-group
           - if params[:captcha]
             = hidden_field_tag(:captcha)
           - if @should_throttle

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,8 +72,6 @@ en:
       <p>Don't see the email? Be sure to check your spam folder. Please wait for a few minutes and %{try_again}.</p>
     try_again: "try again"
     resend_confirmation_email_done: "The confirmation email has been resent."
-    create_auth_token: "Login email sent!"
-    create_auth_token_body: "Please check your email for the login link."
     dashboard_noscript: "Please enable JavaScript in your browser if you wish to interact with the dashboard."
     dashboard_uphold_header: "Your Uphold Wallet"
     dashboard_uphold_balance_sending: "Contribution balance is transferred to your Uphold wallet monthly."
@@ -96,13 +94,10 @@ en:
     login_link_unverified_message: "Your login link has expired. Please send yourself another one."
     login_session_expired: "Your session has expired.  Please log in again."
     new: "Contact Information"
-    log_in: "Log In"
     enter_your_email: "Enter your email"
     new_auth_token_button: "Email me a link to log in"
     new_auth_token_email_html: |
       Email Address <span class="optional">(for unverified domains)</span>
-    new_auth_token_publisher_not_found_part_one: "Couldn't find a publisher with that domain name. Please try again or "
-    new_auth_token_publisher_not_found_part_two: "start a new verification."
     new_auth_token_wrong_email_publisher_not_verified: "Email doesn't match the publisher verification. Please try again or start a new verification."
     new_auth_token_wrong_email_publisher_verified: "Email doesn't match the publisher verification. Try leaving email blank to use the most recent email."
     new_channel: "+ Add Channel"
@@ -154,6 +149,17 @@ en:
       Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error.
     missing_info_provide_email: "We seem to be missing some info. Please make sure you provided an email address."
     invalid_email_value: "We seem to be missing some info. Please make sure you have provided a full email address."
+    create_auth_token:
+      unfound_alert_html: |
+        Couldn't find a publisher with that email address. Please try again or
+        <a href="%{link}">sign up for an account</a>.
+      heading: Login email sent!
+      body: Please check your email for the login link.
+    new_auth_token:
+      log_in: Log In
+      signup:
+        prompt: Don't have an account?
+        link: Sign Up
   publisher_mailer:
     shared:
       contact_help: "If you have any questions, please contact us"
@@ -351,8 +357,6 @@ en:
     landing_login_body: "Log in to your dashboard."
     landing_login_button: "Log in"
     landing_begin_button: "Get Started"
-    landing_signup_prompt: "Don't have an account?"
-    landing_signup: "Sign Up"
   two_factor_authentications:
     totp:
       heading: Two-factor Authentication


### PR DESCRIPTION
This is a follow-up to #490. I noticed during my testing this morning that we neglected to style the alert that appears if the email address can't be found during login.

![Log In Alert](https://user-images.githubusercontent.com/250934/35291385-21c441fe-003b-11e8-9990-39be3496088b.png)

I also performed some follow-up cleanup work that I think we should continue doing along the way during this transition to Bootstrap 4:
- Arrange the login flow translation strings so that they can use template-relative shorthand when possible.
- Sort our `bootstrap-config` variables to match the order that they appear in the original `bootstrap/variables` that they are modifying (with section header comments).

cc: @mixonic 
