### PR TITLE
Adding youtube login back in

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -26,6 +26,11 @@ class PublishersController < ApplicationController
   before_action :require_verified_email,
     only: %i(email_verified
              complete_signup)
+  before_action :require_publisher_email_not_verified_through_youtube_auth,
+    except: %i(update_email
+               change_email)
+  before_action :require_publisher_email_verified_through_youtube_auth,
+                only: %i(update_email)
   before_action :require_verified_publisher,
     only: %i(edit_payment_info
              generate_statement
@@ -97,6 +102,7 @@ class PublishersController < ApplicationController
 
   def email_verified
     @publisher = current_publisher
+    @publisher_created_through_youtube_auth = session[:publisher_created_through_youtube_auth]
   end
 
   def complete_signup
@@ -116,10 +122,30 @@ class PublishersController < ApplicationController
         Raven.capture_exception(e)
       end
 
+      session[:publisher_created_through_youtube_auth] = nil
       redirect_to publisher_next_step_path(@publisher)
     else
       render(:email_verified)
     end
+  end
+
+  def update_email
+    @publisher = current_publisher
+    update_params = publisher_update_email_params
+
+    if update_params[:pending_email].present?
+      if @publisher.update(update_params)
+        PublisherMailer.notify_email_change(@publisher).deliver_later
+        PublisherMailer.confirm_email_change(@publisher).deliver_later
+        PublisherMailer.confirm_email_change_internal(@publisher).deliver_later if PublisherMailer.should_send_internal_emails?
+
+        @publisher_email = @publisher.pending_email
+        render :create_done
+        return
+      end
+    end
+
+    render :change_email
   end
 
   def update
@@ -237,6 +263,14 @@ class PublishersController < ApplicationController
     redirect_to(publisher_next_step_path(@publisher))
   end
 
+  def change_email
+    @publisher = current_publisher
+  end
+
+  def change_email_confirm
+    @publisher = current_publisher
+  end
+
   # Entrypoint for the authenticated re-login link.
   def show
     redirect_to(publisher_next_step_path(current_publisher))
@@ -332,11 +366,16 @@ class PublishersController < ApplicationController
     return if publisher_id.blank? || token.blank?
 
     publisher = Publisher.find(publisher_id)
+    publisher_created_through_youtube_auth = publisher_created_through_youtube_auth?(publisher)
+    if publisher_created_through_youtube_auth
+      session[:publisher_created_through_youtube_auth] = publisher_created_through_youtube_auth
+    end
 
     if PublisherTokenAuthenticator.new(publisher: publisher, token: token, confirm_email: confirm_email).perform
-      if confirm_email.present? && publisher.email == confirm_email
+      if confirm_email.present? && publisher.email == confirm_email && !publisher_created_through_youtube_auth
         flash[:alert] = t(".email_confirmed", email: publisher.email)
       end
+
       if two_factor_enabled?(publisher)
         session[:pending_2fa_current_publisher_id] = publisher_id
         redirect_to two_factor_authentications_path
@@ -354,6 +393,10 @@ class PublishersController < ApplicationController
 
   def publisher_update_params
     params.require(:publisher).permit(:pending_email, :phone, :name, :default_currency, :visible)
+  end
+
+  def publisher_update_email_params
+    params.require(:publisher).permit(:pending_email)
   end
 
   def publisher_create_auth_token_params
@@ -374,6 +417,16 @@ class PublishersController < ApplicationController
   def require_verified_publisher
     return if current_publisher.verified?
     redirect_to(publisher_next_step_path(current_publisher), alert: t(".verification_required"))
+  end
+
+  def require_publisher_email_not_verified_through_youtube_auth
+    return unless publisher_created_through_youtube_auth?(current_publisher)
+    redirect_to(change_email_publishers_path)
+  end
+
+  def require_publisher_email_verified_through_youtube_auth
+    return if publisher_created_through_youtube_auth?(current_publisher)
+    redirect_to(change_email_publishers_path)
   end
 
   # Level 1 throttling -- After the first two requests, ask user to

--- a/app/controllers/site_channels_controller.rb
+++ b/app/controllers/site_channels_controller.rb
@@ -1,5 +1,6 @@
 class SiteChannelsController < ApplicationController
   include ChannelsHelper
+  include PublishersHelper
 
   before_action :authenticate_publisher!
   before_action :setup_current_channel,
@@ -34,6 +35,8 @@ class SiteChannelsController < ApplicationController
                          verification_support_queue
                          verification_github
                          verification_wordpress)
