### PR TITLE
Port signup flow to Bootstrap 4

### DIFF
--- a/app/assets/stylesheets/theme/columns.scss
+++ b/app/assets/stylesheets/theme/columns.scss
@@ -14,6 +14,14 @@
   }
   padding-left: 0;
   padding-right: 0;
+  &--with-right-background {
+    @include make-col(12);
+    @include make-col-offset(0);
+    @include media-breakpoint-up(lg) {
+      @include make-col(6);
+      @include make-col-offset(2);
+    }
+  }
 }
 
 .col-medium-centered {

--- a/app/assets/stylesheets/theme/nav.scss
+++ b/app/assets/stylesheets/theme/nav.scss
@@ -198,6 +198,10 @@
   }
 }
 
+.user-solo-button {
+  margin-top: 5px;
+}
+
 .notifications .alert {
   border-radius: 0;
   border-left: 0;

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -58,6 +58,17 @@ $brave-panels-borderRadius: 8px;
         padding-bottom: $spacer*9;
       }
     }
+    &--platforms {
+      padding-top: $spacer*2;
+      padding-bottom: $spacer;
+      @include media-breakpoint-up(lg) {
+        background-image: url(asset-path("img-brands.png"));
+        background-position: top right;
+        background-repeat: no-repeat;
+        padding-top: $spacer*7;
+        padding-bottom: $spacer*7;
+      }
+    }
     &--alert {
       padding: $spacer $spacer $spacer;
       background: $braveError-Background;
@@ -101,6 +112,9 @@ $brave-panels-borderRadius: 8px;
   &--headline {
     width: 100%;
     margin-bottom: $spacer*2;
+    &--primary {
+      color: theme-color('primary');
+    }
   }
 
   &--list {
@@ -112,7 +126,9 @@ $brave-panels-borderRadius: 8px;
     width: 100%;
     margin-top: $spacer*2;
     margin-bottom: $spacer;
-    text-align: center;
+    &--secondary {
+      text-align: center;
+    }
   }
 }
 

--- a/app/views/application/_nav.html.slim
+++ b/app/views/application/_nav.html.slim
@@ -23,8 +23,13 @@ nav.navbar.navbar-default.navbar-static-top.top-nav-collapse
                       = t ".security"
                   li= link_to t(".log_out"), log_out_publishers_path
           - else
-            .btn.btn-secondary.btn-logout.pull-right.float-right
-              = link_to t(".log_out"), log_out_publishers_path
+            / btn-secondary and btn-highlight are legacy, can be dropped once
+            / bootstrap v3 is removed.
+            = link_to( \
+                t(".log_out"), \
+                log_out_publishers_path, \
+                class: 'btn btn-secondary btn-highlight btn-outline-primary user-solo-button' \
+            )
       .nav.pull-left.float-left
         = link_to(root_path) do
           .brave-logo

--- a/app/views/layouts/publishers.html.slim
+++ b/app/views/layouts/publishers.html.slim
@@ -14,5 +14,5 @@
 = render \
   template: "layouts/application",
   locals: { \
-    viewport_initial_scale: (%w(new_auth_token create_auth_token sign_up create_done).include?(action_name) && "1.0") \
+    viewport_initial_scale: (%w(new_auth_token create_auth_token sign_up create_done email_verified).include?(action_name) && "1.0") \
   }

--- a/app/views/publishers/email_verified.html.slim
+++ b/app/views/publishers/email_verified.html.slim
@@ -1,21 +1,37 @@
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.process-panel.col-center
-    .content-panel
-      h1= t ".heading"
+- content_for(:head_style_tags) do
+  = stylesheet_link_tag("application", media: "all")
+
+.single-panel--wrapper.single-panel--wrapper--medium
+ .single-panel--content.single-panel--content--platforms
+    .col-small-centered.col-small-centered--with-right-background.text-left
+
+      h1.single-panel--headline.single-panel--headline--primary= t ".heading"
       p
         span= t ".intro"
 
-      = form_for @publisher, { method: :patch, url: complete_signup_publishers_path,
-              html: { id: "update_contact_info" }} do |f|
+      = form_for(@publisher, { \
+          method: :patch, \
+          url: complete_signup_publishers_path, \
+          html: { id: "update_contact_info" } \
+      }) do |f|
         .form-group
           = f.label(:name, class: "control-label")
