### PR TITLE
Refactor panels to better show whitespace

### DIFF
--- a/app/assets/stylesheets/pages/two_factor_authentications.scss
+++ b/app/assets/stylesheets/pages/two_factor_authentications.scss
@@ -12,4 +12,7 @@
   &--alternative-hr {
     margin: $spacer*2 0 $spacer*3;
   }
+  &--retry {
+    margin-top: $spacer*1.5;
+  }
 }

--- a/app/assets/stylesheets/theme/columns.scss
+++ b/app/assets/stylesheets/theme/columns.scss
@@ -1,23 +1,15 @@
 .col-small-centered {
   @include make-col-ready();
-  @include media-breakpoint-up(sm) {
-    @include make-col(10);
-    @include make-col-offset(1);
-  }
-  @include media-breakpoint-up(md) {
-    @include make-col(9);
-    @include make-col-offset(1.5);
-  }
-  @include media-breakpoint-up(lg) {
-    @include make-col(8);
-    @include make-col-offset(2);
+  @include make-col(8);
+  margin: 0 auto; 
+  @include media-breakpoint-down(xs) {
+    @include make-col(12);
+    max-width: $spacer*19;
   }
   padding-left: 0;
   padding-right: 0;
   &--with-right-background {
-    @include make-col(12);
-    @include make-col-offset(0);
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(md) {
       @include make-col(6);
       @include make-col-offset(2);
     }
@@ -26,9 +18,10 @@
 
 .col-medium-centered {
   @include make-col-ready();
-  @include media-breakpoint-up(sm) {
-    @include make-col(10);
-    @include make-col-offset(1);
+  @include make-col(10);
+  margin: 0 auto;
+  @include media-breakpoint-down(xs) {
+    @include make-col(12);
   }
   padding-left: 0;
   padding-right: 0;
@@ -72,22 +65,17 @@
 .col-two-factor {
   &--content {
     @include make-col-ready();
+    text-align: left;
+
     @include media-breakpoint-up(md) {
       @include make-col(9);
+      margin-bottom: $spacer*2;
     }
-    @include media-breakpoint-up(lg) {
-      @include make-col(8);
-      @include make-col-offset(1);
-    }
-    text-align: left;
   }
   &--action {
     @include make-col-ready();
     @include media-breakpoint-up(md) {
       @include make-col(3);
-    }
-    @include media-breakpoint-up(lg) {
-      @include make-col(2);
     }
 
     p.icon {

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -1,46 +1,33 @@
 $brave-panels-borderRadius: 8px;
 
+.panels-container {
+  padding: 0 15px;
+}
+
 .single-panel {
 
   &--wrapper {
-    @include make-col-ready();
-    @include media-breakpoint-up(sm) {
-      @include make-col(10);
-      @include make-col-offset(1);
-    }
-    @include media-breakpoint-up(md) {
-      @include make-col(8);
-      @include make-col-offset(2);
-    }
-    @include media-breakpoint-up(lg) {
-      @include make-col(6);
-      @include make-col-offset(3);
-    }
+    max-width: $spacer*40;
+    min-height: $spacer*32;
+    margin: 0 auto;
+    padding: 0 15px;
+    display: flex;
+    flex-direction: column;
 
     background-color: white;
     border-radius: $brave-panels-borderRadius;
     box-shadow: 2px 2px 0px 0px rgba(47,48,50,0.15);
 
+    @include media-breakpoint-down(xs) {
+      min-height: $spacer*10; 
+    }
+
     &--medium {
-      @include media-breakpoint-up(sm) {
-        @include make-col(10);
-        @include make-col-offset(1);
-      }
-      @include media-breakpoint-up(md) {
-        @include make-col(8);
-        @include make-col-offset(2);
-      }
+      max-width: $spacer*45;
     }
 
     &--large {
-      @include media-breakpoint-up(sm) {
-        @include make-col(10);
-        @include make-col-offset(1);
-      }
-      @include media-breakpoint-up(md) {
-        @include make-col(10);
-        @include make-col-offset(1);
-      }
+      max-width: $spacer*50;
     }
 
     &--small {
@@ -61,22 +48,22 @@ $brave-panels-borderRadius: 8px;
 
   &--content {
     @include make-row();
-    padding: $spacer*3 $spacer $spacer*2;
+
     text-align: center;
+    justify-content: center;
+    flex: 1;
 
     &--email-sent {
-      @include media-breakpoint-up(lg) {
+      @include media-breakpoint-up(md) {
         background-image: url(asset-path("email-2@1x.png"));
         background-position: top 59px right 60px;
         background-repeat: no-repeat;
-        padding-top: $spacer*9;
-        padding-bottom: $spacer*9;
       }
     }
     &--platforms {
       padding-top: $spacer*2;
       padding-bottom: $spacer;
-      @include media-breakpoint-up(lg) {
+      @include media-breakpoint-up(md) {
         background-image: url(asset-path("img-brands.png"));
         background-position: top right;
         background-repeat: no-repeat;
@@ -85,7 +72,8 @@ $brave-panels-borderRadius: 8px;
       }
     }
     &--alert {
-      padding: $spacer $spacer $spacer;
+      flex: 0;
+      padding: $spacer*2 $spacer*2 $spacer*2;
       background: $braveError-Background;
       color: $braveError-Foreground;
       border-top-left-radius: $brave-panels-borderRadius;
@@ -95,7 +83,8 @@ $brave-panels-borderRadius: 8px;
       }
     }
     &--warning {
-      padding: $spacer $spacer $spacer;
+      flex: 0;
+      padding: $spacer*2 $spacer*2 $spacer*2;
       background: $braveWarning-Background;
       color: $braveWarning-Foreground;
       border-top-left-radius: $brave-panels-borderRadius;
@@ -105,7 +94,8 @@ $brave-panels-borderRadius: 8px;
       }
     }
     &--notice {
-      padding: $spacer $spacer $spacer;
+      flex: 0;
+      padding: $spacer*2 $spacer*2 $spacer*2;
       background: $braveInfo-Background;
       color: $braveInfo-Foreground;
       border-bottom: 1px solid $braveInfo-Border;
@@ -124,9 +114,25 @@ $brave-panels-borderRadius: 8px;
     }
   }
 
+  &--padded-content {
+    padding: $spacer*2;
+    margin-top: auto;
+    margin-bottom: auto;
+
+    align-items: center;
+    justify-content: center;
+
+    @include media-breakpoint-down(xs) {
+      padding: $spacer;
+    }
+  }
+
   &--headline {
     width: 100%;
     margin-bottom: $spacer*2;
+    @include media-breakpoint-down(xs) {
+      margin-top: $spacer;
+    }
     &--primary {
       color: theme-color('primary');
     }

--- a/app/views/application/_icon_circled_check.html
+++ b/app/views/application/_icon_circled_check.html
@@ -1,14 +1,6 @@
-<svg width="72px" height="72px" viewBox="0 0 72 72" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
-    <title>icn-check</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="legacy-oauth-patch-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-625.000000, -228.000000)">
-        <g id="dialog" transform="translate(364.000000, 143.000000)">
-            <g id="icn-check" transform="translate(264.000000, 88.000000)">
-                <polygon id="Path-3" fill="#00BA99" points="13 35.2333261 17.106044 31.5025196 27.2748634 40.3526342 50.1751806 20 54 23.5034343 29.0434565 49 27.2748634 49"></polygon>
-                <circle id="Oval-4" stroke="#00BA99" stroke-width="5" cx="33" cy="33" r="33"></circle>
-            </g>
-        </g>
-    </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 72 72">
+  <g fill="none" fill-rule="evenodd" transform="translate(3 3)">
+    <polygon fill="#00BA99" fill-rule="nonzero" points="13 35.233 17.106 31.503 27.275 40.353 50.175 20 54 23.503 29.043 49 27.275 49"/>
+    <circle cx="33" cy="33" r="33" stroke="#00BA99" stroke-width="5"/>
+  </g>
 </svg>

--- a/app/views/layouts/publishers.html.slim
+++ b/app/views/layouts/publishers.html.slim
@@ -1,18 +1,18 @@
-- content_for(:content) do
-  / ToDo: DRY this up
-  -if @hide_nav
-    .main-content.sans-nav
-      #content.container
-        = yield
-  -else
-    .main-content
-      #content.container
+- %w(new_auth_token create_auth_token sign_up create_done email_verified change_email change_email_confirm expired_auth_token).include?(action_name).tap do |is_bootstrap4|
+
+  - if is_bootstrap4
+    - content_for(:head_style_tags) do
+      = stylesheet_link_tag("application", media: "all")
+
+  - content_for(:content) do
+    .main-content class="#{@hide_nav ? 'sans-nav' : '' }"
+      div id="#{is_bootstrap4 ? '' : 'content'}" class="#{is_bootstrap4 ? 'panels-container' : 'container' }"
         = yield
 
-// viewport_initial_scale here is a whitelist of actions that have true
-// responsiveness, and no longer need to 0.6 viewport scaling.
-= render \
-  template: "layouts/application",
-  locals: { \
-    viewport_initial_scale: (%w(new_auth_token create_auth_token sign_up create_done email_verified).include?(action_name) && "1.0") \
-  }
+  // viewport_initial_scale here is a whitelist of actions that have true
+  // responsiveness, and no longer need to 0.6 viewport scaling.
+  = render \
+    template: "layouts/application",
+    locals: { \
+      viewport_initial_scale: (is_bootstrap4 && "1.0") \
+    }

--- a/app/views/layouts/totp_registrations.html.slim
+++ b/app/views/layouts/totp_registrations.html.slim
@@ -3,7 +3,7 @@
 
 - content_for(:content) do
   .main-content
-    #content.container
+    .panels-container
       = yield
 
 = render \

--- a/app/views/layouts/two_factor_authentications.html.slim
+++ b/app/views/layouts/two_factor_authentications.html.slim
@@ -3,7 +3,7 @@
 
 - content_for(:content) do
   .main-content
-    #content.container
+    .panels-container
       = yield
 
 = render \

--- a/app/views/layouts/two_factor_registrations.html.slim
+++ b/app/views/layouts/two_factor_registrations.html.slim
@@ -3,7 +3,7 @@
 
 - content_for(:content) do
   .main-content
-    #content.container
+    .panels-container
       = yield
 
 = render \

--- a/app/views/layouts/u2f_registrations.html.slim
+++ b/app/views/layouts/u2f_registrations.html.slim
@@ -3,7 +3,7 @@
 
 - content_for(:content) do
   .main-content
-    #content.container
+    .panels-container
       = yield
 
 = render \

--- a/app/views/publishers/change_email.html.slim
+++ b/app/views/publishers/change_email.html.slim
@@ -1,24 +1,22 @@
-- content_for(:head_style_tags) do
-  = stylesheet_link_tag("application", media: "all")
-
 .single-panel--wrapper
   = render "panel_flash_messages"
   .single-panel--content
+    .single-panel--padded-content
 
-    h3.single-panel--headline= t ".login_email"
+      h3.single-panel--headline= t ".login_email"
 
-    .col-small-centered
-      p
-        span= t ".login_email_message"
+      .col-small-centered
+        p
+          span= t ".login_email_message"
 
-      = form_for @publisher, url: update_email_publishers_path do |f|
-        .form-group
-          = f.email_field :pending_email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email")
-          .text-left
-            strong= t ".login_email_note"
-        - if params[:captcha]
-          = hidden_field_tag(:captcha)
-        - if @should_throttle
+        = form_for @publisher, url: update_email_publishers_path do |f|
           .form-group
-            = recaptcha_tags
-        = f.submit(t("shared.continue"), class: "btn btn-block btn-primary")
+            = f.email_field :pending_email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email")
+            .text-left
+              strong= t ".login_email_note"
+          - if params[:captcha]
+            = hidden_field_tag(:captcha)
+          - if @should_throttle
+            .form-group
+              = recaptcha_tags
+          = f.submit(t("shared.continue"), class: "btn btn-block btn-primary")

--- a/app/views/publishers/change_email_confirm.html.slim
+++ b/app/views/publishers/change_email_confirm.html.slim
@@ -1,14 +1,12 @@
-- content_for(:head_style_tags) do
-  = stylesheet_link_tag("application", media: "all")
-
 .single-panel--wrapper
   = render "panel_flash_messages"
   .single-panel--content
-    .col-small-centered
-      = render "icon_circled_check"
+    .single-panel--padded-content
+      .col-small-centered
+        = render "icon_circled_check"
 
-      h3.single-panel--headline= t ".login_email_changed"
+        h3.single-panel--headline= t ".login_email_changed"
 
-      p= t(".login_email_verified_html", login_email: @publisher.email)
+        p= t(".login_email_verified_html", login_email: @publisher.email)
 
-      = link_to(t("shared.ok"), email_verified_publishers_path, class: "btn btn-block btn-primary")
+        = link_to(t("shared.ok"), email_verified_publishers_path, class: "btn btn-block btn-primary")

--- a/app/views/publishers/create_auth_token.html.slim
+++ b/app/views/publishers/create_auth_token.html.slim
@@ -1,11 +1,9 @@
-- content_for(:head_style_tags) do
-  = stylesheet_link_tag("application", media: "all")
-
 .single-panel--wrapper
   = render "panel_flash_messages"
   .single-panel--content
+    .single-panel--padded-content
 
-    h3.single-panel--headline= t ".heading"
+      h3.single-panel--headline= t ".heading"
 
-    .col-small-centered
-      p.text-center= t ".body"
+      .col-small-centered
+        p.text-center= t ".body"

--- a/app/views/publishers/create_done.html.slim
+++ b/app/views/publishers/create_done.html.slim
@@ -1,13 +1,10 @@
-- content_for(:head_style_tags) do
-  = stylesheet_link_tag("application", media: "all")
-
 .single-panel--wrapper.single-panel--wrapper--large
   = render "panel_flash_messages"
   .single-panel--content.single-panel--content--email-sent
+    .single-panel--padded-content
+      h3.single-panel--headline= t ".heading"
 
-    h3.single-panel--headline= t ".heading"
+      .col-small-centered
+        = t ".body_html", email: @publisher_email, try_again_link: link_to(t(".try_again"), "#", onclick: "document.getElementById('resend_email_form').submit();")
 
-    .col-small-centered
-      = t ".body_html", email: @publisher_email, try_again_link: link_to(t(".try_again"), "#", onclick: "document.getElementById('resend_email_form').submit();")
-
-      = form_tag resend_email_verify_email_publishers_path, method: "post", class: "hidden", id: "resend_email_form"
+        = form_tag resend_email_verify_email_publishers_path, method: "post", class: "hidden", id: "resend_email_form"

--- a/app/views/publishers/email_verified.html.slim
+++ b/app/views/publishers/email_verified.html.slim
@@ -1,41 +1,40 @@
-- content_for(:head_style_tags) do
-  = stylesheet_link_tag("application", media: "all")
+.single-panel--wrapper.single-panel--wrapper--large
+  = render "panel_flash_messages"
+  .single-panel--content.single-panel--content--platforms
+    .single-panel--padded-content
+      .col-small-centered.col-small-centered--with-right-background.text-left
 
-.single-panel--wrapper.single-panel--wrapper--medium
- .single-panel--content.single-panel--content--platforms
-    .col-small-centered.col-small-centered--with-right-background.text-left
+        h1.single-panel--headline.single-panel--headline--primary= t ".heading"
+        p
+          span= t ".intro"
 
-      h1.single-panel--headline.single-panel--headline--primary= t ".heading"
-      p
-        span= t ".intro"
+        = form_for(@publisher, { \
+            method: :patch, \
+            url: complete_signup_publishers_path, \
+            html: { id: "update_contact_info" } \
+        }) do |f|
+          .form-group
+            = f.label(:name, class: "control-label")
+            = f.text_field(:name, \
+                autofocus: true, \
+                class: "form-control", \
+                placeholder: t(".name_placeholder"), \
+                required: true \
+            )
+          .form-group
+            .form-check
+              = f.check_box(:visible, class: "form-check-input")
+              = f.label(:visible, class: "form-check-label", for: "publisher_visible")
+          .form-group.panel-controls
+            - if @publisher_created_through_youtube_auth
+              - @action = t("shared.continue")
+            - else
+              - @action = t("publishers.shared.sign_up")
+            = f.submit(@action, class: "btn btn-primary btn-block")
 
-      = form_for(@publisher, { \
-          method: :patch, \
-          url: complete_signup_publishers_path, \
-          html: { id: "update_contact_info" } \
-      }) do |f|
-        .form-group
-          = f.label(:name, class: "control-label")
-          = f.text_field(:name, \
-              autofocus: true, \
-              class: "form-control", \
-              placeholder: t(".name_placeholder"), \
-              required: true \
-          )
-        .form-group
-          .form-check
-            = f.check_box(:visible, class: "form-check-input")
-            = f.label(:visible, class: "form-check-label", for: "publisher_visible")
-        .form-group.panel-controls
-          - if @publisher_created_through_youtube_auth
-            - @action = t("shared.continue")
-          - else
-            - @action = t("publishers.shared.sign_up")
-          = f.submit(@action, class: "btn btn-primary btn-block")
-
-      .single-panel--footer= t(".tos_html", action: @action, \
-          tos_link: link_to( \
-              t("shared.terms_of_service"), \
-              "https://basicattentiontoken.org/publisher-terms-of-service/" \
-          ) \
-      )
+        .single-panel--footer= t(".tos_html", action: @action, \
+            tos_link: link_to( \
+                t("shared.terms_of_service"), \
+                "https://basicattentiontoken.org/publisher-terms-of-service/" \
+            ) \
+        )

--- a/app/views/publishers/expired_auth_token.html.slim
+++ b/app/views/publishers/expired_auth_token.html.slim
@@ -1,16 +1,11 @@
-- content_for(:navbar_content) do
+.single-panel--wrapper
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    | &nbsp;
+      h3.single-panel--headline= t ".heading"
 
-.expired-token-panel.col-center
-  .sub-panel.col-center
-    .row.col-center
-      .col.col-md-12
-        h3.text-center= t ".heading"
-    .row
-      .col.col-md-8.col-md-offset-2.text-center.col-center
+      .col-small-centered
         p= t ".body"
         = form_for @publisher, {method: :post, url: create_auth_token_publishers_path} do |f|
           = f.hidden_field(:email, :value => @publisher.email)

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -1,23 +1,20 @@
-- content_for(:head_style_tags) do
-  = stylesheet_link_tag("application", media: "all")
-
 .single-panel--wrapper
   = render "panel_flash_messages"
   .single-panel--content
+    .single-panel--padded-content
+      h3.single-panel--headline= t "shared.log_in"
 
-    h3.single-panel--headline= t "shared.log_in"
-
-    .col-small-centered
-      = form_for @publisher, url: create_auth_token_publishers_path do |f|
-        .form-group
-          = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email")
-        - if params[:captcha]
-          = hidden_field_tag(:captcha)
-        - if @should_throttle
+      .col-small-centered
+        = form_for @publisher, url: create_auth_token_publishers_path do |f|
           .form-group
-            = recaptcha_tags
-        = f.submit(t("shared.log_in"), class: "btn btn-block btn-primary")
+            = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email")
+          - if params[:captcha]
+            = hidden_field_tag(:captcha)
+          - if @should_throttle
+            .form-group
+              = recaptcha_tags
+          = f.submit(t("shared.log_in"), class: "btn btn-block btn-primary")
 
-    .single-panel--footer.single-panel--footer--secondary
-      ' #{t(".signup_prompt")}
-      = link_to t("publishers.shared.sign_up"), sign_up_publishers_path
+      .single-panel--footer.single-panel--footer--secondary
+        ' #{t(".signup_prompt")}
+        = link_to t("publishers.shared.sign_up"), sign_up_publishers_path

--- a/app/views/publishers/sign_up.html.slim
+++ b/app/views/publishers/sign_up.html.slim
@@ -1,23 +1,21 @@
-- content_for(:head_style_tags) do
-  = stylesheet_link_tag("application", media: "all")
-
 .single-panel--wrapper
   = render "panel_flash_messages"
   .single-panel--content
+    .single-panel--padded-content
 
-    h3.single-panel--headline= t ".heading"
+      h3.single-panel--headline= t ".heading"
 
-    .col-small-centered
-      = form_tag publishers_path, method: :post do |f|
-        .form-group
-          = email_field_tag :email, nil, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email"), required: true, value: @publisher.email
-        - if params[:captcha]
-          = hidden_field_tag :captcha
-        - if @should_throttle
+      .col-small-centered
+        = form_tag publishers_path, method: :post do |f|
           .form-group
-            = recaptcha_tags
-        = submit_tag t("shared.get_started"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing"
+            = email_field_tag :email, nil, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email"), required: true, value: @publisher.email
+          - if params[:captcha]
+            = hidden_field_tag :captcha
+          - if @should_throttle
+            .form-group
+              = recaptcha_tags
+          = submit_tag t("shared.get_started"), class: "btn btn-block btn-primary", :"data-piwik-action" => "StartFlowClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Landing"
 
-    .single-panel--footer.single-panel--footer--secondary
-      ' #{t("shared.existing_account")}
-      = link_to t("shared.log_in"), new_auth_token_publishers_path
+      .single-panel--footer.single-panel--footer--secondary
+        ' #{t("shared.existing_account")}
+        = link_to t("shared.log_in"), new_auth_token_publishers_path

--- a/app/views/totp_registrations/new.html.slim
+++ b/app/views/totp_registrations/new.html.slim
@@ -1,4 +1,4 @@
-.single-panel--wrapper.single-panel--wrapper--medium
+.single-panel--wrapper
   = render "panel_flash_messages"
   - if totp_enabled?(current_publisher)
     .single-panel--content.single-panel--content--warning.icon-and-text--wrapper
@@ -7,34 +7,35 @@
       .icon-and-text--text
         = t ".warning"
   .single-panel--content
-    .col-medium-centered
+    .single-panel--padded-content
+      .col-medium-centered
 
-      .text-left
-        h3.single-panel--headline= t ".heading"
+        .text-left
+          h3.single-panel--headline= t ".heading"
 
-        = form_for @totp_registration do |f|
-          = f.hidden_field :secret
+          = form_for @totp_registration do |f|
+            = f.hidden_field :secret
 
-          ol.single-panel--list
-            li.form-group= t ".step_1"
-            li.form-group
-              = t ".step_2"
-              '
-              em= t ".step_2_alt"
-              '
-              strong= @totp_registration.secret.scan(/.{4}/).join(" ")
-              .text-center
-                .totp-svg== qr_code_svg @provisioning_url
-            li.form-group
-              = t ".step_3"
+            ol.single-panel--list
+              li.form-group= t ".step_1"
+              li.form-group
+                = t ".step_2"
+                '
+                em= t ".step_2_alt"
+                '
+                strong= @totp_registration.secret.scan(/.{4}/).join(" ")
+                .text-center
+                  .totp-svg== qr_code_svg @provisioning_url
+              li.form-group
+                = t ".step_3"
 
-          .col-halves
-            .col-half
-              .form-group
-                input.form-control name="totp_password" placeholder=t(".password_prompt") autofocus=true
-            .col-half
-              = render 'smartphone_with_code_tilted'
+            .col-halves
+              .col-half
+                .form-group
+                  input.form-control name="totp_password" placeholder=t(".password_prompt") autofocus=true
+              .col-half
+                = render 'smartphone_with_code_tilted'
 
-          .col-halves
-            .col-half= f.submit t(".submit_value"), class: "btn btn-primary"
-            .col-half.text-right= link_to t("shared.cancel"), two_factor_registrations_path, class: "btn btn-link"
+            .col-halves
+              .col-half= f.submit t(".submit_value"), class: "btn btn-primary"
+              .col-half.text-right= link_to t("shared.cancel"), two_factor_registrations_path, class: "btn btn-link"

--- a/app/views/two_factor_authentications/_u2f.html.slim
+++ b/app/views/two_factor_authentications/_u2f.html.slim
@@ -10,12 +10,12 @@ div.js-feature-u2f-available
     .col-small-centered
       .js-u2f-is-working
         p = t ".body"
-        p = render "application/usb_with_lines"
+        = render "application/usb_with_lines"
 
     .col-small-centered
       .js-u2f-is-prompting
         p = render "application/usb"
-        p.retry = submit_tag t(".submit_value"), class: "btn btn-primary btn-block"
+        p.two-factor-authentication--retry = submit_tag t(".submit_value"), class: "btn btn-primary btn-block"
 
   - if @totp_enabled
     .col-small-centered

--- a/app/views/two_factor_authentications/index.html.slim
+++ b/app/views/two_factor_authentications/index.html.slim
@@ -55,8 +55,9 @@
 
 
   .single-panel--content
-    - if @u2f_authentication_attempt
-      = render partial: "u2f", locals: @u2f_authentication_attempt
+    .single-panel--padded-content
+      - if @u2f_authentication_attempt
+        = render partial: "u2f", locals: @u2f_authentication_attempt
 
-    - elsif @totp_enabled
-      = render "totp"
+      - elsif @totp_enabled
+        = render "totp"

--- a/app/views/two_factor_registrations/index.html.slim
+++ b/app/views/two_factor_registrations/index.html.slim
@@ -1,100 +1,103 @@
 .single-panel--wrapper.single-panel--wrapper--large
   .single-panel--content
-    .col-two-factor--content
-      h3.single-panel--headline= t ".heading"
-      p= t ".intro"
-    .col-two-factor--action.two-factor-enabled-status
-      - if two_factor_enabled?(current_publisher)
-        span.two-factor-enabled= t ".enabled_yes"
-      - else
-        span.two-factor-disabled= t ".enabled_no"
+    .single-panel--padded-content
+      .row
+        .col-two-factor--content
+          h3.single-panel--headline= t ".heading"
+          p= t ".intro"
+        .col-two-factor--action.two-factor-enabled-status
+          - if two_factor_enabled?(current_publisher)
+            span.two-factor-enabled= t ".enabled_yes"
+          - else
+            span.two-factor-disabled= t ".enabled_no"
 
-    .col-two-factor--content
-      h5= t ".totp.heading"
-      p= t ".totp.intro"
-      - if totp_enabled?(current_publisher)
-        p
-          span.totp-enabled= t ".totp.enabled"
-          = " | "
-          = link_to t(".totp.reconfigure"), new_totp_registration_path
-      - else
-        - if current_publisher.u2f_registrations.length == 1
-          .card
-            .card-header.icon-and-text--wrapper
-              .icon-and-text--icon
-                = render "application/icon_circled_bang"
-              .icon-and-text--text
-                = t ".totp.disabled_without_fallback_html"
-        - else
-          p.two-factor-method-disabled
-            == "&bull; "
-            = t ".totp.disabled"
-    .col-two-factor--action
-      - if totp_enabled?(current_publisher)
-        p= link_to \
-            t(".totp.destroy"),
-            totp_registration_path(current_publisher.totp_registration),
-            method: :delete,
-            class: "btn btn-block btn-outline-secondary",
-            data: { "js-confirm-with-modal": "disable-totp-prompt" }
-        script#disable-totp-prompt type="text/html"
-          .col-medium-center
-            h4= t ".totp.confirm_disable.header"
+        br
+        .col-two-factor--content
+          h5= t ".totp.heading"
+          p= t ".totp.intro"
+          - if totp_enabled?(current_publisher)
             p
-              = t ".totp.confirm_disable.intro"
-              - if current_publisher.u2f_registrations.any?
-                - current_publisher.u2f_registrations.each do |u2f_registration|
-                  br
-                  strong
-                    | Security key
-                    = " \"#{u2f_registration.name.presence || t(".totp.name_default")}\""
-                  = " (registered #{l(u2f_registration.created_at.to_date, format: :short)})"
-              - else
-                br
-                strong.error = t(".totp.confirm_disable.none")
-            - if current_publisher.u2f_registrations.any?
-              p= t ".totp.confirm_disable.no_totp_warning"
+              span.totp-enabled= t ".totp.enabled"
+              = " | "
+              = link_to t(".totp.reconfigure"), new_totp_registration_path
+          - else
+            - if current_publisher.u2f_registrations.length == 1
+              .card
+                .card-header.icon-and-text--wrapper
+                  .icon-and-text--icon
+                    = render "application/icon_circled_bang"
+                  .icon-and-text--text
+                    = t ".totp.disabled_without_fallback_html"
             - else
-              p== t ".totp.confirm_disable.no_2fa_warning_html"
-            p= t ".totp.confirm_disable.final_confirmation"
-          .col-medium-center
-            .md-confirm-buttons
-              = link_to t(".totp.confirm_disable.deny"), "#", class: "js-deny btn btn-outline-secondary"
-              = link_to t(".totp.confirm_disable.confirm"), "#", class: "js-confirm btn btn-outline-secondary"
+              p.two-factor-method-disabled
+                == "&bull; "
+                = t ".totp.disabled"
+        .col-two-factor--action
+          - if totp_enabled?(current_publisher)
+            p= link_to \
+                t(".totp.destroy"),
+                totp_registration_path(current_publisher.totp_registration),
+                method: :delete,
+                class: "btn btn-block btn-outline-secondary",
+                data: { "js-confirm-with-modal": "disable-totp-prompt" }
+            script#disable-totp-prompt type="text/html"
+              .col-medium-center
+                h4= t ".totp.confirm_disable.header"
+                p
+                  = t ".totp.confirm_disable.intro"
+                  - if current_publisher.u2f_registrations.any?
+                    - current_publisher.u2f_registrations.each do |u2f_registration|
+                      br
+                      strong
+                        | Security key
+                        = " \"#{u2f_registration.name.presence || t(".totp.name_default")}\""
+                      = " (registered #{l(u2f_registration.created_at.to_date, format: :short)})"
+                  - else
+                    br
+                    strong.error = t(".totp.confirm_disable.none")
+                - if current_publisher.u2f_registrations.any?
+                  p= t ".totp.confirm_disable.no_totp_warning"
+                - else
+                  p== t ".totp.confirm_disable.no_2fa_warning_html"
+                p= t ".totp.confirm_disable.final_confirmation"
+              .col-medium-center
+                .md-confirm-buttons
+                  = link_to t(".totp.confirm_disable.deny"), "#", class: "js-deny btn btn-outline-secondary"
+                  = link_to t(".totp.confirm_disable.confirm"), "#", class: "js-confirm btn btn-outline-secondary"
 
-      - else
-        p= link_to t(".totp.button"), new_totp_registration_path, class: "btn btn-block btn-primary"
-      p.icon= render "smartphone_with_code"
+          - else
+            p= link_to t(".totp.button"), new_totp_registration_path, class: "btn btn-block btn-primary"
+          p.icon= render "smartphone_with_code"
 
-    / FIXME: U2F is dark launched, and you need to specify params[:u2f]
-    / We will enable it when Brave is ready. See issue #442
-    - if @u2f_registrations.any? || params[:u2f].present?
-      .col-two-factor--content
-        h5= t ".u2f.heading"
-        p
-          = t ".u2f.intro"
-          br
-          small
-            = "*#{t ".u2f.intro_warning"} "
-            span.tf-tooltip
-              span.icon= render "icon_help"
-              span.tf-tooltip-content
-                span.tf-tooltip-content-heading= t ".u2f.browser.heading"
-                span.tf-tooltip-content-content== t ".u2f.browser.content_html"
-          br
-          small
-            = "*#{t ".u2f.device.tooltip"} "
-            span.tf-tooltip
-              span.icon= render "icon_help"
-              span.tf-tooltip-content
-                span.tf-tooltip-content-heading= t ".u2f.device.heading"
-                span.tf-tooltip-content-content== t ".u2f.device.content_html"
-        - if @u2f_registrations.any?
-          p= render @u2f_registrations
-        - else
-          p.two-factor-method-disabled
-            == "&bull; "
-            = t ".u2f.disabled"
-      .col-two-factor--action
-        p= link_to t(".u2f.button"), new_u2f_registration_path, class: "btn btn-block btn-primary"
-        p.icon= render "usb"
+        / FIXME: U2F is dark launched, and you need to specify params[:u2f]
+        / We will enable it when Brave is ready. See issue #442
+        - if @u2f_registrations.any? || params[:u2f].present?
+          .col-two-factor--content
+            h5= t ".u2f.heading"
+            p
+              = t ".u2f.intro"
+              br
+              small
+                = "*#{t ".u2f.intro_warning"} "
+                span.tf-tooltip
+                  span.icon= render "icon_help"
+                  span.tf-tooltip-content
+                    span.tf-tooltip-content-heading= t ".u2f.browser.heading"
+                    span.tf-tooltip-content-content== t ".u2f.browser.content_html"
+              br
+              small
+                = "*#{t ".u2f.device.tooltip"} "
+                span.tf-tooltip
+                  span.icon= render "icon_help"
+                  span.tf-tooltip-content
+                    span.tf-tooltip-content-heading= t ".u2f.device.heading"
+                    span.tf-tooltip-content-content== t ".u2f.device.content_html"
+            - if @u2f_registrations.any?
+              p= render @u2f_registrations
+            - else
+              p.two-factor-method-disabled
+                == "&bull; "
+                = t ".u2f.disabled"
+          .col-two-factor--action
+            p= link_to t(".u2f.button"), new_u2f_registration_path, class: "btn btn-block btn-primary"
+            p.icon= render "usb"

--- a/app/views/two_factor_registrations/prompt.html.slim
+++ b/app/views/two_factor_registrations/prompt.html.slim
@@ -1,17 +1,18 @@
 .single-panel--wrapper
   .single-panel--content
+    .single-panel--padded-content
 
-    .col-small-centered
-      p= render "icon_security"
+      .col-small-centered
+        p= render "icon_security"
 
-    h3.single-panel--headline.mb-1= t".heading"
+      h3.single-panel--headline.mb-1= t".heading"
 
-    .col-small-centered
-      h4= t ".subheading"
-      p= t ".intro"
+      .col-small-centered
+        h4= t ".subheading"
+        p= t ".intro"
 
-      .col-buttons
-        .col-buttons-half
-          = link_to t(".skip"), home_publishers_path, class: "btn btn-link-primary btn-block"
-        .col-buttons-half
-          = link_to t(".setup"), two_factor_registrations_path, class: "btn btn-primary btn-block"
+        .col-buttons
+          .col-buttons-half
+            = link_to t(".skip"), home_publishers_path, class: "btn btn-link-primary btn-block"
+          .col-buttons-half
+            = link_to t(".setup"), two_factor_registrations_path, class: "btn btn-primary btn-block"

--- a/app/views/u2f_registrations/new.html.slim
+++ b/app/views/u2f_registrations/new.html.slim
@@ -47,6 +47,7 @@
     .error-group--no-error.js-no-error
 
   .single-panel--content
+    .single-panel--padded-content
 
       h3.single-panel--headline= t ".heading"
 


### PR DESCRIPTION
Introduce a more whitespace-friendly pane layout. Closes #552 

This changes the layout DOM, and introduces new ways to size content:

* `.single-panel--wrapper.` a wrapper with a max-width of 40em (1em is 16px, so 640px). It also has a min-height to ensure it looks good even if there is not a lot of content.
* `.single-panel--wrapper.single-panel--wrapper--medium` a wrapper with a max-width of 45em or 720px.
* `.single-panel--wrapper.single-panel--wrapper--large` a wrapper with a max-width of 50em or 800px.
* `.single-panel--padded-content` is used inside `.single-panel--content`. It provides padding of 2em or 32px on all sides until the extra small breakpoint, and ensures the content is vertically centered.
* `.col-small-centered` is 66% of a panel's width until the extra small breakpoint.
* `.col-medium-centered` is 83% of a panel's width until the extra small breakpoint.

<details>
  <summary>Click to expand a long list of before/after screenshots</summary>
<br>
<strong>A) Login</strong>. Note that the content in the panel is horizontally and vertically centered. This is a <i>normal</i> size pane and has a max-width of 40em (1em is 16px, so 640px).
<img width="1920" alt="screen shot 2018-02-20 at 4 55 16 pm" src="https://user-images.githubusercontent.com/8752/36457787-a2a1551a-1660-11e8-970a-3755409d43e9.png">

**B) Login with error**. The box has a min-height (32em or 512px), and the content of the panel re-centers in the now shorter block.
<img width="1920" alt="screen shot 2018-02-20 at 4 56 03 pm" src="https://user-images.githubusercontent.com/8752/36457786-a2850450-1660-11e8-9a71-26537bf56077.png">

**C) Sign in success**. This is a *large* size pane and has a max-width of 50em or 800px. Again content is horizontally and vertically centered.
<img width="1920" alt="screen shot 2018-02-20 at 4 56 39 pm" src="https://user-images.githubusercontent.com/8752/36457785-a268086e-1660-11e8-9426-93607aa9cce9.png">

**D) Enter name screen**. My window sizes here are 960px which is an awkward size, but this again is a large pane.
<img width="1920" alt="screen shot 2018-02-20 at 4 57 50 pm" src="https://user-images.githubusercontent.com/8752/36457784-a24a6d68-1660-11e8-9981-54f1e06cfcdd.png">

**E) Enter name screen, zoomed out 75%**. This emulates a screen 1280px wide.
<img width="1920" alt="screen shot 2018-02-20 at 4 58 12 pm" src="https://user-images.githubusercontent.com/8752/36457783-a22b3bbe-1660-11e8-915b-f7511142e6ba.png">

**F) 2FA prompt**. A normal size panel, again with content horizontally and vertically centered.
<img width="1920" alt="screen shot 2018-02-20 at 4 58 57 pm" src="https://user-images.githubusercontent.com/8752/36457782-a20eb93a-1660-11e8-96d6-fd9822348f59.png">

**G) 2FA Registrations**. A large panel. 
<img width="1920" alt="screen shot 2018-02-20 at 4 59 24 pm" src="https://user-images.githubusercontent.com/8752/36457781-a1e622a4-1660-11e8-8aee-cb61b0301d66.png">

**H) 2FA Registrations, zoomed to %75**. Because we're using max-width here instead of the grid system and breakpoints, the large panel basically stays the same size as the window gets bigger.
<img width="1920" alt="screen shot 2018-02-20 at 4 59 40 pm" src="https://user-images.githubusercontent.com/8752/36457780-a1c2ecd0-1660-11e8-8c49-4c0fa789c979.png">

**I) 2FA Registrations, mobile**. Fixed padding and margins.
<img width="1920" alt="screen shot 2018-02-20 at 5 00 32 pm" src="https://user-images.githubusercontent.com/8752/36457779-a1a5251a-1660-11e8-82d3-aa24a2349654.png">

**J) TOTP Registration**. Again normal size panel.
<img width="1920" alt="screen shot 2018-02-20 at 5 01 12 pm" src="https://user-images.githubusercontent.com/8752/36457778-a1892acc-1660-11e8-8131-48f7704097e4.png">

**K) TOTP Registration zoomed out**, again it doesn't change size at a larger window size.
<img width="1920" alt="screen shot 2018-02-20 at 5 01 36 pm" src="https://user-images.githubusercontent.com/8752/36457777-a169cc04-1660-11e8-8663-f59d37350d9b.png">

**L) TOTP Registration with error**
<img width="1920" alt="screen shot 2018-02-20 at 5 02 00 pm" src="https://user-images.githubusercontent.com/8752/36457776-a14d18d4-1660-11e8-9184-40f2899c872a.png">
</details>