### PR TITLE
Owners data export

### DIFF
--- a/app/controllers/api/owners_controller.rb
+++ b/app/controllers/api/owners_controller.rb
@@ -1,0 +1,8 @@
+class Api::OwnersController < Api::BaseController
+  include PublishersHelper
+  include ActionController::Serialization
+
+  def index
+    render(json: Publisher.all)
+  end
+end

--- a/app/serializers/publisher_serializer.rb
+++ b/app/serializers/publisher_serializer.rb
@@ -1,0 +1,9 @@
+class PublisherSerializer < ActiveModel::Serializer
+  attributes :owner_identifier, :email, :name, :phone, :phone_normalized, :channel_identifiers
+
+  def channel_identifiers
+    object.channels.verified.collect do |channel|
+      channel.details.channel_identifier
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
   root "static#index"
 
   namespace :api do
-    resources :owners, format: false, only: %i(), constraints: { owner_id: %r{[^\/]+} } do
+    resources :owners, format: false, only: %i(index), constraints: { owner_id: %r{[^\/]+} } do
       resources :channels, only: %i(), constraints: { channel_id: %r{[^\/]+} } do
         get "/", action: :show
         patch "verifications", action: :verify

--- a/test/controllers/api/owners_controller_test.rb
+++ b/test/controllers/api/owners_controller_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
+  test "can get all owners with verifier channel identifiers as json" do
+    owner = publishers(:verified)
+
+    get "/api/owners/"
+
+    assert_equal 200, response.status
+
+    assert_match /#{owner.owner_identifier}/, response.body
+    assert_match /#{owner.channels.verified.first.details.channel_identifier}/, response.body
+  end
+end


### PR DESCRIPTION
~~This is built on #519 and it should not be merged until after that. Done for expediency since it will result in merge conflicts otherwise.~~ Fixed now that #519 was merged.

Implements #521

Example data:
```json
[
  {
    "owner_identifier": "publishers#uuid:8115922c-f8f5-48e6-b035-308a2525d933",
    "email": "user2@gmail.com",
    "name": null,
    "phone": null,
    "phone_normalized": null,
    "channel_identifiers": []
  },
  {
    "owner_identifier": "publishers#uuid:1beb20ad-dc87-4f9d-86bb-7aa03828c6fc",
    "email": "user3@brave.com",
    "name": "Marshall Rose",
    "phone": null,
    "phone_normalized": null,
    "channel_identifiers": [
      "youtube#channel:UCU4cR3CS1fHUGf_TTLYH8NQ"
    ]
  }
]
```
Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))