### PR TITLE
Bootstrap 4: Sign up alerts

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -11,6 +11,7 @@
 @import "bootstrap-3/grid";
 @import "bootstrap-3/forms";
 @import "bootstrap-3/buttons";
+@import "bootstrap-3/alerts";
 @import "bootstrap-3/utilities";
 
 @import "legacy/shared/forms";

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -45,7 +45,7 @@ class PublishersController < ApplicationController
     email = params[:email]
 
     if email.blank?
-      return redirect_to(root_path, notice: I18n.t("publishers.missing_info_provide_email") )
+      return redirect_to sign_up_publishers_path, alert: t(".missing_email")
     end
 
     @publisher = Publisher.new(pending_email: email)
@@ -70,7 +70,7 @@ class PublishersController < ApplicationController
         redirect_to create_done_publishers_path
       else
         Rails.logger.error("Create publisher errors: #{@publisher.errors.full_messages}")
-        redirect_to(root_path, notice: I18n.t("publishers.invalid_email_value") )
+        redirect_to sign_up_publishers_path, alert: t(".invalid_email")
       end
     else
       redirect_to root_path(captcha: params[:captcha])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,8 +138,9 @@ en:
     youtube_channel_taken_noscript_html: |
       The YouTube channel "%{youtube_channel_title}" was registered by %{youtube_channel_registered_by} on %{youtube_channel_registration_date}.
       Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error.
-    missing_info_provide_email: "We seem to be missing some info. Please make sure you provided an email address."
-    invalid_email_value: "We seem to be missing some info. Please make sure you have provided a full email address."
+    create:
+      missing_email: We seem to be missing some info. Please make sure you provided an email address.
+      invalid_email: We seem to be missing some info. Please make sure you have provided a full email address.
     create_auth_token:
       unfound_alert_html: |
         Couldn't find a publisher with that email address. Please try again or


### PR DESCRIPTION
- Refactors i18n alert strings handled by the `Publishers#create` action.
- Changes the redirect for these alerts to `sign_up_publishers_path` since the sign up form is no longer on the main landing page.
- Re-enables the Bootstrap 3 alerts CSS on the static landing page as I noticed those were unstyled when an alert redirected there (which I'm sure still affects some auth-related alerts).