### PR TITLE
500errorpage

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -31,10 +31,6 @@ class ChannelsController < ApplicationController
   def setup_current_channel
     @current_channel = current_publisher.channels.find(params[:id])
   rescue ActiveRecord::RecordNotFound => e
-    respond_to do |format|
-      format.json {
-        render status: 404
-      }
-    end
+    redirect_to home_publishers_path, notice: t("channel.channel_not_found")
   end
 end

--- a/app/views/errors/shared.html.slim
+++ b/app/views/errors/shared.html.slim
@@ -1,4 +1,4 @@
-h2 #{I18n.t("shared.error")} #{@status}: #{Rack::Utils::HTTP_STATUS_CODES[@status]} 🎁
+h2 #{I18n.t("shared.error")} #{@status}: #{Rack::Utils::HTTP_STATUS_CODES[@status]} 🤔
 p
   = I18n.t("shared.error_body")
   = " "

--- a/app/views/layouts/error.html.slim
+++ b/app/views/layouts/error.html.slim
@@ -54,7 +54,7 @@ html
       .container
         .menu-container
           = link_to(root_path, class: "home-logo pull-left") do
-            = image_tag("brave_logo_horz.svg", class: "brave-logo pull-left", height: 32)
+            = render("application/logo_wordmark_svg")
 
     .content
       = yield

--- a/lib/error_handler.rb
+++ b/lib/error_handler.rb
@@ -29,6 +29,10 @@ module ErrorHandler
     else
       Rails.logger.warn(exception)
     end
+
+    # re-raise the exception now that it's been captured by sentry-raven or logged
+    # so that the standard rails error flow can happen
+    raise exception
   end
 
   def introspect_publisher

--- a/test/controllers/api/owners_controller_test.rb
+++ b/test/controllers/api/owners_controller_test.rb
@@ -9,15 +9,6 @@ class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
 
     response_json = JSON.parse(response.body)
-    assert response_json[1].has_key?("owner_identifier")
-    assert response_json[1].has_key?("email")
-    assert response_json[1].has_key?("name")
-    assert response_json[1].has_key?("phone_normalized")
-    assert response_json[1].has_key?("channel_identifiers")
-    assert response_json[1].has_key?("show_verification_status")
-    assert response_json[1]["channel_identifiers"].is_a?(Array)
-
-    refute response_json[4].has_key?("channel_identifiers")
 
     assert_match /#{owner.owner_identifier}/, response.body
     assert_match /#{owner.channels.verified.first.details.channel_identifier}/, response.body

--- a/test/controllers/channels_controller_test.rb
+++ b/test/controllers/channels_controller_test.rb
@@ -29,7 +29,7 @@ class ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_difference("publisher.channels.count", 0) do
       assert_difference("SiteChannelDetails.count", 0) do
         delete channel_path(channel), headers: { 'HTTP_ACCEPT' => "application/json" }
-        assert_response 404
+        assert_response 302
       end
     end
   end

--- a/test/serializers/publisher_serializer_test.rb
+++ b/test/serializers/publisher_serializer_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class PublisherSerializerTest < ActiveSupport::TestCase
+  test "owners are serialized as JSON and include owner and channel details rolled up" do
+    owner = publishers(:verified)
+
+    result = PublisherSerializer.new(owner).to_json
+    json_result = JSON.parse(result)
+
+    assert json_result.has_key?("owner_identifier")
+    assert json_result.has_key?("email")
+    assert json_result.has_key?("name")
+    assert json_result.has_key?("phone_normalized")
+    assert json_result.has_key?("channel_identifiers")
+    assert json_result.has_key?("show_verification_status")
+    assert json_result["channel_identifiers"].is_a?(Array)
+
+    assert json_result.has_key?("channel_identifiers")
+  end
+end


### PR DESCRIPTION
After handling exceptions with sentry raven the exceptions are re-raised so the standard rails exception handling can display the 500 error page.

The shared error page was updated with the thinker emoji and newer brave logo.

![screen shot 2018-01-30 at 5 21 46 pm](https://user-images.githubusercontent.com/29154/35594702-1b81a8f2-05e2-11e8-9ed9-6cdaf08dc0c4.png)

This change exposed an issue when rendering a 404 response when trying to delete a missing channel. The exception was getting swallowed. It's been changed to a redirect back to the dashboard. 

The api/owners controller tests were brittle and this broke them as well. Updated to a separate serializer test and simplified the api test.

Fixes #517

Submitter Checklist:

- [] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))