### PR TITLE
Bootstrap4: Convert the 2FA flows

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import "application-config";
 @import "components/**/*";
 @import "theme/**/*";
+@import "pages/**/*";

--- a/app/assets/stylesheets/components/btn.scss
+++ b/app/assets/stylesheets/components/btn.scss
@@ -1,0 +1,3 @@
+.btn-wide {
+  width: 100%;
+}

--- a/app/assets/stylesheets/pages/two_factor_authentications.scss
+++ b/app/assets/stylesheets/pages/two_factor_authentications.scss
@@ -1,0 +1,9 @@
+.totp-authentication {
+  svg {
+    margin-top: 4px;
+    margin-right: 16px;
+  }
+}
+.two-factor-authentication-alternative {
+  margin-top: $spacer;
+}

--- a/app/assets/stylesheets/theme/columns.scss
+++ b/app/assets/stylesheets/theme/columns.scss
@@ -4,6 +4,10 @@
     @include make-col(10);
     @include make-col-offset(1);
   }
+  @include media-breakpoint-up(md) {
+    @include make-col(9);
+    @include make-col-offset(1.5);
+  }
   @include media-breakpoint-up(lg) {
     @include make-col(8);
     @include make-col-offset(2);

--- a/app/assets/stylesheets/theme/error-group.scss
+++ b/app/assets/stylesheets/theme/error-group.scss
@@ -1,0 +1,22 @@
+/*
+ * .error-group--wrapper is manipulated by JavaScript in the ErrorManager
+ * class. A child element can be promoted to visible by adding .show. If
+ * a child element has .error-group--no-error it will be visible regardless,
+ * but will not be displayed when the modifier .error-group--wrapper--has-error
+ * is present on the .error-group--wrapper.
+ */
+
+.error-group--wrapper {
+  > div {
+    display: none
+  }
+  > div.show {
+    display: block
+  }
+  .error-group--no-error {
+    display: block
+  }
+  &.error-group--wrapper--has-error .error-group--no-error {
+    display: none
+  }
+}

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -9,6 +9,10 @@ $brave-panels-borderRadius: 8px;
       @include make-col-offset(1);
     }
     @include media-breakpoint-up(md) {
+      @include make-col(8);
+      @include make-col-offset(2);
+    }
+    @include media-breakpoint-up(lg) {
       @include make-col(6);
       @include make-col-offset(3);
     }
@@ -66,6 +70,9 @@ $brave-panels-borderRadius: 8px;
       color: theme-color-level('brave-success', 6);
       border-top-left-radius: $brave-panels-borderRadius;
       border-top-right-radius: $brave-panels-borderRadius;
+    }
+    > form, > div {
+      width: 100%;
     }
   }
 

