### PR TITLE
Job record not found exceptions

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,6 +6,11 @@ class ApplicationJob < ActiveJob::Base
     ErrorHandlerDelegator.new(super)
   end
 
+  rescue_from(ActiveRecord::RecordNotFound) do |exception|
+    require "sentry-raven"
+    Raven.capture_exception(exception)
+  end
+
   def self.instance
     @__instance__ ||= new
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,9 @@ require "selenium/webdriver"
 require "minitest/rails/capybara"
 require "webmock/minitest"
 require "chromedriver/helper"
+require 'sidekiq/testing'
+
+Sidekiq::Testing.fake!
 
 WebMock.allow_net_connect!
 


### PR DESCRIPTION
This fixes the issue observer in #629 where tests jobs are entered into the development redis queue. it also sends the RecordNotFound errors to Raven. That shouldn't happen on production, but...

Fixes #629

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))