### PR TITLE
Change some warning content for U2F

### DIFF
--- a/app/views/two_factor_authentications/_u2f.html.slim
+++ b/app/views/two_factor_authentications/_u2f.html.slim
@@ -34,7 +34,7 @@ div.js-feature-u2f-unavailable
         br
 
   - else
+    h3.single-panel--headline = t ".unavailable.heading"
     .col-small-centered
-      h3.single-panel--headline = t ".unavailable.heading"
       p.alert.alert-warning == t ".unavailable.body_html"
       br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,15 +378,15 @@ en:
       totp_alternative_link: Use authentication code instead.
       submit_value: Try Again
       unavailable:
-        totp_available: Your browser doesn't support security key, the preferred
-          two-factor authentication method for your account. Your account also
-          has authentication code configured. Please use authentication code
-          or change your browser to Google Chrome to use your security key.
-        heading: Security Key Unsupported
+        totp_available: |
+          Your preferred method of two-factor authentication is security key.
+          But it's not supported by your current browser. Switch to Google
+          Chrome or Opera or login using authentication code below.
+        heading: Security key not supported by your browser
         body_html: |
-          Your browser doesn't support security key, the only two-factor
-          authentication method your account has configured. Please use
-          Google Chrome to authenticate with your security key.
+          Switch to Google Chrome or Opera to log in. We recommend setting up
+          authenticator app as a backup method for two-factor authentication
+          for this situation.
     index:
       u2f-error:
         bad-request: |


### PR DESCRIPTION
From https://github.com/brave-intl/publishers/issues/551:

* Ensure the "security key unsupported" headline is not inside the small column.
* If user has U2F and TOTP but no U2F support change the message to: "Your preferred method of two-factor authentication is security key. But it's not supported by your current browser. Switch to Google Chrome or Opera or login using authentication code below."
* If user has U2F and no TOTP, but no U2F support change the message to: "Switch to Google Chrome or Opera to log in. We recommend setting up authenticator app as a backup method for two-factor authentication for this situation." and the title to "Security key not supported by your browser."

Really we're only looking at the content here. There is also a change in styles we want to do for these pages but that is in the process of being mocked.

**User has security key, no security code, and U2F is unsupported**

![localhost_3000_publishers_two_factor_authentications 3](https://user-images.githubusercontent.com/8752/35539102-19d8a0ce-0505-11e8-8835-fdc664f70dc5.png)

**User has security key and security code, and U2F is unsupported**

![localhost_3000_publishers_two_factor_authentications 4](https://user-images.githubusercontent.com/8752/35539101-19ba4c00-0505-11e8-8412-da5ce8f48887.png)