+  before_action :require_publisher_email_not_verified_through_youtube_auth,
+                only: %i(create)
 
   attr_reader :current_channel
 
@@ -148,5 +151,10 @@ class SiteChannelsController < ApplicationController
         raise "unknown action"
     end
     current_channel.details.save! if current_channel.details.verification_method_changed?
+  end
+
+  def require_publisher_email_not_verified_through_youtube_auth
+    return unless publisher_created_through_youtube_auth?(current_publisher)
+    redirect_to(home_publishers_path)
   end
 end

--- a/app/views/application/_icon_circled_check.html
+++ b/app/views/application/_icon_circled_check.html
@@ -1,0 +1,14 @@
+<svg width="72px" height="72px" viewBox="0 0 72 72" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>icn-check</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="legacy-oauth-patch-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-625.000000, -228.000000)">
+        <g id="dialog" transform="translate(364.000000, 143.000000)">
+            <g id="icn-check" transform="translate(264.000000, 88.000000)">
+                <polygon id="Path-3" fill="#00BA99" points="13 35.2333261 17.106044 31.5025196 27.2748634 40.3526342 50.1751806 20 54 23.5034343 29.0434565 49 27.2748634 49"></polygon>
+                <circle id="Oval-4" stroke="#00BA99" stroke-width="5" cx="33" cy="33" r="33"></circle>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/views/publishers/change_email.html.slim
+++ b/app/views/publishers/change_email.html.slim
@@ -1,0 +1,24 @@
+- content_for(:head_style_tags) do
+  = stylesheet_link_tag("application", media: "all")
+
+.single-panel--wrapper
+  = render "panel_flash_messages"
+  .single-panel--content
+
+    h3.single-panel--headline= t ".login_email"
+
+    .col-small-centered
+      p
+        span= t ".login_email_message"
+
+      = form_for @publisher, url: update_email_publishers_path do |f|
+        .form-group
+          = f.email_field :pending_email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email")
+          .text-left
+            strong= t ".login_email_note"
+        - if params[:captcha]
+          = hidden_field_tag(:captcha)
+        - if @should_throttle
+          .form-group
+            = recaptcha_tags
+        = f.submit(t("shared.continue"), class: "btn btn-block btn-primary")

--- a/app/views/publishers/change_email_confirm.html.slim
+++ b/app/views/publishers/change_email_confirm.html.slim
@@ -1,0 +1,14 @@
+- content_for(:head_style_tags) do
+  = stylesheet_link_tag("application", media: "all")
+
+.single-panel--wrapper
+  = render "panel_flash_messages"
+  .single-panel--content
+    .col-small-centered
+      = render "icon_circled_check"
+
+      h3.single-panel--headline= t ".login_email_changed"
+
+      p= t(".login_email_verified_html", login_email: @publisher.email)
+
+      = link_to(t("shared.ok"), email_verified_publishers_path, class: "btn btn-block btn-primary")

--- a/app/views/publishers/choose_new_channel_type.html.slim
+++ b/app/views/publishers/choose_new_channel_type.html.slim
@@ -12,7 +12,7 @@
         .choice-description
           h3.text-center= t ".site_operator.heading"
           p.text-center= t ".site_operator.description"
-  = link_to(publisher_google_oauth2_omniauth_authorize_path) do
+  = link_to(publisher_register_youtube_channel_omniauth_authorize_path) do
     .choice-panel.choice-panel-right
       .individual-creator.select-choice
         .choice-description