--- a/app/assets/stylesheets/theme/svg.scss
+++ b/app/assets/stylesheets/theme/svg.scss
@@ -1,0 +1,74 @@
+.usb-with-lines.animated {
+  .cycle-1 {
+    animation-duration: 3s;
+    animation-iteration-count: infinite;
+    animation-name: cycle-1;
+  }
+  .cycle-2 {
+    animation-duration: 3s;
+    animation-iteration-count: infinite;
+    animation-name: cycle-2;
+  }
+  .cycle-3 {
+    animation-duration: 3s;
+    animation-iteration-count: infinite;
+    animation-name: cycle-3;
+  }
+}
+
+@keyframes cycle-1 {
+  0% {
+    opacity: 1;
+  }
+  31% {
+    opacity: 1;
+  }
+  33% {
+    opacity: 1;
+  }
+  98% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes cycle-2 {
+  0% {
+    opacity: 0;
+  }
+  31% {
+    opacity: 0;
+  }
+  33% {
+    opacity: 1;
+  }
+  64% {
+    opacity: 1;
+  }
+  66% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes cycle-3 {
+  0% {
+    opacity: 0;
+  }
+  64% {
+    opacity: 0;
+  }
+  66% {
+    opacity: 1;
+  }
+  98% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/app/assets/stylesheets/theme/u2f.scss
+++ b/app/assets/stylesheets/theme/u2f.scss
@@ -1,0 +1,25 @@
+.js-feature-u2f-available {
+  display: none;
+}
+
+body.js-feature-available-u2f {
+  .js-feature-u2f-available {
+    display: block;
+  }
+  .js-feature-u2f-unavailable {
+    display: none;
+  }
+}
+
+.js-u2f-is-working {
+  display: none;
+}
+
+.js-u2f-working {
+  .js-u2f-is-working {
+    display: block;
+  }
+  .js-u2f-is-prompting {
+    display: none;
+  }
+}

--- a/app/views/layouts/two_factor_authentications.html.slim
+++ b/app/views/layouts/two_factor_authentications.html.slim
@@ -1,3 +1,6 @@
+- content_for(:head_style_tags) do
+  = stylesheet_link_tag("application", media: "all")
+
 - content_for(:content) do
   .main-content
     #content.container

--- a/app/views/two_factor_authentications/_totp.html.slim
+++ b/app/views/two_factor_authentications/_totp.html.slim
@@ -1,23 +1,24 @@
-h3.text-center = t(".heading")
+h3.single-panel--headline = t(".heading")
 
 = yield
 
-.col.col-xs-12.col-sm-10.col-md-8.col-lg-10.col-center.text-center
+.col-small-centered
+
   p = t ".body"
 
   = form_tag totp_authentications_path, class: "totp-authentication" do
-    div
-      .col.pull-left
-        = render "application/smartphone_with_code"
-      .col.authentication-code-prompt.text-left
-        label for="totp_password" = t ".totp_password_label"
-        input.form-control name="totp_password" placeholder=t(".enter_code_placeholder") autofocus=true
-    div
-      p = submit_tag t(".submit_value"), class: "btn btn-primary btn-wide"
+    .form-group
+      .icon-and-text--wrapper
+        .icon-and-text--icon
+          = render "application/smartphone_with_code"
+        .icon-and-text--text
+          label for="totp_password" = t ".totp_password_label"
+          input.form-control name="totp_password" placeholder=t(".enter_code_placeholder") autofocus=true
+    = submit_tag t(".submit_value"), class: "btn btn-primary btn-wide"
 
   - if @u2f_enabled
     div.js-feature-u2f-available
-      p.two-factor-authentication-alternative.text-center
-          = t(".u2f_alternative_available")
-          br
-          = link_to t(".u2f_alternative_link"), two_factor_authentications_path
+      p.two-factor-authentication-alternative
+        = t(".u2f_alternative_available")
+        br
+        = link_to t(".u2f_alternative_link"), two_factor_authentications_path

--- a/app/views/two_factor_authentications/_u2f.html.slim
+++ b/app/views/two_factor_authentications/_u2f.html.slim
@@ -5,34 +5,36 @@ div.js-feature-u2f-available
     input type="hidden" name="u2f_challenge" value=(challenge.as_json.to_json)
     input type="hidden" name="u2f_sign_requests" value=(sign_requests.as_json.to_json)
     input type="hidden" name="u2f_response"
-    h3.text-center = t ".heading"
-    .col.col-xs-10.col-sm-8.col-center.text-center
+    h3.single-panel--headline = t ".heading"
+
+    .col-small-centered
       .js-u2f-is-working
         p = t ".body"
-        .text-center
-          = render "application/usb_with_lines"
-    .col.col-xs-10.col-sm-8.col-center.text-center
-      .js-u2f-is-prompting.text-center
-        .text-center
-          = render "application/usb"
+        p = render "application/usb_with_lines"
+
+    .col-small-centered
+      .js-u2f-is-prompting
+        p = render "application/usb"
         p.retry = submit_tag t(".submit_value"), class: "btn btn-primary btn-wide"
 
   - if @totp_enabled
-    .col.col-xs-12.col-sm-10.col-center.text-center
-      p.two-factor-authentication-alternative.text-center
+    .col-small-centered
+      p.two-factor-authentication-alternative
         = t(".totp_alternative_available")
         br
         = link_to t(".totp_alternative_link"), two_factor_authentications_path(request_totp: true)
 
 div.js-feature-u2f-unavailable
 
-  .col.col-xs-12.col-sm-10.col-center.text-center
+  - if @totp_enabled
 
-    - if @totp_enabled
-
-      = render "totp" do
+    = render "totp" do
+      .col-small-centered
         p.alert.alert-warning = t("two_factor_authentications.u2f.unavailable.totp_available")
+        br
 
-    - else
-      h3.text-center = t ".unavailable.heading"
+  - else
+    .col-small-centered
+      h3.single-panel--headline = t ".unavailable.heading"
       p.alert.alert-warning == t ".unavailable.body_html"
+      br

--- a/app/views/two_factor_authentications/index.html.slim
+++ b/app/views/two_factor_authentications/index.html.slim
@@ -1,69 +1,53 @@
-.container
-  .row
-    .col-center.col-xs-12.col-sm-10.col-md-8.col-lg-6
-      .error-group--wrapper.js-authenticate-u2f-error
+.single-panel--wrapper
+  = render "panel_flash_messages"
 
-        .js-u2f-error-bad-request
-          .sub-panel.sub-panel--panel--error-top
-            .row
-              .sub-panel--top-wrapper
-                .sub-panel--top-icon
-                  = render 'icon_circled_x'
-                .sub-panel--top-body
-                  = t ".u2f-error.bad-request"
+  .error-group--wrapper.js-authenticate-u2f-error
 
-        .js-u2f-error-configuration-unsupported
-          .sub-panel.sub-panel--panel--error-top
-            .row
-              .sub-panel--top-wrapper
-                .sub-panel--top-icon
-                  = render 'icon_circled_x'
-                .sub-panel--top-body
-                  = t ".u2f-error.configuration-unsupported"
+    .js-u2f-error-bad-request
+      .single-panel--content.single-panel--content--warning.icon-and-text--wrapper
+        .icon-and-text--icon
+          = render 'icon_circled_x'
+        .icon-and-text--text
+          = t ".u2f-error.bad-request"
 
-        .js-u2f-error-device-ineligible
-          .sub-panel.sub-panel--panel--error-top
-            .row
-              .sub-panel--top-wrapper
-                .sub-panel--top-icon
-                  = render 'icon_circled_x'
-                .sub-panel--top-body
-                  = t ".u2f-error.device-ineligible"
+    .js-u2f-error-configuration-unsupported
+      .single-panel--content.single-panel--content--warning.icon-and-text--wrapper
+        .icon-and-text--icon
+          = render 'icon_circled_x'
+        .icon-and-text--text
+          = t ".u2f-error.configuration-unsupported"
 
-        .js-u2f-error-other-error
-          .sub-panel.sub-panel--panel--error-top
-            .row
-              .sub-panel--top-wrapper
-                .sub-panel--top-icon
-                  = render 'icon_circled_x'
-                .sub-panel--top-body
-                  = t ".u2f-error.other-error"
+    .js-u2f-error-device-ineligible
+      .single-panel--content.single-panel--content--warning.icon-and-text--wrapper
+        .icon-and-text--icon
+          = render 'icon_circled_x'
+        .icon-and-text--text
+          = t ".u2f-error.device-ineligible"
 
-        .js-u2f-error-timeout
-          .sub-panel.sub-panel--panel--error-top
-            .row
-              .sub-panel--top-wrapper
-                .sub-panel--top-icon
-                  = render 'icon_circled_x'
-                .sub-panel--top-body
-                  = t ".u2f-error.timeout"
+    .js-u2f-error-other-error
+      .single-panel--content.single-panel--content--warning.icon-and-text--wrapper
+        .icon-and-text--icon
+          = render 'icon_circled_x'
+        .icon-and-text--text
+          = t ".u2f-error.other-error"
 
-        .js-u2f-error-implementation-incomplete
-          .sub-panel.sub-panel--panel--error-top
-            .row
-              .sub-panel--top-wrapper
-                .sub-panel--top-icon
-                  = render 'icon_circled_x'
-                .sub-panel--top-body
-                  = t ".u2f-error.implementation-incomplete"
+    .js-u2f-error-timeout
+      .single-panel--content.single-panel--content--warning.icon-and-text--wrapper
+        .icon-and-text--icon
+          = render 'icon_circled_x'
+        .icon-and-text--text
+          = t ".u2f-error.timeout"
 
-        .error-group--no-error.js-no-error
-          .sub-panel.sub-panel--panel--filler-top
+    .js-u2f-error-implementation-incomplete
+      .single-panel--content.single-panel--content--warning.icon-and-text--wrapper
+        .icon-and-text--icon
+          = render 'icon_circled_x'
+        .icon-and-text--text
+          = t ".u2f-error.implementation-incomplete"
 
-      .sub-panel.sub-panel--panel--bottom
+  .single-panel--content
+    - if @u2f_authentication_attempt
+      = render partial: "u2f", locals: @u2f_authentication_attempt
 
-        - if @u2f_authentication_attempt
-          = render partial: "u2f", locals: @u2f_authentication_attempt
-
-        - elsif @totp_enabled
-          = render "totp"
+    - elsif @totp_enabled
+      = render "totp"


### PR DESCRIPTION
This converts the 2FA flows to Bootstrap 4.

* Adds `pages/` folder to the styles. This is for utility classes specific to a single page, not ones re-used across other pages on the site.
* Add `.btn-wide` for full-width buttons
* Tweak `.col-small-centered` and the single panel styles to have nicer responsiveness.
* Include a commit to add padding to the bottom of a page if the panel is taller than the viewport.
* Bring the error-group styles over from legacy
* Bring the `.js-feature-u2f-available` styles over from legacy

**Security key attempt**

<img width="967" alt="screen shot 2018-01-24 at 9 02 50 pm" src="https://user-images.githubusercontent.com/8752/35371679-6bafe7a4-014a-11e8-88a9-8463faf41c34.png">

**Security key error**

<img width="968" alt="screen shot 2018-01-24 at 9 03 33 pm" src="https://user-images.githubusercontent.com/8752/35371678-6b960fd2-014a-11e8-8adf-2d4f24b7bf36.png">

**TOTP**

<img width="968" alt="screen shot 2018-01-24 at 9 02 23 pm" src="https://user-images.githubusercontent.com/8752/35371682-6c02a73c-014a-11e8-89e7-1716f2f7710b.png">

**TOTP error**

<img width="968" alt="screen shot 2018-01-24 at 9 02 39 pm" src="https://user-images.githubusercontent.com/8752/35371681-6be9a84a-014a-11e8-85b5-5afe8b2519a5.png">

**User only has security key, but is using an unsupported browser**

<img width="968" alt="screen shot 2018-01-24 at 9 03 48 pm" src="https://user-images.githubusercontent.com/8752/35371677-6b7cb7bc-014a-11e8-8c12-d86b58ff01fa.png">

**User has security key and TOTP, but is using an unsupported browser**

<img width="965" alt="screen shot 2018-01-24 at 9 04 59 pm" src="https://user-images.githubusercontent.com/8752/35371676-6b6293d2-014a-11e8-922b-03ecc988f98a.png">

TODO

* [ ] Use the proper flash style for TOTP errors to make them appear as warnings.
* [ ] Ensure the "security key unsupported" headline is not inside the small column.