### PR TITLE
BUGFIX: Remove unnecessary prevention of default event handling

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -69,7 +69,6 @@ javascript:
       var publisherVisibleCheckbox = document.getElementById('publisher_visible');
       publisherVisibleCheckbox.addEventListener('click', function(event) {
         window.submitForm('update_publisher_visible_form', 'PATCH', true);
-        event.preventDefault();
       }, false);
 
       var defaultCurrencySelect = document.getElementById('publisher_default_currency');
@@ -77,7 +76,6 @@ javascript:
         defaultCurrencySelect.addEventListener('change', function(event) {
           window.submitForm('update_default_currency_form', 'PATCH', true);
           refreshBalance();
-          event.preventDefault();
         }, false);
       }
 


### PR DESCRIPTION
This fixes a problem on `staging2` only - this change never made it to `staging`. Mea culpa, I introduced this problem while pattern matching on some other event handlers.

The default event handling must be allowed to proceed for the visibility checkbox and the currency selector, or else the elements themselves won’t reflect updates.

/cc @ayumi 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
