### PR TITLE
Use an HTML modal for channel removal confirmation

### DIFF
--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -303,7 +303,7 @@ body[data-controller="publishers"]
     .container
       .col-details
         margin-top: 30px
-      h4
+      h4.balance-header
         font-size: 13px
         font-weight: 300
         letter-spacing: 0.5px

--- a/app/javascript/modal.js
+++ b/app/javascript/modal.js
@@ -66,7 +66,7 @@ var MODAL_SHOW_CLASS = 'md-show';
 /*
  * On demand open a modal.
  */
-function openModal(html, confirmCallback, denyCallback) {
+self.openModal = function openModal(html, confirmCallback, denyCallback) {
   var modalElement = document.querySelector('.js-shared-modal');
   var contentElement = modalElement.querySelector('.md-content');
   var containerElement = modalElement.querySelector('.md-container');
@@ -85,15 +85,14 @@ function openModal(html, confirmCallback, denyCallback) {
       return;
     }
 
+    modalElement.removeEventListener('click', confirmationEventDelegate);
+    contentElement.innerHTML = '';
+    containerElement.classList.remove(MODAL_SHOW_CLASS);
+    event.preventDefault();
+
     if (target.classList.contains('js-confirm')) {
-      event.preventDefault();
       confirmCallback();
     } else if (target.classList.contains('js-deny')) {
-      modalElement.removeEventListener('click', confirmationEventDelegate);
-      contentElement.innerHTML = '';
-      containerElement.classList.remove(MODAL_SHOW_CLASS);
-      event.preventDefault();
-
       denyCallback();
     }
   }

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -99,7 +99,7 @@ html
     / This block of HTML is used by modal_shared.js to trigger modal
     / boxes. See that JavaScript file for more details.
     .js-shared-modal
-      .md-container.container
+      .md-container.container data-test-modal-container=""
         .col.col-10.col-md-8.col-sm-10.col-xs-12.col-center.sub-panel.sub-panel--panel--modal
           .md-content
           = link_to "#", class: "md-close js-deny"

--- a/app/views/publishers/_remove_channel_modal.html.slim
+++ b/app/views/publishers/_remove_channel_modal.html.slim
@@ -1,0 +1,13 @@
+.col.col-center.col-xs-12.col-sm-10.col-md-10.col-lg-10
+  h4 = t(".headline")
+  p
+    = t(".intro")
+    br
+    strong
+      = channel.publication_title
+  p
+    = t(".final_confirmation")
+  .row
+    .col.md-confirm-buttons.pull-right
+      = link_to t(".deny"), "#", class: "js-deny btn btn-secondary"
+      = link_to t(".confirm"), "#", class: "js-confirm btn btn-secondary"

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -65,10 +65,10 @@ javascript:
       for (var i = 0, l = removeChannelLinks.length; i < l; i++) {
         removeChannelLinks[i].addEventListener('click', function(event) {
           var channelId = event.target.getAttribute('data-channel-id');
-          var confirmationMessage = event.target.getAttribute('data-confirmation-message');
-          if (window.confirm(confirmationMessage)) {
+          var template = document.querySelector('[data-js-channel-removal-confirmation-template="'+channelId+'"]');
+          openModal(template.innerHTML, function() {
             removeChannel(channelId);
-          }
+          }, function() {});
           event.preventDefault();
         }, false);
       }
@@ -267,7 +267,7 @@ noscript
 
 .row
   .col.col-details.col-md-5.col-xs-10.col-xs-center.col-sm-center
-    h4= t("publishers.balance_pending")
+    h4.balance-header = t("publishers.balance_pending")
     .balance
       .pull-left
         = image_tag("bat-logo@1x.png", class: "")
@@ -372,8 +372,10 @@ noscript
                 = t("publishers.dashboard_channel_added", date: channel.created_at.to_date.iso8601)
               .separator
                 = '|'
-              a.remove-channel href="#" data-channel-id=(channel.id) data-confirmation-message=(t("publishers.dashboard_channel_confirm_remove_channel", channel_name: channel.publication_title))
+              a.remove-channel href="#" data-channel-id=(channel.id)
                 = t("publishers.dashboard_channel_remove_verified_channel")
+              script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
+                = render "publishers/remove_channel_modal", channel: channel
               = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
 
           .channel-status.pull-right
@@ -385,8 +387,10 @@ noscript
             .one-more-step= t("publishers.dashboard_channel_one_more_step")
           .channel-status.pull-right
             = link_to(t("publishers.dashboard_channel_lets_finish"), channel_next_step_path(channel), class: "btn btn-primary")
-          a.remove-channel.pull-right href="#" data-channel-id=(channel.id) data-confirmation-message=(t("publishers.dashboard_channel_confirm_remove_channel", channel_name: channel.publication_title))
+          a.remove-channel.pull-right href="#" data-channel-id=(channel.id)
             = t("publishers.dashboard_channel_remove_unverified_channel")
+          script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
+            = render "publishers/remove_channel_modal", channel: channel
           = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
         .clearfix
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,6 @@ en:
     dashboard_channel_lets_finish: "Let's Finish"
     dashboard_channel_remove_verified_channel: "Remove Channel"
     dashboard_channel_remove_unverified_channel: "Remove"
-    dashboard_channel_confirm_remove_channel: "Are you sure that you want to remove the channel '%{channel_name}'"
     dashboard_channel_verified: "Verified"
     current_deposit_currency: "Current deposit currency: BAT to "
     edit_contact: "Edit Contact"
@@ -173,6 +172,12 @@ en:
         link: Sign Up
     sign_up:
       heading: Join Brave Payments
+    remove_channel_modal:
+      headline: Remove Channel?
+      intro: "You are removing the channel:"
+      final_confirmation: Are you sure you want to remove this channel?
+      deny: Do Not Remove
+      confirm: Remove Channel
   publisher_mailer:
     shared:
       contact_help: "If you have any questions, please contact us"

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -40,4 +40,32 @@ class PublishersHomeTest < Capybara::Rails::TestCase
     assert_content page, new_name
     refute_content 'Update'
   end
+
+  test "publishers page renders, unverified channel can be removed after confirmation" do
+    publisher = publishers(:small_media_group)
+    channel = channels(:small_media_group_to_verify)
+
+    sign_in publisher
+    visit home_publishers_path
+
+    assert_content page, channel.publication_title
+    click_link('Remove')
+    assert_content page, "Are you sure you want to remove this channel?"
+    find('[data-test-modal-container]').click_link("Remove Channel")
+    refute_content page, channel.publication_title
+  end
+
+  test "publishers page renders, verified channel can be removed after confirmation" do
+    publisher = publishers(:small_media_group)
+    channel = channels(:small_media_group_to_delete)
+
+    sign_in publisher
+    visit home_publishers_path
+
+    assert_content page, channel.publication_title
+    click_link('Remove Channel')
+    assert_content page, "Are you sure you want to remove this channel?"
+    find('[data-test-modal-container]').click_link("Remove Channel")
+    refute_content page, channel.publication_title
+  end
 end

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -117,6 +117,7 @@ small_media_group:
   name: "Small Media Group"
   phone: "4159001421"
   phone_normalized: "+14159001421"
+  two_factor_prompted_at: "<%= 1.day.ago %>"
   agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 


### PR DESCRIPTION
Closes #576. Stop using `window.confirm`, instead use our HTML dialog.

TODO:

* [x] Add a test to confirm this.

**Confirming a channel removal, desktop**

![localhost_3000_publishers_home 2](https://user-images.githubusercontent.com/8752/35639874-6cc903e8-0670-11e8-92ea-52ae521c2f56.png)

**Confirming a channel removal, mobileish**

This page is not really responsive, but here is what  it looks like:

![localhost_3000_publishers_home 3](https://user-images.githubusercontent.com/8752/35639873-6cac1d96-0670-11e8-9a6e-e8666d62a23d.png)