### PR TITLE
Add show_verification_status to /api/owners endpoint, exclude blank fields and unverified owners

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source "https://rubygems.org"
 # Serialize models for JSON APIs
 gem "active_model_serializers", "~> 0.10.0"
 
+# Pagination
+gem "api-pagination"
+
 # Encrypt DB data at rest
 gem "attr_encrypted", "~> 3.0.0"
 
@@ -78,6 +81,9 @@ gem 'webpacker', '~> 3.0'
 gem "whois", "~> 4.0", require: false
 
 gem "whois-parser", "~> 1.0", require: false
+
+# pagination support for models
+gem "will_paginate"
 
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    api-pagination (4.7.0)
     archive-zip (0.7.0)
       io-like (~> 0.3.0)
     arel (7.1.4)
@@ -389,6 +390,7 @@ GEM
     whois-parser (1.0.1)
       activesupport (>= 4)
       whois (>= 4.0.0)
+    will_paginate (3.1.6)
     xpath (3.0.0)
       nokogiri (~> 1.8)
 
@@ -397,6 +399,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
+  api-pagination
   attr_encrypted (~> 3.0.0)
   bootstrap (~> 4.0.0.beta3)
   bootstrap-3-sass!
@@ -447,6 +450,7 @@ DEPENDENCIES
   webpacker (~> 3.0)
   whois (~> 4.0)
   whois-parser (~> 1.0)
+  will_paginate
 
 RUBY VERSION
    ruby 2.3.6p384

--- a/app/controllers/api/owners_controller.rb
+++ b/app/controllers/api/owners_controller.rb
@@ -3,6 +3,6 @@ class Api::OwnersController < Api::BaseController
   include ActionController::Serialization
 
   def index
-    render(json: Publisher.all)
+    render(json: Publisher.where.not(email: nil))
   end
 end

--- a/app/controllers/api/owners_controller.rb
+++ b/app/controllers/api/owners_controller.rb
@@ -3,6 +3,10 @@ class Api::OwnersController < Api::BaseController
   include ActionController::Serialization
 
   def index
-    render(json: Publisher.where.not(email: nil))
+    owners = Publisher.where.not(email: nil).order(:created_at)
+
+    page_num = params[:page] || 1
+    page_size = params[:per_page] || Rails.application.secrets[:default_api_page_size] || 100
+    paginate json: owners, per_page: page_size, page: page_num
   end
 end

--- a/app/serializers/publisher_serializer.rb
+++ b/app/serializers/publisher_serializer.rb
@@ -10,4 +10,10 @@ class PublisherSerializer < ActiveModel::Serializer
       channel.details.channel_identifier
     end
   end
+
+  def serializable_hash(adapter_options = nil, options = {}, adapter_instance = self.class.serialization_adapter_instance)
+    hash = super
+    hash.each { |key, value| hash.delete(key) if value.blank? }
+    hash
+  end
 end

--- a/app/serializers/publisher_serializer.rb
+++ b/app/serializers/publisher_serializer.rb
@@ -1,5 +1,9 @@
 class PublisherSerializer < ActiveModel::Serializer
-  attributes :owner_identifier, :email, :name, :phone, :phone_normalized, :channel_identifiers
+  attributes :owner_identifier, :email, :name, :phone, :phone_normalized, :channel_identifiers, :show_verification_status
+
+  def show_verification_status
+    object.visible?
+  end
 
   def channel_identifiers
     object.channels.verified.collect do |channel|

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -57,6 +57,7 @@ default: &default
   bat_reddit_url: <%= ENV["BAT_REDDIT_URL"] %>
   bat_rocketchat_url: <%= ENV["BAT_ROCKETCHAT_URL"] %>
   log_api_requests: <%= ENV["LOG_API_REQUESTS"] %>
+  default_api_page_size: <%= ENV["DEFAULT_API_PAGE_SIZE"] %>
 
 development:
   <<: *default

--- a/test/controllers/api/owners_controller_test.rb
+++ b/test/controllers/api/owners_controller_test.rb
@@ -10,5 +10,15 @@ class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
 
     assert_match /#{owner.owner_identifier}/, response.body
     assert_match /#{owner.channels.verified.first.details.channel_identifier}/, response.body
+
+    response_json = JSON.parse(response.body)
+    assert response_json[0].has_key?("owner_identifier")
+    assert response_json[0].has_key?("email")
+    assert response_json[0].has_key?("name")
+    assert response_json[0].has_key?("phone")
+    assert response_json[0].has_key?("phone_normalized")
+    assert response_json[0].has_key?("channel_identifiers")
+    assert response_json[0].has_key?("show_verification_status")
+    assert response_json[0]["channel_identifiers"].is_a?(Array)
   end
 end

--- a/test/controllers/api/owners_controller_test.rb
+++ b/test/controllers/api/owners_controller_test.rb
@@ -1,15 +1,12 @@
 require "test_helper"
 
 class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
-  test "can get all owners with verifier channel identifiers as json" do
+  test "can get owners with verifier channel identifiers as json" do
     owner = publishers(:verified)
 
-    get "/api/owners/"
+    get "/api/owners"
 
     assert_equal 200, response.status
-
-    assert_match /#{owner.owner_identifier}/, response.body
-    assert_match /#{owner.channels.verified.first.details.channel_identifier}/, response.body
 
     response_json = JSON.parse(response.body)
     assert response_json[1].has_key?("owner_identifier")
@@ -22,5 +19,30 @@ class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
     assert response_json[1]["channel_identifiers"].is_a?(Array)
 
     refute response_json[0].has_key?("channel_identifiers")
+
+    assert_match /#{owner.owner_identifier}/, response.body
+    assert_match /#{owner.channels.verified.first.details.channel_identifier}/, response.body
+  end
+
+  test "can paginate owners and set page size" do
+    owner = publishers(:verified)
+
+    get "/api/owners/?per_page=10"
+
+    assert_equal 200, response.status
+
+    response_json = JSON.parse(response.body)
+    assert_equal 10, response_json.length
+  end
+
+  test "can paginate owners and set page size and number" do
+    owner = publishers(:verified)
+
+    get "/api/owners/?per_page=5&page=3"
+
+    assert_equal 200, response.status
+
+    response_json = JSON.parse(response.body)
+    assert_equal 3, response_json.length
   end
 end

--- a/test/controllers/api/owners_controller_test.rb
+++ b/test/controllers/api/owners_controller_test.rb
@@ -12,13 +12,15 @@ class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
     assert_match /#{owner.channels.verified.first.details.channel_identifier}/, response.body
 
     response_json = JSON.parse(response.body)
-    assert response_json[0].has_key?("owner_identifier")
-    assert response_json[0].has_key?("email")
-    assert response_json[0].has_key?("name")
-    assert response_json[0].has_key?("phone")
-    assert response_json[0].has_key?("phone_normalized")
-    assert response_json[0].has_key?("channel_identifiers")
-    assert response_json[0].has_key?("show_verification_status")
-    assert response_json[0]["channel_identifiers"].is_a?(Array)
+    assert response_json[1].has_key?("owner_identifier")
+    assert response_json[1].has_key?("email")
+    assert response_json[1].has_key?("name")
+    assert response_json[1].has_key?("phone")
+    assert response_json[1].has_key?("phone_normalized")
+    assert response_json[1].has_key?("channel_identifiers")
+    assert response_json[1].has_key?("show_verification_status")
+    assert response_json[1]["channel_identifiers"].is_a?(Array)
+
+    refute response_json[0].has_key?("channel_identifiers")
   end
 end


### PR DESCRIPTION
Fixes #528, #521 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
