### PR TITLE
handle case where channel being verified does not match eyeshade response

### DIFF
--- a/app/services/site_channel_verifier.rb
+++ b/app/services/site_channel_verifier.rb
@@ -29,7 +29,7 @@ class SiteChannelVerifier < BaseApiClient
 
     return false if response_hash["status"] != "success" || verified_channel_id.blank?
 
-    assert_publisher_matches_verified_id!
+    return false unless channel.id == verified_channel_id
 
     # Channel should have been verified through a call to PATCH /api/owners/:owner_id/channels/:channel_id/verifications
     # from eyeshade, so we won't update it here, just reload it
@@ -45,18 +45,16 @@ class SiteChannelVerifier < BaseApiClient
     @verified_channel_id = verify_offline_publisher_id
     return false if verified_channel_id.blank?
     update_verified_on_channel_offline
-    assert_publisher_matches_verified_id! if channel
+
+    return false unless channel.id == verified_channel_id
+
+    verified_channel_post_verify
   end
 
   private
 
   def api_base_uri
     Rails.application.secrets[:api_eyeshade_base_uri]
-  end
-
-  def assert_publisher_matches_verified_id!
-    return true if channel.id == verified_channel_id
-    raise VerificationIdMismatch.new("Channel UUID / verificationId mismatch: #{channel.id} / #{verified_channel_id}")
   end
 
   def update_verified_on_channel_offline


### PR DESCRIPTION
A stopgap fix for #579. The verifications will still be attempted hourly, but this should stop the exceptions being caught by Sentry.

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))