### PR TITLE
Add filename and note about not changing filename or contents

### DIFF
--- a/app/assets/stylesheets/legacy/application/site_channels.sass
+++ b/app/assets/stylesheets/legacy/application/site_channels.sass
@@ -144,11 +144,16 @@ body
         margin-bottom: 24px
     .file-content
       width: 360px
-    .file-content-header
+    .file-content-header, .file-name-header
       color: #48494B
       font-size: 12px
       font-weight: 600
-
+    .file-name
+      font-size: 16px
+      font-weight: 600
+      margin-bottom: 15px
+    .file-note
+      color: #e30d27
     .instructions
       margin-left: -22px
       margin-top: 35px

--- a/app/controllers/site_channels_controller.rb
+++ b/app/controllers/site_channels_controller.rb
@@ -79,6 +79,13 @@ class SiteChannelsController < ApplicationController
   def verification_github
     generator = SiteChannelVerificationFileGenerator.new(site_channel: current_channel)
     @public_file_content = generator.generate_file_content
+    @public_file_name = generator.filename
+  end
+
+  def verification_public_file
+    generator = SiteChannelVerificationFileGenerator.new(site_channel: current_channel)
+    @public_file_content = generator.generate_file_content
+    @public_file_name = generator.filename
   end
 
   # TODO: Rate limit

--- a/app/views/site_channels/verification_github.html.slim
+++ b/app/views/site_channels/verification_github.html.slim
@@ -20,6 +20,8 @@
             .pull-left
               = image_tag("file@1x.png", class: "instruction-img")
             .pull-right
+              .file-name-header= t("site_channels.verification_file_name")
+              .file-name= @public_file_name
               .file-content-header= t("site_channels.verification_file_contents")
               .file-content
                 = simple_format h site_channel_filter_public_file_content(current_channel, @public_file_content)

--- a/app/views/site_channels/verification_public_file.html.slim
+++ b/app/views/site_channels/verification_public_file.html.slim
@@ -18,6 +18,8 @@
             .pull-left
               = image_tag("file@1x.png", class: "instruction-img")
             .pull-right
+              .file-name-header= t("site_channels.verification_file_name")
+              .file-name= @public_file_name
               .file-content-header= t("site_channels.verification_file_contents")
               .file-content
                 = simple_format h publisher_filter_public_file_content(current_channel.details, @public_file_content)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -361,11 +361,12 @@ en:
       %{download_link} the verification file.
     verification_upload_html: |
       Upload the verification file to the '<strong>.well-known</strong>' folder on your domain (create the folder if you
-      don't have one).
+      don't have one). <span class="file-note">* Do not change the file name or file content.</span>
     verification_verify: "Make sure the verification file is placed in the folder and click verify."
     verification_verify_note: "Note: this process may take a few minutes to several hours depending on where your site is hosted."
     verification_file_contents: "File contents:"
     verification_option_place_trusted_file: "Place a Trusted File into your Domain"
+    verification_file_name: "File name:"
   static:
     landing_header-welcome: "Welcome to"
     landing_header: "Brave Payments"


### PR DESCRIPTION
Shows filename for reference and adds note about not changing the filename.

Also fixed an issue with missing file content on public_file page introduced in the multichannel changes.

Fixes #598

![screen shot 2018-02-01 at 4 46 29 pm](https://user-images.githubusercontent.com/29154/35705100-7df3d918-076f-11e8-9fd9-09b016736656.png)
![screen shot 2018-02-01 at 4 46 10 pm](https://user-images.githubusercontent.com/29154/35705104-8126f958-076f-11e8-9b7d-e2c9bc334fba.png)


WIP pending review by @jenn-rhim


Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))