### PR TITLE
Re-enable submit button after submitting contact form

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -88,7 +88,7 @@ javascript:
       var pendingContactEmail = document.getElementById('pending_contact_email');
       showPendingContactEmail(pendingContactEmail.innerText);
 
-      var updateContact = document.getElementById('update_contact');
+      var updateContactForm = document.getElementById('update_contact');
       var updateContactName = document.getElementById('update_contact_name');
       var updateContactEmail = document.getElementById('update_contact_email');
       var updateContactPhone = document.getElementById('update_contact_phone');
@@ -107,7 +107,7 @@ javascript:
         updateContactEmail.value = pendingContactEmail.innerText || showContactEmail.innerText;
         updateContactPhone.value = showContactPhone.innerText;
         showContact.style.display = 'none';
-        updateContact.style.display = 'block';
+        updateContactForm.style.display = 'block';
         editContact.style.display = 'none';
         updateContactName.focus();
         event.preventDefault();
@@ -115,12 +115,12 @@ javascript:
 
       cancelEditContact.addEventListener('click', function(event) {
         showContact.style.display = 'block';
-        updateContact.style.display = 'none';
+        updateContactForm.style.display = 'none';
         editContact.style.display = 'block';
         event.preventDefault();
       }, false);
 
-      updateContact.addEventListener('submit', function(event) {
+      updateContactForm.addEventListener('submit', function(event) {
         event.preventDefault();
         window.submitForm('update_contact', 'PATCH', true)
           .then(function() {
@@ -130,10 +130,17 @@ javascript:
             pendingContactEmail.innerText = updatedEmail;
             showPendingContactEmail(updatedEmail);
 
-            updateContact.style.display = 'none';
+            updateContactForm.style.display = 'none';
             showContact.style.display = 'block';
             editContact.style.display = 'block';
             showContactPhoneSeparator.style.display = (showContactPhone.innerText ? 'inline' : 'none');
+
+            // Re-enable submit button to allow form to be resubmitted
+            var submitButton = updateContactForm.querySelector('input[type=submit][disabled]');
+            if (submitButton) {
+              submitButton.removeAttribute('disabled');
+              submitButton.blur();
+            }
           });
       }, false);
 

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -27,5 +27,17 @@ class PublishersHomeTest < Capybara::Rails::TestCase
 
     assert_content page, new_name
     refute_content 'Update'
+
+    # Ensure that form has been reset and can be resubmitted
+
+    click_link('Edit Contact')
+
+    new_name = 'Thomas the Tank Engine'
+    fill_in 'update_contact_name', with: new_name
+
+    click_button('Update')
+
+    assert_content page, new_name
+    refute_content 'Update'
   end
 end


### PR DESCRIPTION
This allows the contact form to be submitted multiple times without refreshing the page.

Fixes #543

/cc @mixonic @ayumi 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
