### PR TITLE
Fix a style regression on the login successful page

### DIFF
--- a/app/views/publishers/create_auth_token.html.slim
+++ b/app/views/publishers/create_auth_token.html.slim
@@ -3,9 +3,7 @@
 
 .single-panel--wrapper
   .single-panel--content
-    .row
-      h3.single-panel--headline= t ".heading"
+    h3.single-panel--headline= t ".heading"
 
-    .row
-      .col-small-centered
-        p.text-center= t ".body"
+    .col-small-centered
+      p.text-center= t ".body"


### PR DESCRIPTION
A small style fix for the "login successful" page.

**Before**

![screen shot 2018-01-23 at 12 43 43 pm](https://user-images.githubusercontent.com/8752/35299754-1c36e1f6-003b-11e8-8eda-9568de7f451e.png)

**After**

![screen shot 2018-01-23 at 12 43 26 pm](https://user-images.githubusercontent.com/8752/35299747-17833ccc-003b-11e8-9119-5f201952257f.png)