### PR TITLE
Bootstrap 4: Panel flash followup

### DIFF
--- a/app/views/application/_panel_flash_messages.html.slim
+++ b/app/views/application/_panel_flash_messages.html.slim
@@ -17,7 +17,7 @@
 - [:alert, :notice, :warning].each do |name|
   - {alert: 'icon_circled_i', warning: 'icon_circled_x'}[name].tap do |icon_partial|
     - if flash[name]
-      div class="single-panel--content single-panel--content--#{name} icon-and-text--wrapper"
+      .single-panel--content.icon-and-text--wrapper class="single-panel--content--#{name}"
         - if icon_partial
           .icon-and-text--icon
             = render icon_partial
@@ -25,7 +25,7 @@
           = flash[name]
     - "#{name}_html_safe".tap do |html_safe_name|
       - if flash[html_safe_name]
-        div class="single-panel--content single-panel--content--#{name} icon-and-text--wrapper"
+        .single-panel--content.icon-and-text--wrapper class="single-panel--content--#{name}"
           - if icon_partial
             .icon-and-text--icon
               = render icon_partial

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -82,11 +82,11 @@ html
           - [:alert, :notice, :warning].each do |name|
             - {alert: 'warning', notice: 'success', warning: 'warning'}[name].tap do |flash_class|
               - if flash[name]
-                div class="alert alert-#{flash_class} flash"
+                .alert.flash class="alert-#{flash_class}"
                   = flash[name]
               - "#{name}_html_safe".tap do |html_safe_name|
                 - if flash[html_safe_name]
-                  div class="alert alert-#{flash_class} flash"
+                  .alert.flash class="alert-#{flash_class}"
                     == flash[html_safe_name]
           - if content_for(:content_form_errors)
             .alert.alert-warning= I18n.t("activerecord.shared.errors")


### PR DESCRIPTION
This is a follow up to review of #515. The only change I make here is that I recommend that we stick to the convention within Slim templates of using static classes when possible in place of the `div` selector (or attached directly to other elements) and only use `class=""` for dynamically generated class names. IMO, this helps make it readily apparent which classes are statically applied vs. dynamically generated.

cc: @mixonic 