### PR TITLE
Update wordpress plugin location

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,10 +351,10 @@ en:
      Follow the steps below to verify your Wordpress site.<br />
      (Hmmm, my site is a <a href="%{choose_path}">normal website</a> or <a href="%{github_path}">on GitHub</a>.)
     verification_option_wordpress_install_plugin_html: |
-      <p class="li-text"><a href="https://wordpress.org/plugins/well-known-uris/" class="download-link">Install the plugin</a> that makes the
+      <p class="li-text"><a href="https://wordpress.org/plugins/brave-payments-verification/" class="download-link">Install the plugin</a> that makes the
        entire process a snap.</p>
-      <p class="note-text">(Plugin location: <a href="https://wordpress.org/plugins/well-known-uris/">
-      https://wordpress.org/plugins/well-known-uris/</a>)</p>
+      <p class="note-text">(Plugin location: <a href="https://wordpress.org/plugins/brave-payments-verification/">
+      https://wordpress.org/plugins/brave-payments-verification/</a>)</p>
     verification_option_wordpress_verification_token: "Copy the verification code below into the plugin."
     verification_option_wordpress_token: "Verification code:"
     verification_option_wordpress_help_verify: "Once the code is pasted in, click verify."


### PR DESCRIPTION
This brings the changes @nvonpentz made in https://github.com/brave-intl/publishers/commit/2f058c4a53d6c88a787aefc27d83752d5559a5e9 and https://github.com/brave-intl/publishers/commit/00a26ffa797e2922be70f579fb409ff813feaad7 over to the multichannel code.

Fix #596

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))