### PR TITLE
Bootstrap4: Port sign_up and create_done

### DIFF
--- a/app/assets/stylesheets/theme/columns.scss
+++ b/app/assets/stylesheets/theme/columns.scss
@@ -8,4 +8,6 @@
     @include make-col(8);
     @include make-col-offset(2);
   }
+  padding-left: 0;
+  padding-right: 0;
 }

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -14,11 +14,32 @@
     background-color: white;
     border-radius: 8px;
     box-shadow: 2px 2px 0px 0px rgba(47,48,50,0.15);
+
+    &--medium {
+      @include media-breakpoint-up(sm) {
+        @include make-col(10);
+        @include make-col-offset(1);
+      }
+      @include media-breakpoint-up(md) {
+        @include make-col(10);
+        @include make-col-offset(1);
+      }
+    }
   }
 
   &--content {
+    @include make-row();
     padding: $spacer*3 $spacer $spacer*2;
     text-align: center;
+    &--email-sent {
+      @include media-breakpoint-up(lg) {
+        background-image: url(asset-path("email-2@1x.png"));
+        background-position: top 59px right 60px;
+        background-repeat: no-repeat;
+        padding-top: $spacer*9;
+        padding-bottom: $spacer*9;
+      }
+    }
   }
 
   &--headline {
@@ -27,7 +48,9 @@
   }
 
   &--footer {
+    width: 100%;
     margin-top: $spacer*2;
     margin-bottom: $spacer;
+    text-align: center;
   }
 }

--- a/app/assets/stylesheets/theme/text.scss
+++ b/app/assets/stylesheets/theme/text.scss
@@ -1,0 +1,3 @@
+strong, b {
+  color: $braveBrand;
+}

--- a/app/views/layouts/publishers.html.slim
+++ b/app/views/layouts/publishers.html.slim
@@ -9,8 +9,10 @@
       #content.container
         = yield
 
+// viewport_initial_scale here is a whitelist of actions that have true
+// responsiveness, and no longer need to 0.6 viewport scaling.
 = render \
   template: "layouts/application",
   locals: { \
-    viewport_initial_scale: (%w(new_auth_token create_auth_token).include?(action_name) && "1.0") \
+    viewport_initial_scale: (%w(new_auth_token create_auth_token sign_up create_done).include?(action_name) && "1.0") \
   }

--- a/app/views/publishers/create_done.html.slim
+++ b/app/views/publishers/create_done.html.slim
@@ -1,15 +1,20 @@
-- content_for(:navbar_content) do
+- content_for(:head_style_tags) do
+  = stylesheet_link_tag("application", media: "all")
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    | &nbsp;
+.single-panel--wrapper.single-panel--wrapper--medium
+  .single-panel--content.single-panel--content--email-sent
 
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.info-panel.col-center.email-panel
-    .content-panel
-      h3.text-center= t("publishers.create_done_header")
-      = t("publishers.create_done_body_html",
-              email: @publisher_email,
-              try_again: link_to(t("publishers.try_again"), "#", :onclick=>"document.getElementById('resend_email_form').submit();"))
+    h3.single-panel--headline= t("publishers.create_done_header")
+
+    .col-small-centered
+      = t( \
+          "publishers.create_done_body_html",
+          email: @publisher_email,
+          try_again: link_to( \
+            t("publishers.try_again"),
+            "#",
+            onclick: "document.getElementById('resend_email_form').submit();" \
+          ) \
+        )
 
       = form_tag(resend_email_verify_email_publishers_path, method: "post", class: "hidden", id: "resend_email_form")

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -3,22 +3,19 @@
 
 .single-panel--wrapper
   .single-panel--content
-    .row
-      h3.single-panel--headline = t("publishers.log_in")
 
-    .row
-      .col-small-centered
+    h3.single-panel--headline = t("publishers.log_in")
 
