### PR TITLE
Adds `default_currency` and `uphold_verified` to owners serializer

### DIFF
--- a/app/serializers/publisher_serializer.rb
+++ b/app/serializers/publisher_serializer.rb
@@ -1,5 +1,6 @@
 class PublisherSerializer < ActiveModel::Serializer
-  attributes :owner_identifier, :email, :name, :phone_normalized, :channel_identifiers, :show_verification_status
+  attributes :owner_identifier, :email, :name, :phone_normalized, :channel_identifiers, :show_verification_status,
+             :default_currency, :uphold_verified
 
   def show_verification_status
     object.visible?

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -120,6 +120,8 @@ small_media_group:
   two_factor_prompted_at: "<%= 1.day.ago %>"
   agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
+  default_currency: "BAT"
+
 
 medium_media_group:
   email: "barney@medium.org"

--- a/test/serializers/publisher_serializer_test.rb
+++ b/test/serializers/publisher_serializer_test.rb
@@ -2,7 +2,9 @@ require "test_helper"
 
 class PublisherSerializerTest < ActiveSupport::TestCase
   test "owners are serialized as JSON and include owner and channel details rolled up" do
-    owner = publishers(:verified)
+    owner = publishers(:small_media_group)
+    owner.uphold_verified = true
+    owner.save!
 
     result = PublisherSerializer.new(owner).to_json
     json_result = JSON.parse(result)
@@ -12,6 +14,8 @@ class PublisherSerializerTest < ActiveSupport::TestCase
     assert json_result.has_key?("name")
     assert json_result.has_key?("phone_normalized")
     assert json_result.has_key?("channel_identifiers")
+    assert json_result.has_key?("default_currency")
+    assert json_result.has_key?("uphold_verified")
     assert json_result.has_key?("show_verification_status")
     assert json_result["channel_identifiers"].is_a?(Array)
 


### PR DESCRIPTION
Note, this api filters out `blank` values. This includes false booleans. 

Fixes #616 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