--- a/app/views/publishers/email_verified.html.slim
+++ b/app/views/publishers/email_verified.html.slim
@@ -27,9 +27,13 @@
             = f.check_box(:visible, class: "form-check-input")
             = f.label(:visible, class: "form-check-label", for: "publisher_visible")
         .form-group.panel-controls
-          = f.submit(t("publishers.shared.sign_up"), class: "btn btn-primary btn-block")
+          - if @publisher_created_through_youtube_auth
+            - @action = t("shared.continue")
+          - else
+            - @action = t("publishers.shared.sign_up")
+          = f.submit(@action, class: "btn btn-primary btn-block")
 
-      .single-panel--footer= t(".tos_html", \
+      .single-panel--footer= t(".tos_html", action: @action, \
           tos_link: link_to( \
               t("shared.terms_of_service"), \
               "https://basicattentiontoken.org/publisher-terms-of-service/" \

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,16 @@ Devise.setup do |config|
                   Rails.application.secrets[:google_client_id],
                   Rails.application.secrets[:google_client_secret],
                   {
-                    scope: "profile,email,https://www.googleapis.com/auth/youtube.readonly"
+                      name: 'register_youtube_channel',
+                      scope: "profile,email,https://www.googleapis.com/auth/youtube.readonly"
+                  }
+
+  config.omniauth :google_oauth2,
+                  Rails.application.secrets[:google_client_id],
+                  Rails.application.secrets[:google_client_secret],
+                  {
+                      name: 'youtube_login',
+                      scope: "profile,email,https://www.googleapis.com/auth/youtube.readonly"
                   }
 
   # ==> Warden configuration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     log_in: Log In
     remove: Remove
     terms_of_service: Terms of Service
+    ok: OK
   activerecord:
     shared:
       errors: "There were errors saving your request:"
@@ -227,6 +228,14 @@ en:
     show:
       email_confirmed: Your updated email address %{email} has been confirmed.
       token_invalid: Authentication failed. Your login link may have expired; please send yourself a new sign in link.
+    change_email:
+      login_email: Login Email
+      login_email_message: We need your valid email address for account access and recovery purposes.
+      login_email_note: "* This will be your login from now on."
+    change_email_confirm:
+      login_email_changed: Great!
+      login_email_verified_html: |
+        <strong>'%{login_email}'</strong> has been verified. Please use this email as a login to access your account with Brave Payments.
     choose_new_channel_type:
       intro: Let's start with choosing where you're publishing your content.
       site_operator:
@@ -264,7 +273,7 @@ en:
       heading: One last thing...
       intro: Finish signing up by entering below.
       name_placeholder: First and last name
-      tos_html: By clicking 'Sign Up', you're agreeing to our %{tos_link}
+      tos_html: By clicking '%{action}', you're agreeing to our %{tos_link}
     expired_auth_token:
       expired_error: Your login link has expired. Please send yourself another one.
       heading: Login Link Expired
@@ -295,8 +304,10 @@ en:
     new_auth_token:
       signup_prompt: Don't have an account?
     omniauth_callbacks:
-      google_oauth2:
+      register_youtube_channel:
         channel_already_registered: You have already registered this YouTube channel.
+      youtube_login:
+        channel_not_eligable_for_youtube_login: Channel is not able to use Youtube login. Please use your email address.
       require_publisher:
         log_in_and_retry: Please log in to Brave Payments and retry the operation
     require_unauthenticated_publisher:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
       get :home
       get :log_in, action: :new_auth_token, as: :new_auth_token
       post :log_in, action: :create_auth_token, as: :create_auth_token
+      get :change_email
+      get :change_email_confirm
+      patch :update_email
       get :expired_auth_token
       get :log_out
       get :email_verified

--- a/test/controllers/api/owners_controller_test.rb
+++ b/test/controllers/api/owners_controller_test.rb
@@ -33,6 +33,6 @@ class Api::OwnersControllerTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
 
     response_json = JSON.parse(response.body)
-    assert_equal 4, response_json.length
+    assert_equal 5, response_json.length
   end
 end

--- a/test/controllers/publishers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/publishers/omniauth_callbacks_controller_test.rb
@@ -29,9 +29,9 @@ module Publishers
 
         token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
 
-        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+        OmniAuth.config.mock_auth[:register_youtube_channel] = OmniAuth::AuthHash.new(
             {
-                "provider" => "google_oauth2",
+                "provider" => "register_youtube_channel",
                 "uid" => "123545",
                 "info" => {
                     "name" => "Test Brand Account",
@@ -70,17 +70,17 @@ module Publishers
             to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
 
         assert_difference("Channel.count", 1) do
-          get(publisher_google_oauth2_omniauth_authorize_url)
+          get(publisher_register_youtube_channel_omniauth_authorize_url)
           follow_redirect!
           assert_redirected_to home_publishers_path
         end
         channel = Channel.order(created_at: :asc).last
 
-        assert_equal channel.details.auth_provider, "google_oauth2"
+        assert_equal channel.details.auth_provider, "register_youtube_channel"
         assert_equal channel.details.auth_user_id, "123545"
         assert_equal channel.details.auth_email, "brand@nonfunctional.google.com"
         assert_not_nil channel.details.youtube_channel_id
-        assert_equal "google_oauth2", channel.details.auth_provider
+        assert_equal "register_youtube_channel", channel.details.auth_provider
         assert_equal "DIY", channel.details.title
       end
     end
@@ -99,9 +99,9 @@ module Publishers
 
         token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
 
-        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+        OmniAuth.config.mock_auth[:register_youtube_channel] = OmniAuth::AuthHash.new(
             {
-                "provider" => "google_oauth2",
+                "provider" => "register_youtube_channel",
                 "uid" => "123545",
                 "info" => {
                     "name" => "Test Brand Account",
@@ -140,7 +140,7 @@ module Publishers
             to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
 
         assert_difference("Channel.count", 0) do
-          get(publisher_google_oauth2_omniauth_authorize_url)
+          get(publisher_register_youtube_channel_omniauth_authorize_url)
           follow_redirect!
           assert_redirected_to home_publishers_path
           follow_redirect!
@@ -167,9 +167,9 @@ module Publishers
 
         token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
 
-        OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+        OmniAuth.config.mock_auth[:register_youtube_channel] = OmniAuth::AuthHash.new(
             {
-                "provider" => "google_oauth2",
+                "provider" => "register_youtube_channel",
                 "uid" => "123545",
                 "info" => {
                     "name" => "Test Brand Account",
@@ -208,16 +208,154 @@ module Publishers
             to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
 
         assert_difference("Channel.count", 0) do
-          get(publisher_google_oauth2_omniauth_authorize_url)
+          get(publisher_register_youtube_channel_omniauth_authorize_url)
           follow_redirect!
           assert_redirected_to home_publishers_path
           follow_redirect!
         end
 
         assert_select('div.notifications') do |element|
-          assert_match(I18n.t("publishers.omniauth_callbacks.google_oauth2.channel_already_registered"), element.text)
+          assert_match(I18n.t("publishers.omniauth_callbacks.register_youtube_channel.channel_already_registered"), element.text)
         end
         Rails.application.secrets[:active_promo_id] = active_promo_id_original
+      end
+    end
+
+    test "a publisher who only has a google plus email can login using their login channel" do
+      begin
+        OmniAuth.config.test_mode = true
+
+        token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
+
+        OmniAuth.config.mock_auth[:youtube_login] = OmniAuth::AuthHash.new(
+            {
+                "provider" => "youtube_login",
+                "uid" => "joe123456",
+                "info" => {
+                    "name" => "Joe's awesome stuff",
+                    "email" => "joes-great-channel@pages.plusgoogle.com",
+                    "first_name" => "Joe",
+                    "image" => "https://some_image_host.com/some_image.png"
+                },
+                "credentials" => {
+                    "token" => token,
+                    "expires_at" => 2510156374,
+                    "expires" => true
+                }
+            }
+        )
+
+        get(publisher_youtube_login_omniauth_authorize_url)
+        follow_redirect!
+        assert_redirected_to change_email_publishers_path
+      end
+    end
+
+    test "a publisher who does not have a google plus email can not login using their login channel" do
+      begin
+        OmniAuth.config.test_mode = true
+
+        token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
+
+        OmniAuth.config.mock_auth[:youtube_login] = OmniAuth::AuthHash.new(
+            {
+                "provider" => "youtube_login",
+                "uid" => "global_yt1_details_abc123",
+                "info" => {
+                    "name" => "Global 1",
+                    "email" => "global_yt1_details@pages.plusgoogle.com",
+                    "first_name" => "Global 1",
+                    "image" => "https://some_image_host.com/some_image.png"
+                },
+                "credentials" => {
+                    "token" => token,
+                    "expires_at" => 2510156374,
+                    "expires" => true
+                }
+            }
+        )
+
+        get(publisher_youtube_login_omniauth_authorize_url)
+        follow_redirect!
+        assert_redirected_to new_auth_token_publishers_path
+      end
+    end
+
+    test "a publisher who was registered by youtube channel signup can't add additional youtube channels" do
+      begin
+        OmniAuth.config.test_mode = true
+
+        token = "ya29.Glz-BARu50BO8bmnXM247jcU42d5GX4LsVm1Vy57rcRxm9TfA_damOV0mX6ZY1H0vL3uxUglXykMC1NmZyr-Lg7J0JYwNkgfkFfKv_jn1ePsikVKkMjz1RqaLT3Hbw"
+
+        OmniAuth.config.mock_auth[:youtube_login] = OmniAuth::AuthHash.new(
+            {
+                "provider" => "youtube_login",
+                "uid" => "joe123456",
+                "info" => {
+                    "name" => "Joe's awesome stuff",
+                    "email" => "joes-great-channel@pages.plusgoogle.com",
+                    "first_name" => "Joe",
+                    "image" => "https://some_image_host.com/some_image.png"
+                },
+                "credentials" => {
+                    "token" => token,
+                    "expires_at" => 2510156374,
+                    "expires" => true
+                }
+            }
+        )
+
+        get(publisher_youtube_login_omniauth_authorize_url)
+        follow_redirect!
+        assert_redirected_to change_email_publishers_path
+
+        OmniAuth.config.mock_auth[:register_youtube_channel] = OmniAuth::AuthHash.new(
+            {
+                "provider" => "register_youtube_channel",
+                "uid" => "123545",
+                "info" => {
+                    "name" => "Test Brand Account",
+                    "email" => "brand@nonfunctional.google.com",
+                    "first_name" => "Test Brand Account",
+                    "image" => "https://lh4.googleusercontent.com/-tP57axXeGuI/AAAAAAAAAAI/AAAAAAAAAA0/LSxNfj3nB8c/photo.jpg"
+                },
+                "credentials" => {
+                    "token" => token,
+                    "expires_at" => 2510156374,
+                    "expires" => true
+                }
+            }
+        )
+
+        channel_data = {
+            "id" => "234542342332134",
+            "snippet" => {
+                "title" => "DIY",
+                "description" => "DIY Description",
+                "thumbnails" => {
+                    "default" => {
+                        "url" => "http://some_host.com/thumb.png"
+                    }
+                }
+            },
+            "statistics" => {
+                "subscriberCount" => 12
+            }
+        }
+
+        stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?mine=true&part=statistics,snippet").
+            with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                            'Authorization' => "Bearer #{token}",
+                            'User-Agent' => 'Faraday v0.9.2' }).
+            to_return(status: 200, body: { items: [channel_data] }.to_json, headers: {})
+
+        assert_difference("Channel.count", 0) do
+          get(publisher_register_youtube_channel_omniauth_authorize_url)
+          follow_redirect!
+          assert_redirected_to home_publishers_path
+          follow_redirect!
+          assert_redirected_to change_email_publishers_path
+        end
       end
     end
   end

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -114,3 +114,8 @@ medium_media_group_abandoned_3:
   verified: false
   created_at: <%= Time.now - 1.hour %>
   updated_at: <%= Time.now - 1.hour %>
+
+joe_yt1:
+  publisher: joe_the_only_yt_verified
+  details: joe_yt1_details (YoutubeChannelDetails)
+  verified: true

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -132,3 +132,11 @@ medium_media_group:
   agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
 
+joe_the_only_yt_verified:
+  email: "joes-great-channel@pages.plusgoogle.com"
+  name: "Joe Schmoe"
+  phone: "6035551212"
+  phone_normalized: "+16035551212"
+  visible: true
+  agreed_to_tos: "<%= 1.day.ago %>"
+  two_factor_prompted_at: "<%= 1.day.ago %>"

--- a/test/fixtures/youtube_channel_details.yml
+++ b/test/fixtures/youtube_channel_details.yml
@@ -4,29 +4,38 @@ youtube_initial_details:
   youtube_channel_id:
 
 youtube_new_details:
-  auth_user_id: "abc123"
+  auth_user_id: "youtube_new_details_abc123"
   auth_provider: "google_oauth2"
   youtube_channel_id: "323541525412313421"
   title: "The DIY Channel"
   thumbnail_url: "https://some_image_host.com/some_image.png"
 
 google_verified_details:
-  auth_user_id: "abc123"
+  auth_user_id: "google_verified_details_abc123"
   auth_provider: "google_oauth2"
   youtube_channel_id: "78032"
   title: "Some Other Guy's Channel"
   thumbnail_url: "https://some_image_host.com/some_image.png"
 
 global_yt1_details:
-  auth_user_id: "abc123"
+  auth_user_id: "global_yt1_details_abc123"
+  auth_email: "global_yt1_details@pages.plusgoogle.com"
   auth_provider: "google_oauth2"
   youtube_channel_id: "dsfdsa"
   title: "Global 1"
   thumbnail_url: "https://some_image_host.com/some_image.png"
 
 global_yt2_details:
-  auth_user_id: "abc123"
+  auth_user_id: "global_yt2_details_abc123"
   auth_provider: "google_oauth2"
   youtube_channel_id: "dadsgdfssfdsa"
   title: "Global 2"
+  thumbnail_url: "https://some_image_host.com/some_image.png"
+
+joe_yt1_details:
+  auth_user_id: "joe123456"
+  auth_email: "joes-great-channel@pages.plusgoogle.com"
+  auth_provider: "google_oauth2"
+  youtube_channel_id: "joeddfsads"
+  title: "Joe's awesome stuff"
   thumbnail_url: "https://some_image_host.com/some_image.png"


### PR DESCRIPTION
This PR adds OAuth login for publishers that were created through the login attempt of a youtube channel.

Access to this login process is through a non public link "/publishers/auth/youtube_login".

The OAuth logins have also been reworked to handle login separately from channel authentication. The changes require the creation of two new "Authorized redirect URIs". For example these are the URIs for a development server, and must be [entered](https://console.developers.google.com/apis/credentials) before merging this PR:

`http://localhost:3000/publishers/auth/register_youtube_channel/callback`
`http://localhost:3000/publishers/auth/youtube_login/callback`

and we can remove the old one once the changes are deployed:
`http://localhost:3000/publishers/auth/google_oauth2/callback`

**Todo** Still waiting on some additional wording changes for the login screen, and on the screen after the change email has been sent. That is currently reusing the "An email is on its way!" which is sent after sign-up.

Fixes #610 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
