### PR TITLE
Remove duplicate rails-controller-testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,7 +137,6 @@ group :development, :test do
   gem "minitest-rails-capybara"
   gem "capybara-selenium"
   gem "chromedriver-helper"
-  gem "rails-controller-testing"
 end
 
 group :production, :staging do


### PR DESCRIPTION
During development today, I received the following warning when running `bundle install`:

```
Your Gemfile lists the gem rails-controller-testing (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```

It appears that both #519 and #515 introduced the `rails-controller-testing` gem, one inside the `group :test do` block and one inside the `group :development, :test do` block. Since this is a gem used for testing and #515 introduced it to development without making use of it, I'm going to guess that the introduction there was unintentional (and likely cropped up as part of a rebase or something).

I've removed the redundant listing inside of the `group :development, :test do` block and left the gem listed for test environment only.