### PR TITLE
Fix piwik by using window._paq

### DIFF
--- a/app/javascript/analytics.js
+++ b/app/javascript/analytics.js
@@ -1,12 +1,12 @@
 if (document.head.dataset.piwikHost) {
-  var _paq = _paq || [];
+  window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
+  window._paq.push(['trackPageView']);
+  window._paq.push(['enableLinkTracking']);
   (function() {
     var u=document.head.dataset.piwikHost;
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', '6']);
+    window._paq.push(['setTrackerUrl', u+'piwik.php']);
+    window._paq.push(['setSiteId', '6']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
@@ -16,7 +16,7 @@ if (document.head.dataset.piwikHost) {
     var target = e.target || e.srcElement;
 
     if (target.dataset.piwikAction) {
-      _paq.push(['trackEvent', target.dataset.piwikAction, target.dataset.piwikName, target.dataset.piwikValue]);
+      window._paq.push(['trackEvent', target.dataset.piwikAction, target.dataset.piwikName, target.dataset.piwikValue]);
     }
   }, false);
 }


### PR DESCRIPTION
Fix #636

I tried to manually trigger a tracking event on prod with:

`_paq.push(['trackEvent', 'test', 'console', 42])`

This led to an error about a Piwik tracker not being configured.

I hypothesize that the migration to webpacker removed global scope from our JS files. This PR assigns `_paq` to `window` to be sure it's global. I've deployed it to staging2, and it fixed the above error with tracker configuration.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
