### PR TITLE
Style alert, warning and notice messages in panels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,7 @@ group :development, :test do
   gem "minitest-rails-capybara"
   gem "capybara-selenium"
   gem "chromedriver-helper"
+  gem "rails-controller-testing"
 end
 
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.6)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -424,6 +428,7 @@ DEPENDENCIES
   puma (= 3.10)
   rack-attack (~> 5.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing
   recaptcha (~> 3.3)
   redis-rails (~> 5)
   redis-store (~> 1.4.0)

--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -23,6 +23,10 @@ $braveFailure: #e2052a;
 $braveFailure-Light: #ff5874;
 $braveFailure-Ghost: #ff9aab;
 
+$theme-colors: (
+  "brave-success": $braveSuccess-Light,
+);
+
 $braveInfo-Background: #eefbfd;
 $braveInfo-Foreground: #00bcd6;
 $braveInfo-Border: #e7ebee;

--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -23,6 +23,13 @@ $braveFailure: #e2052a;
 $braveFailure-Light: #ff5874;
 $braveFailure-Ghost: #ff9aab;
 
+$braveInfo-Background: #eefbfd;
+$braveInfo-Foreground: #00bcd6;
+$braveInfo-Border: #e7ebee;
+
+$braveError-Background: #feedf0;
+$braveError-Foreground: #dd0529;
+
 $braveGray-1: #222326;
 $braveGray-2: #484b4e;
 $braveGray-3: #606467;

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -1,3 +1,5 @@
+$brave-panels-borderRadius: 8px;
+
 .single-panel {
 
   &--wrapper {
@@ -12,7 +14,7 @@
     }
 
     background-color: white;
-    border-radius: 8px;
+    border-radius: $brave-panels-borderRadius;
     box-shadow: 2px 2px 0px 0px rgba(47,48,50,0.15);
 
     &--medium {
@@ -40,6 +42,28 @@
         padding-bottom: $spacer*9;
       }
     }
+    &--alert {
+      padding: $spacer $spacer $spacer;
+      background: $braveInfo-Background;
+      color: $braveInfo-Foreground;
+      border-bottom: 1px solid $braveInfo-Border;
+      border-top-left-radius: $brave-panels-borderRadius;
+      border-top-right-radius: $brave-panels-borderRadius;
+    }
+    &--warning {
+      padding: $spacer $spacer $spacer;
+      background: $braveError-Background;
+      color: $braveError-Foreground;
+      border-top-left-radius: $brave-panels-borderRadius;
+      border-top-right-radius: $brave-panels-borderRadius;
+    }
+    &--notice {
+      padding: $spacer $spacer $spacer;
+      background: $braveSuccess-Ghost;
+      color: $braveSuccess-Dark;
+      border-top-left-radius: $brave-panels-borderRadius;
+      border-top-right-radius: $brave-panels-borderRadius;
+    }
   }
 
   &--headline {
@@ -52,5 +76,22 @@
     margin-top: $spacer*2;
     margin-bottom: $spacer;
     text-align: center;
+  }
+}
+
+.icon-and-text {
+  &--wrapper {
+    display: flex;
+    justify-content: flex-start;
+    flex-direction: row;
+    flex-wrap: nowrap;
+  }
+  &--icon {
+    flex: 0 0 58px;
+    align-self: center;
+  }
+  &--text {
+    text-align: left;
+    flex: 1 1 100%;
   }
 }

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -59,8 +59,8 @@ $brave-panels-borderRadius: 8px;
     }
     &--notice {
       padding: $spacer $spacer $spacer;
-      background: $braveSuccess-Ghost;
-      color: $braveSuccess-Dark;
+      background: theme-color-level('brave-success', -10);
+      color: theme-color-level('brave-success', 6);
       border-top-left-radius: $brave-panels-borderRadius;
       border-top-right-radius: $brave-panels-borderRadius;
     }

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -49,6 +49,9 @@ $brave-panels-borderRadius: 8px;
       border-bottom: 1px solid $braveInfo-Border;
       border-top-left-radius: $brave-panels-borderRadius;
       border-top-right-radius: $brave-panels-borderRadius;