-          = f.text_field(:name, autofocus: true, class: "form-control", placeholder: t(".name_placeholder"), required: true)
+          = f.text_field(:name, \
+              autofocus: true, \
+              class: "form-control", \
+              placeholder: t(".name_placeholder"), \
+              required: true \
+          )
         .form-group
-          = f.check_box(:visible, class: "form-check-input")
-          = f.label(:visible, class: "form-check-label", for: "publisher_visible")
-        .panel-controls
-          = f.submit(t("publishers.shared.sign_up"), class: "btn btn-primary")
+          .form-check
+            = f.check_box(:visible, class: "form-check-input")
+            = f.label(:visible, class: "form-check-label", for: "publisher_visible")
+        .form-group.panel-controls
+          = f.submit(t("publishers.shared.sign_up"), class: "btn btn-primary btn-block")
 
-      .tos=t(".tos_html",
-              tos_link: link_to(t("shared.terms_of_service"),
-                                'https://basicattentiontoken.org/publisher-terms-of-service/'))
+      .single-panel--footer= t(".tos_html", \
+          tos_link: link_to( \
+              t("shared.terms_of_service"), \
+              "https://basicattentiontoken.org/publisher-terms-of-service/" \
+          ) \
+      )

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -18,6 +18,6 @@
             = recaptcha_tags
         = f.submit(t("shared.log_in"), class: "btn btn-block btn-primary")
 
-    .single-panel--footer
+    .single-panel--footer.single-panel--footer--secondary
       ' #{t(".signup_prompt")}
       = link_to t("pubilshers.shared.sign_up"), sign_up_publishers_path

--- a/app/views/publishers/sign_up.html.slim
+++ b/app/views/publishers/sign_up.html.slim
@@ -18,6 +18,6 @@
             = recaptcha_tags
         = submit_tag t("shared.get_started"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing"
 
-    .single-panel--footer
+    .single-panel--footer.single-panel--footer--secondary
       ' #{t("shared.existing_account")}
       = link_to t("shared.log_in"), new_auth_token_publishers_path

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -44,6 +44,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "sends an email with an access link" do
+    url = nil
     perform_enqueued_jobs do
       post(publishers_path, params: SIGNUP_PARAMS)
       publisher = Publisher.order(created_at: :asc).last
@@ -54,6 +55,9 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
       url = publisher_url(publisher, token: publisher.authentication_token)
       assert_email_body_matches(matcher: url, email: email)
     end
+
+    get url
+    assert_redirected_to email_verified_publishers_path
   end
 
   test "re-used access link is rejected and send publisher to the expired auth token page" do

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -75,7 +75,7 @@ class PublishersHomeTest < Capybara::Rails::TestCase
     find('[data-test-modal-container]').click_link("Remove Channel")
     refute_content page, channel.publication_title
   end
-  
+
   test "land page renders, bad login can create an account" do
     email = 'new-test@example.com'
 
@@ -91,4 +91,21 @@ class PublishersHomeTest < Capybara::Rails::TestCase
     assert_content page, "An email is on its way"
   end
 
+  test "email verified publishers path" do
+    name = 'Some name'
+    publisher = publishers(:unprompted)
+    sign_in publisher
+
+    visit email_verified_publishers_path
+
+    assert_content page, "Finish signing up"
+
+    fill_in 'publisher_name', with: name
+    click_button('Sign Up')
+
+    assert_current_path(prompt_two_factor_registrations_path)
+    click_link('Skip for now')
+
+    assert_current_path(home_publishers_path)
+  end
 end


### PR DESCRIPTION
Port the `email_verified` page to Bootstrap 4. This page prompts the user to enter their name after signup. I've also added some tests around the flow.

Locally I'm getting test failures that seem related to Chrome beta/canary. For `fill_in` I get an error `call function result missing 'value'`. I'll keep looking into this, but I believe we should work around it by pinning Chrome versions where possible.

  * https://stackoverflow.com/questions/48609069/org-openqa-selenium-webdriverexception-unknown-error-call-function-result-miss/48665237#48665237

**Before**

<img width="1363" alt="screen shot 2018-02-12 at 1 01 12 pm" src="https://user-images.githubusercontent.com/8752/36119489-f0864c44-0ff4-11e8-9a35-accd3d1e8b4c.png">

**After**

<img width="1363" alt="screen shot 2018-02-12 at 1 01 48 pm" src="https://user-images.githubusercontent.com/8752/36119499-f68809a2-0ff4-11e8-93b4-e410ac096b7c.png">
