### PR TITLE
Ensure that publisher_humanize_balance helper works without a wallet

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -35,7 +35,7 @@ module PublishersHelper
   end
 
   def publisher_humanize_balance(publisher, currency)
-    if balance = publisher.wallet.contribution_balance
+    if balance = publisher.wallet && publisher.wallet.contribution_balance
       '%.2f' % balance.convert_to(currency)
     else
       I18n.t("publishers.balance_error")

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'eyeshade/wallet'
 
 class PublishersHelperTest < ActionView::TestCase
   # test "should render brave publisher id as a link" do
@@ -30,5 +31,52 @@ class PublishersHelperTest < ActionView::TestCase
 
   test "can extract the uuid from an owner_identifier" do
     assert_equal "b8317d8a-78a4-48a6-9eeb-a2674c6455c4", publisher_id_from_owner_identifier("publishers#uuid:b8317d8a-78a4-48a6-9eeb-a2674c6455c4")
+  end
+
+  test "publisher_humanize_balance should return a formatted & converted wallet balance" do
+    class FakePublisher
+      attr_reader :default_currency, :wallet
+
+      def initialize(wallet_json:)
+        @wallet = Eyeshade::Wallet.new(wallet_json: wallet_json) if wallet_json
+        @default_currency = 'USD'
+      end
+    end
+
+    publisher = FakePublisher.new(
+      wallet_json: {
+        "status" => {
+          "provider" => "uphold"
+        },
+        "contributions" => {
+          "amount" => "9001.00",
+          "currency" => "USD",
+          "altcurrency" => "BAT",
+          "probi" => "38077497398351695427000"
+        },
+        "rates" => {
+          "BTC" => 0.00005418424016883016,
+          "ETH" => 0.000795331082073117,
+          "USD" => 0.2363863335301452,
+          "EUR" => 0.20187818378874756,
+          "GBP" => 0.1799810085548496
+        },
+        "wallet" => {
+          "provider" => "uphold",
+          "authorized" => true,
+          "preferredCurrency" => 'USD',
+          "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
+        }
+      }
+    )
+    assert_not_nil publisher.wallet
+    assert_equal "9001.00", publisher_humanize_balance(publisher, "USD")
+
+    publisher = FakePublisher.new(
+      wallet_json: nil
+    )
+
+    assert_nil publisher.wallet
+    assert_equal "Unavailable", publisher_humanize_balance(publisher, "USD")
   end
 end


### PR DESCRIPTION
In the case when a publisher has not been assigned a wallet, this helper should return the `publishers.balance_error` message without also logging a Sentry exception.

Fixes #587

/cc @ayumi 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
