### PR TITLE
use env var to log verbosely only sometimes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,12 @@ module Publishers
 
     config.exceptions_app = routes
 
+    if Rails.application.secrets[:log_verbose].present?
+      config.log_level = :debug
+    else
+      config.log_level = :info
+    end
+
     config.lograge.enabled = true
 
     config.time_zone = "Pacific Time (US & Canada)"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -45,11 +45,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  # info so ActionMailer doesn't spam the logs with full attachments
-  config.log_level = :debug
-
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -62,6 +62,7 @@ default: &default
   bat_reddit_url: <%= ENV["BAT_REDDIT_URL"] %>
   bat_rocketchat_url: <%= ENV["BAT_ROCKETCHAT_URL"] %>
   log_api_requests: <%= ENV["LOG_API_REQUESTS"] %>
+  log_verbose: <%= ENV["LOG_VERBOSE"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
env vars would be an easier way to toggle on/off verbose logs in dev/staging