+      a {
+        text-decoration: underline;
+      }
     }
     &--warning {
       padding: $spacer $spacer $spacer;

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -177,7 +177,7 @@ class PublishersController < ApplicationController
       # Success shown in view #create_auth_token
     else
       # Failed to find publisher
-      flash[:alert_html_safe] = t('.unfound_alert_html', link: sign_up_publishers_path)
+      flash.now[:alert_html_safe] = t('.unfound_alert_html', link: sign_up_publishers_path)
       render(:new_auth_token)
     end
   end

--- a/app/views/application/_panel_flash_messages.html.slim
+++ b/app/views/application/_panel_flash_messages.html.slim
@@ -1,0 +1,23 @@
+- content_for :application_flash do
+  div
+    // Intentionally left blank to disable application flash
+
+- [:alert, :notice, :warning].each do |name|
+  - {alert: 'icon_circled_i', warning: 'icon_circled_x'}[name].tap do |icon_partial|
+    - if flash[name]
+      div class="single-panel--content single-panel--content--#{name} icon-and-text--wrapper"
+        - if icon_partial
+          .icon-and-text--icon
+            = render icon_partial
+        .icon-and-text--text
+          = flash[name]
+    / This should only be used in cases where we know the flash content is NOT user-provided
+    / (such as translation strings that include minor formatting or links)
+    - "#{name}_html_safe".tap do |html_safe_name|
+      - if flash[html_safe_name]
+        div class="single-panel--content single-panel--content--#{name} icon-and-text--wrapper"
+          - if icon_partial
+            .icon-and-text--icon
+              = render icon_partial
+          .icon-and-text--text
+            == flash[html_safe_name]

--- a/app/views/application/_panel_flash_messages.html.slim
+++ b/app/views/application/_panel_flash_messages.html.slim
@@ -1,3 +1,15 @@
+/ Flash messages *may* appear at the top of a panel in a styled page. To
+/ opt into that styling you must be using non-legacy styles and this partial.
+/ For example:
+/
+/     .single-panel--wrapper
+/       = render "panel_flash_messages" / <-- this partial
+/       .single-panel--content
+/
+/ Pages using that partial will only have messages appear on the top
+/ of the panel. The flash messages below the navigation bar wil be
+/ squashed.
+
 - content_for :application_flash do
   div
     // Intentionally left blank to disable application flash
@@ -11,8 +23,6 @@
             = render icon_partial
         .icon-and-text--text
           = flash[name]
-    / This should only be used in cases where we know the flash content is NOT user-provided
-    / (such as translation strings that include minor formatting or links)
     - "#{name}_html_safe".tap do |html_safe_name|
       - if flash[html_safe_name]
         div class="single-panel--content single-panel--content--#{name} icon-and-text--wrapper"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -34,7 +34,48 @@ html
       - unless @hide_nav
         = render("nav")
 
+      /
+      / ## Using flash messages in Brave Publishers ##
+      /
+      / Three styled variants for flash messages in this app exist:
+      /
+      /   * `:alert` a message with neutral blue styling.
+      /   * `:notice` a message with positive green styling.
+      /   * `:warning` a message with negative red styling.
+      /
+      / By default these messages appear in a bar below the navigation.
+      /
+      / ## Flash messages in panels ##
+      /
+      / The messages *may* appear at the top of a panel in a styled page. To
+      / opt into that styling you must be using non-legacy styles and the
+      / following render partial:
+      /
+      /     .single-panel--wrapper
+      /       = render "panel_flash_messages" / <-- this partial
+      /       .single-panel--content
+      /
+      / Pages using that partial will only have messages appear on the top
+      / of the panel. The flash messages below the navigation bar wil be
+      / squashed.
+      /
+      / ## Flash messages with html content ##
+      /
+      / Sometime a translation string, or other content you want to include
+      / in a flash message, will contain HTML. In these cases you can use
+      / the symbol postfix `_html_safe`. For example:
+      /
+      /     flash[:alert_html_safe] = "<strong>Foo</strong>";
+      /
+      / THIS CONTENT WILL NOT BE ESCAPED. Thus it should contain NO
+      / user-entered content.
+      /
+      / The postfix is available for all three flash names and for rendering
+      / below the navigation bar or in a panel.
+      /
       - if content_for?(:application_flash)
+        / This branch permits the panel_flash_messages parital to disable
+        / navigation bar flash messages.
         = yield(:application_flash)
       - else
         .notifications.navbar-static-top#flash
@@ -45,8 +86,6 @@ html
                   = flash[name]
               - "#{name}_html_safe".tap do |html_safe_name|
                 - if flash[html_safe_name]
-                  / This should only be used in cases where we know the flash content is NOT user-provided
-                  / (such as translation strings that include minor formatting or links)
                   div class="alert alert-#{flash_class} flash"
                     == flash[html_safe_name]
           - if content_for(:content_form_errors)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -34,18 +34,21 @@ html
       - unless @hide_nav
         = render("nav")
 
-      .notifications.navbar-static-top#flash
-        - if flash[:alert]
-          .alert.alert-warning.flash= flash[:alert]
-        - if flash[:alert_html_safe]
-          / This should only be used in cases where we know the flash content is NOT user-provided
-          / (such as translation strings that include minor formatting or links)
-          .alert.alert-warning.flash== flash[:alert_html_safe]
-        - if flash[:notice]
-          .alert.alert-success.flash= flash[:notice]
-        - if content_for(:content_form_errors)
-          .alert.alert-warning= I18n.t("activerecord.shared.errors")
-          = yield(:content_form_errors)
+      - if content_for?(:application_flash)
+        = yield(:application_flash)
+      - else
+        .notifications.navbar-static-top#flash
+          - if flash[:alert]
+            .alert.alert-warning.flash= flash[:alert]
+          - if flash[:alert_html_safe]
+            / This should only be used in cases where we know the flash content is NOT user-provided
+            / (such as translation strings that include minor formatting or links)
+            .alert.alert-warning.flash== flash[:alert_html_safe]
+          - if flash[:notice]
+            .alert.alert-success.flash= flash[:notice]
+          - if content_for(:content_form_errors)
+            .alert.alert-warning= I18n.t("activerecord.shared.errors")
+            = yield(:content_form_errors)
 
       = content_for?(:content) ? yield(:content) : yield
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,14 +38,17 @@ html
         = yield(:application_flash)
       - else
         .notifications.navbar-static-top#flash
-          - if flash[:alert]
-            .alert.alert-warning.flash= flash[:alert]
-          - if flash[:alert_html_safe]
-            / This should only be used in cases where we know the flash content is NOT user-provided
-            / (such as translation strings that include minor formatting or links)
-            .alert.alert-warning.flash== flash[:alert_html_safe]
-          - if flash[:notice]
-            .alert.alert-success.flash= flash[:notice]
+          - [:alert, :notice, :warning].each do |name|
+            - {alert: 'warning', notice: 'success', warning: 'warning'}[name].tap do |flash_class|
+              - if flash[name]
+                div class="alert alert-#{flash_class} flash"
+                  = flash[name]
+              - "#{name}_html_safe".tap do |html_safe_name|
+                - if flash[html_safe_name]
+                  / This should only be used in cases where we know the flash content is NOT user-provided
+                  / (such as translation strings that include minor formatting or links)
+                  div class="alert alert-#{flash_class} flash"
+                    == flash[html_safe_name]
           - if content_for(:content_form_errors)
             .alert.alert-warning= I18n.t("activerecord.shared.errors")
             = yield(:content_form_errors)

--- a/app/views/publishers/create_auth_token.html.slim
+++ b/app/views/publishers/create_auth_token.html.slim
@@ -2,7 +2,9 @@
   = stylesheet_link_tag("application", media: "all")
 
 .single-panel--wrapper
+  = render "panel_flash_messages"
   .single-panel--content
+
     h3.single-panel--headline= t ".heading"
 
     .col-small-centered

--- a/app/views/publishers/create_done.html.slim
+++ b/app/views/publishers/create_done.html.slim
@@ -2,6 +2,7 @@
   = stylesheet_link_tag("application", media: "all")
 
 .single-panel--wrapper.single-panel--wrapper--medium
+  = render "panel_flash_messages"
   .single-panel--content.single-panel--content--email-sent
 
     h3.single-panel--headline= t ".heading"

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -2,6 +2,7 @@
   = stylesheet_link_tag("application", media: "all")
 
 .single-panel--wrapper
+  = render "panel_flash_messages"
   .single-panel--content
 
     h3.single-panel--headline= t(".log_in")

--- a/app/views/publishers/sign_up.html.slim
+++ b/app/views/publishers/sign_up.html.slim
@@ -2,6 +2,7 @@
   = stylesheet_link_tag("application", media: "all")
 
 .single-panel--wrapper
+  = render "panel_flash_messages"
   .single-panel--content
 
     h3.single-panel--headline= t ".heading"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,7 +140,9 @@ en:
       Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error.
     create:
       missing_email: We seem to be missing some info. Please make sure you provided an email address.
-      invalid_email: We seem to be missing some info. Please make sure you have provided a full email address.
+      invalid_email: There was an unexpected error creating your account. Please make sure you have provided a full email address.
+      email_already_active: The email address you entered "%{email}" is an active account. We've emailed you a login link.
+      access_throttled: You've attempted to sign up too many times and your access had been throttled. Try again later.
     create_auth_token:
       unfound_alert_html: |
         Couldn't find a publisher with that email address. Please try again or

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -39,7 +39,8 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
         post(publishers_path, params: { email: "alice@verified.org" })
       end
     end
-    assert_redirected_to(create_done_publishers_path)
+    assert_response :success
+    assert_template :create_auth_token
   end
 
   test "sends an email with an access link" do


### PR DESCRIPTION
This introduces unified support for `:alert`, `:notice` and `:warning` as flash messages for anywhere in the app and all have `_html_safe` variants as well.

This also introduces styles for different flash messages within a panel on the Bootstrap 4 pages. A panel template should use this render partial:

```slim
.single-panel--wrapper
  = render "panel_flash_messages" // <------
  .single-panel--content
    h3.single-panel--headline Howdy user!
```

With that partial flash messages will no longer appear below the navbar, instead they will appear as part of that panel. For example:

**`flash[:alert] = message`**

<img width="384" alt="screen shot 2018-01-23 at 1 59 55 pm" src="https://user-images.githubusercontent.com/8752/35303726-c51c97d2-0047-11e8-8a3d-b31b3176c181.png">

**`flash[:notice] = message`**

edit: Colors here have changed, see https://github.com/brave-intl/publishers/pull/515#issuecomment-359998380

<img width="386" alt="screen shot 2018-01-23 at 1 59 43 pm" src="https://user-images.githubusercontent.com/8752/35303727-c535e458-0047-11e8-8b3b-124c26c674bd.png">

**`flash[:warning] = message`**

<img width="385" alt="screen shot 2018-01-23 at 1 59 29 pm" src="https://user-images.githubusercontent.com/8752/35303728-c5617e7e-0047-11e8-88f5-c527bb5514d9.png">

TODO:

* [x] Rebase over https://github.com/brave-intl/publishers/pull/514 when that is merged.
* [x] Investigate porting this same solution to errors from creating an account (if appropriate).
* [ ] ~Confirm the `notice` colors here with @jenn-rhim. I think the green is suspect. I think we want something signifying "success" and hence green. Currently the background is `#9bf0e1` and the foreground text `#009683` both taken from the master styles palette. Also, should we use an icon here?~ I've tweaked the colors here to be Good Enough, I think. They can definitely be changed down the line, and an icon could be added. See https://github.com/brave-intl/publishers/pull/515#issuecomment-359998380
* [ ] ~The `alert` colors are background `#eefbfd` and foreground text `#00bcd6`, these are based on the current site. The text color is the exact same as our link color, so links are basically invisible. Seems bad. /cc @jenn-rhim~ I've added an underline to links in this area. See https://github.com/brave-intl/publishers/pull/515#issuecomment-359999616
* [x] Document the usage of `= render "panel_flash_messages"`.
* [x] Centralize some documentation for flash options in general.