### PR TITLE
Fix dynamic ellipsis

### DIFF
--- a/app/javascript/utils/dynamicEllipsis.js
+++ b/app/javascript/utils/dynamicEllipsis.js
@@ -28,7 +28,7 @@ export default {
       var displayText = text;
       count++;
       if (count > max) count = 0;
-      for (i = 0; i < count; i++) displayText += '.';
+      for (let i = 0; i < count; i++) displayText += '.';
       element.innerText = displayText;
     }, duration);
   },

--- a/app/javascript/utils/dynamicEllipsis.js
+++ b/app/javascript/utils/dynamicEllipsis.js
@@ -3,12 +3,12 @@ let tempId = 0;
 
 export default {
   start: function(elementOrId, durationBetween, maxEllipsis) {
-    var elementId;
-    var element;
-    var text;
-    var count = 0;
-    var max = maxEllipsis || 5;
-    var duration = durationBetween || 200;
+    let elementId;
+    let element;
+    let text;
+    let count = 0;
+    let max = maxEllipsis || 5;
+    let duration = durationBetween || 200;
 
     if (typeof elementOrId === 'string') {
       elementId = elementOrId;
@@ -25,7 +25,7 @@ export default {
     text = element.innerText;
 
     ellipsisIntervals[elementId] = setInterval(function() {
-      var displayText = text;
+      let displayText = text;
       count++;
       if (count > max) count = 0;
       for (let i = 0; i < count; i++) displayText += '.';
@@ -34,7 +34,7 @@ export default {
   },
 
   stop: function(elementOrId) {
-    var elementId = typeof elementOrId === 'string' ? elementOrId : elementOrId.id;
+    let elementId = typeof elementOrId === 'string' ? elementOrId : elementOrId.id;
     clearInterval(ellipsisIntervals[elementId]);
   }
 };


### PR DESCRIPTION
An undeclared variable was preventing the dynamic ellipsis from functioning when doing things like generating statements on the dashboard.

This also modernizes the JS to favor `let` instead of `var`.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
