### PR TITLE
Refactor sign up i18n strings

### DIFF
--- a/app/views/publishers/create_done.html.slim
+++ b/app/views/publishers/create_done.html.slim
@@ -4,17 +4,9 @@
 .single-panel--wrapper.single-panel--wrapper--medium
   .single-panel--content.single-panel--content--email-sent
 
-    h3.single-panel--headline= t("publishers.create_done_header")
+    h3.single-panel--headline= t ".heading"
 
     .col-small-centered
-      = t( \
-          "publishers.create_done_body_html",
-          email: @publisher_email,
-          try_again: link_to( \
-            t("publishers.try_again"),
-            "#",
-            onclick: "document.getElementById('resend_email_form').submit();" \
-          ) \
-        )
+      = t ".body_html", email: @publisher_email, try_again_link: link_to(t(".try_again"), "#", onclick: "document.getElementById('resend_email_form').submit();")
 
-      = form_tag(resend_email_verify_email_publishers_path, method: "post", class: "hidden", id: "resend_email_form")
+      = form_tag resend_email_verify_email_publishers_path, method: "post", class: "hidden", id: "resend_email_form"

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -10,13 +10,12 @@
       = form_for @publisher, url: create_auth_token_publishers_path do |f|
         .form-group
           = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email")
-        .form-group
-          - if params[:captcha]
-            = hidden_field_tag(:captcha)
-          - if @should_throttle
-            .form-group
-              = recaptcha_tags
-        = f.submit t(".log_in"), class: "btn btn-block btn-primary"
+        - if params[:captcha]
+          = hidden_field_tag(:captcha)
+        - if @should_throttle
+          .form-group
+            = recaptcha_tags
+        = f.submit(t("shared.log_in"), class: "btn btn-block btn-primary")
 
     .single-panel--footer
       ' #{t(".signup.prompt")}

--- a/app/views/publishers/sign_up.html.slim
+++ b/app/views/publishers/sign_up.html.slim
@@ -4,20 +4,19 @@
 .single-panel--wrapper
   .single-panel--content
 
-    h3.single-panel--headline = t("publishers.sign_up_header")
+    h3.single-panel--headline= t ".heading"
 
     .col-small-centered
       = form_tag publishers_path, method: :post do |f|
         .form-group
