### PR TITLE
Automatically show statement UI after uphold connection

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -230,6 +230,7 @@ javascript:
               document.getElementById('uphold_connect').style.display = 'none';
               var upholdDashboard = document.getElementById('uphold_dashboard');
               upholdDashboard.style.display = '';
+              document.getElementById('statement_section').classList.remove('hidden');
               window.dynamicEllipsis.stop('publisher_status');
               clearInterval(checkUpholdStatusInterval);
             } else if (checkUpholdStatusCount >= 15) {
@@ -293,7 +294,7 @@ noscript
             = link_to(t("publishers.uphold_check_balance"), uphold_dashboard_url, class: "btn btn-primary", :"data-piwik-action" => "CheckUpholdBalanceClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
   .col.col-details.col-md-6.col-xs-10.col-xs-center.col-sm-center
     .sub-panel.dashboard-panel
-      .statements#statement_section style=(current_publisher.uphold_verified ? '' : 'display: none')
+      .statements#statement_section class=(current_publisher.uphold_verified ? '' : 'hidden')
         .panel-header.panel-header-h4#publishers_statement
           = t("publishers.statements")
         - if unused_statement_periods.length > 0


### PR DESCRIPTION
Once Uphold connects dynamically via polling, the statement generation UI is now shown automatically without requiring a page reload.

I'm guessing that this fixes the problem @jenn-rhim is referencing in #542 

Note: I'd like to perform some comprehensive cleanup of the JS on the dashboard and move it to an external JS module, but I'm trying to keep the fixes targeted before release.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
