### PR TITLE
Add rake task to export eyeshade transition file

### DIFF
--- a/app/serializers/publisher_serializer.rb
+++ b/app/serializers/publisher_serializer.rb
@@ -1,5 +1,5 @@
 class PublisherSerializer < ActiveModel::Serializer
-  attributes :owner_identifier, :email, :name, :phone, :phone_normalized, :channel_identifiers, :show_verification_status
+  attributes :owner_identifier, :email, :name, :phone_normalized, :channel_identifiers, :show_verification_status
 
   def show_verification_status
     object.visible?

--- a/lib/tasks/temp/export_eyeshade_transition_data.rake
+++ b/lib/tasks/temp/export_eyeshade_transition_data.rake
@@ -1,0 +1,10 @@
+namespace :publishers do
+  desc "Export eyeshade transition file"
+  task :export_eyeshade_transition_data => [:environment] do
+    file = File.open(File.expand_path("~/publishers_eyeshade_transition_file.json"), 'w')
+    owners = Publisher.where.not(email: nil).order(:created_at)
+    serializable_resource = ActiveModelSerializers::SerializableResource.new(owners)
+    file.write serializable_resource.to_json
+    file.close
+  end
+end

--- a/test/controllers/api/owners_controller_test.rb
+++ b/test/controllers/api/owners_controller_test.rb
@@ -12,7 +12,6 @@ class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
     assert response_json[1].has_key?("owner_identifier")
     assert response_json[1].has_key?("email")
     assert response_json[1].has_key?("name")
-    assert response_json[1].has_key?("phone")
     assert response_json[1].has_key?("phone_normalized")
     assert response_json[1].has_key?("channel_identifiers")
     assert response_json[1].has_key?("show_verification_status")


### PR DESCRIPTION
A rake task to implement #548. Tests have not yet been added for this.

Run as:

```bash
bin/rake publishers:export_eyeshade_transition_data
```

Example of output file, which will be stored in the user's home directory and named "publishers_eyeshade_transition_file.json":

```json
[
  {
    "owner_identifier": "publishers#uuid:02e81b29-f150-54b9-9a08-ce75944f6889",
    "email": "alice@default.org",
    "name": "Alice the Pyramid",
    "phone": "4159001420",
    "phone_normalized": "+14159001420",
    "show_verification_status": true
  },
  {
    "owner_identifier": "publishers#uuid:8f3ae7ad-2842-53fd-8b63-c843afe1a33a",
    "email": "alice@verified.org",
    "name": "Alice the Verified",
    "phone": "4159001421",
    "phone_normalized": "+14159001421",
    "channel_identifiers": [
      "verified.org"
    ],
    "show_verification_status": true
  },
...
]
```

Closes #548


Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