-        = form_for(@publisher, url: create_auth_token_publishers_path) do |f|
-          div.form-group
-            = f.email_field(:email, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email"))
-          div.form-group
-            - if params[:captcha]
-              = hidden_field_tag(:captcha)
-            - if @should_throttle
-              .form-group
-                = recaptcha_tags
-          = f.submit(t("publishers.log_in"), class: "btn btn-block btn-primary")
+    .col-small-centered
+      = form_for @publisher, url: create_auth_token_publishers_path do |f|
+        .form-group
+          = f.email_field(:email, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email"))
+        - if params[:captcha]
+          = hidden_field_tag(:captcha)
+        - if @should_throttle
+          .form-group
+            = recaptcha_tags
+        = f.submit(t("publishers.log_in"), class: "btn btn-block btn-primary")
 
     .single-panel--footer
       = t("static.landing_signup_prompt")

--- a/app/views/publishers/sign_up.html.slim
+++ b/app/views/publishers/sign_up.html.slim
@@ -1,27 +1,23 @@
-- content_for(:navbar_content) do
+- content_for(:head_style_tags) do
+  = stylesheet_link_tag("application", media: "all")
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    | &nbsp;
+.single-panel--wrapper
+  .single-panel--content
 
-.publisher-panel.login-panel.col-center
-  .sub-panel.process-panel.col-center
-    .content-panel
-      h3.text-center= t("publishers.sign_up_header")
+    h3.single-panel--headline = t("publishers.sign_up_header")
+
+    .col-small-centered
       = form_tag publishers_path, method: :post do |f|
         .form-group
-          .row.form-row
-            .col.col-xs-12.col-sm-8.col-center
-              = email_field_tag(:email, nil, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email"), required: true)
-              - if params[:captcha]
-                = hidden_field_tag(:captcha)
-              - if @should_throttle
-                .form-group
-                  = recaptcha_tags
-          .row.form-row
-            .col.col-xs-12.col-sm-8.col-center
-              = submit_tag(t("static.landing_begin_button"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
-          .row.form-footer
-            .col.col-xs-12.col-sm-8.col-center
-              = t("static.landing_login")
-              = link_to(t("static.landing_login_button"), new_auth_token_publishers_path)
+          = email_field_tag(:email, nil, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email"), required: true)
+        - if params[:captcha]
+          = hidden_field_tag(:captcha)
+        - if @should_throttle
+          .form-group
+            = recaptcha_tags
+        = submit_tag(t("static.landing_begin_button"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
+
+    .single-panel--footer
+      = t("static.landing_login")
+      = " "
+      = link_to(t("static.landing_login_button"), new_auth_token_publishers_path)


### PR DESCRIPTION
* Port the sign up page to Bootstrap 4
* Port the sign up completed page to Bootstrap 4
* Change `col-small-centered` to be a bit more friendly, not require internal `.row` elements
* Add `single-panel--wrapper--medium` which is larger than the default `single-panel--wrapper`
* Add `single-panel--content--email-sent` which adds padding and a paper plane background image, but only does so at a large viewport size.
* Errors during signup will suffer from the same style issues resolved by https://github.com/brave-intl/publishers/pull/510
* Remove these pages from the legacy viewport scaling.

TODO:

* [x] The email address is red in the current site. Port that detail to the new site.
* [ ] @jenn-rhim the body font here is `#606467` as a color. Can you confirm this is correct? I based this on the color of the text for "Don't have an account?" on login (re: https://github.com/brave-intl/publishers/pull/490#issuecomment-359578106)

**Before: Sign up, large screen**

<img width="1491" alt="screen shot 2018-01-23 at 10 21 52 am" src="https://user-images.githubusercontent.com/8752/35293131-a7bd95bc-0027-11e8-9e9d-36cfaac885ef.png">

**After: Sign up, large screen**

<img width="1488" alt="screen shot 2018-01-23 at 10 21 59 am" src="https://user-images.githubusercontent.com/8752/35293152-b4d095a6-0027-11e8-91bc-a454107b4f5c.png">

**Before: Sign up, medium screen**

<img width="956" alt="screen shot 2018-01-23 at 10 21 37 am" src="https://user-images.githubusercontent.com/8752/35293158-bb7d01dc-0027-11e8-84f5-80f3e43c22f9.png">

**After: Sign up, medium screen**

<img width="959" alt="screen shot 2018-01-23 at 10 21 43 am" src="https://user-images.githubusercontent.com/8752/35293166-c45c07c6-0027-11e8-827a-270ad612601a.png">

**Before: Sign up, small screen**

<img width="523" alt="screen shot 2018-01-23 at 10 20 50 am" src="https://user-images.githubusercontent.com/8752/35293178-d1654e64-0027-11e8-86b5-be0f5550fe07.png">

**After: Sign up, small screen**

<img width="263" alt="screen shot 2018-01-23 at 10 21 02 am" src="https://user-images.githubusercontent.com/8752/35293184-d8517f04-0027-11e8-9360-5958ec5150ad.png">

**Before: Sign up complete, large screen**

<img width="755" alt="screen shot 2018-01-23 at 10 19 28 am" src="https://user-images.githubusercontent.com/8752/35293196-e24e833a-0027-11e8-9483-5237a8d76973.png">

**After: Sign up complete, large screen**

<img width="1491" alt="screen shot 2018-01-23 at 10 19 34 am" src="https://user-images.githubusercontent.com/8752/35293203-e84029b0-0027-11e8-91dc-52795d59cc87.png">

**Before: Sign up complete, medium screen**

<img width="956" alt="screen shot 2018-01-23 at 10 19 54 am" src="https://user-images.githubusercontent.com/8752/35293220-ee3c7e7c-0027-11e8-9378-6925df49c4d4.png">

**After: Sign up complete, medium screen**

<img width="959" alt="screen shot 2018-01-23 at 10 20 01 am" src="https://user-images.githubusercontent.com/8752/35293235-f6426a96-0027-11e8-9ac2-e2a457c74848.png">

**Before: Sign up complete, small screen**

<img width="523" alt="screen shot 2018-01-23 at 10 20 21 am" src="https://user-images.githubusercontent.com/8752/35293242-ff4dff06-0027-11e8-9173-3652ed34c93d.png">

**After: Sign up complete, small screen**

<img width="520" alt="screen shot 2018-01-23 at 10 20 29 am" src="https://user-images.githubusercontent.com/8752/35293260-0b14d602-0028-11e8-9f2e-4f186266d7c4.png">