-          = email_field_tag(:email, nil, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email"), required: true)
+          = email_field_tag :email, nil, autofocus: true, class: "form-control", placeholder: t("publishers.enter_your_email"), required: true
         - if params[:captcha]
-          = hidden_field_tag(:captcha)
+          = hidden_field_tag :captcha
         - if @should_throttle
           .form-group
             = recaptcha_tags
-        = submit_tag(t("static.landing_begin_button"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
+        = submit_tag t("shared.get_started"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing"
 
     .single-panel--footer
-      = t("static.landing_login")
-      = " "
-      = link_to(t("static.landing_login_button"), new_auth_token_publishers_path)
+      ' #{t("shared.existing_account")}
+      = link_to t("shared.log_in"), new_auth_token_publishers_path

--- a/app/views/static/index.html.slim
+++ b/app/views/static/index.html.slim
@@ -18,14 +18,14 @@
           p= t("static.landing_new_body")
           .row.form-row
             .col.col-xs-12.col-sm-12
-              = link_to(t("static.landing_begin_button"), sign_up_publishers_path, class: "btn btn-block btn-primary", :"data-piwik-action" => "LandingLoginClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
+              = link_to(t("shared.get_started"), sign_up_publishers_path, class: "btn btn-block btn-primary", :"data-piwik-action" => "LandingLoginClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
           hr.divider
           .row
             .col.col-xs-12.col-sm-8
               p.alt-path-copy
-                strong= t("static.landing_login")
+                strong= t("shared.existing_account")
               p= t("static.landing_login_body")
             .col.col-xs-12.col-sm-4.button-column
-              = link_to(t("static.landing_login_button"), new_auth_token_publishers_path, class: "btn btn-block btn-secondary", :"data-piwik-action" => "LandingLoginClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
+              = link_to(t("shared.log_in"), new_auth_token_publishers_path, class: "btn btn-block btn-secondary", :"data-piwik-action" => "LandingLoginClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing")
         .terms-of-service.pull-right
           = link_to(t("shared.terms_of_service"), "https://basicattentiontoken.org/publisher-terms-of-service/")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,15 +62,6 @@ en:
     contact_person: "Contact person"
     contact: "Contact"
     contact_name_placeholder: "First and last name"
-    sign_up_header: "Join Brave Payments"
-    create_done_header: "An email is on its way!"
-    create_done_body_html: |
-      <p>We're excited that you want to be in on Brave Payments. We just sent an email to
-      <strong class="email-address">%{email}</strong>. Click on the access link provided in the email to jump into
-      the verification process.</p>
-      <hr>
-      <p>Don't see the email? Be sure to check your spam folder. Please wait for a few minutes and %{try_again}.</p>
-    try_again: "try again"
     resend_confirmation_email_done: "The confirmation email has been resent."
     dashboard_noscript: "Please enable JavaScript in your browser if you wish to interact with the dashboard."
     dashboard_uphold_header: "Your Uphold Wallet"
@@ -155,11 +146,22 @@ en:
         <a href="%{link}">sign up for an account</a>.
       heading: Login email sent!
       body: Please check your email for the login link.
+    create_done:
+      heading: An email is on its way!
+      body_html: |
+        <p>We're excited that you want to be in on Brave Payments. We just sent an email to
+        <strong class="email-address">%{email}</strong>. Click on the access link provided in the email to jump into
+        the verification process.</p>
+        <hr>
+        <p>Don't see the email? Be sure to check your spam folder. Please wait for a few minutes and %{try_again_link}.</p>
+      try_again: try again
     new_auth_token:
       log_in: Log In
       signup:
         prompt: Don't have an account?
         link: Sign Up
+    sign_up:
+      heading: Join Brave Payments
   publisher_mailer:
     shared:
       contact_help: "If you have any questions, please contact us"
@@ -261,14 +263,17 @@ en:
     api_error: "Your request couldn't be processed due to an API error."
     app_title: Brave Payments
     cancel: "Cancel"
+    continue: "Continue"
+    email_address: "Email address"
+    existing_account: "Already have an account?"
     error: "Error"
     error_body: "Oops, sorry about that. You can try to refresh the page or return to"
     error_contact: "For assistance please contact us at: %{support_email}"
     generate: "Generate"
-    continue: "Continue"
-    update: "Update"
-    email_address: "Email address"
+    get_started: "Get Started"
+    log_in: "Log In"
     terms_of_service: "Terms of Service"
+    update: "Update"
   site_channels:
     check_for_https_button: "Check for HTTPS"
     copy_to_clipboard: "Copy to clipboard"
@@ -353,10 +358,7 @@ en:
         of fans may have already filled your wallet!</p>
     landing_new_header: "New to Brave Payments?"
     landing_new_body: "Start verification by entering your email."
-    landing_login: "Already have an account?"
     landing_login_body: "Log in to your dashboard."
-    landing_login_button: "Log in"
-    landing_begin_button: "Get Started"
   two_factor_authentications:
     totp:
       heading: Two-factor Authentication

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -6,7 +6,7 @@ class PublishersHomeTest < Capybara::Rails::TestCase
   test "land page renders, can navigate to log in" do
     visit root_path
     assert_content page, "Brave Payments"
-    click_link('Log in')
+    click_link('Log In')
     assert_content page, "Log In"
   end
 


### PR DESCRIPTION
I was working on this to be included in #511, but it got merged before I got the commit pushed. This does the same i18n refactoring for the sign up flow as I did earlier for the log in flow.