### PR TITLE
Add /api/tokens endpoint to get unverified recent site channels for eyeshade

### DIFF
--- a/app/controllers/api/tokens_controller.rb
+++ b/app/controllers/api/tokens_controller.rb
@@ -1,0 +1,18 @@
+class Api::TokensController < Api::BaseController
+
+  include PublishersHelper
+
+  def index
+    max_age = params[:max_age] ? Integer(params[:max_age]).days : 6.weeks
+
+    site_channel_details = SiteChannelDetails.recent_unverified_site_channels(max_age: max_age).order(:created_at)
+
+    page_num = params[:page] || 1
+    page_size = params[:per_page] || Rails.application.secrets[:default_api_page_size] || 100
+    tokens = paginate site_channel_details, per_page: page_size, page: page_num
+
+    render json: tokens, each_serializer: TokenSerializer
+  rescue ArgumentError
+    render(json: { message: "Invalid arguement" }, status: 400)
+  end
+end

--- a/app/jobs/enqueue_site_channel_verifications.rb
+++ b/app/jobs/enqueue_site_channel_verifications.rb
@@ -17,6 +17,6 @@ class EnqueueSiteChannelVerifications < ApplicationJob
 
   # Get unverified channel ids created recently.
   def recent_unverified_site_channels_ids
-    SiteChannelDetails.recent_unverified_site_channels(max_age: MAX_AGE).pluck("channels.id")
+    SiteChannelDetails.recent_unverified_site_channels(max_age: MAX_AGE).select(:brave_publisher_id).distinct.pluck("channels.id")
   end
 end

--- a/app/models/site_channel_details.rb
+++ b/app/models/site_channel_details.rb
@@ -20,7 +20,6 @@ class SiteChannelDetails < ApplicationRecord
 
   scope :recent_unverified_site_channels, -> (max_age: 6.weeks) {
     joins(:channel)
-        .select(:brave_publisher_id).distinct
         .where.not(brave_publisher_id: SiteChannelDetails.joins(:channel).select(:brave_publisher_id).distinct.where("channels.verified": true))
         .where("channels.created_at": max_age.ago..Time.now)
   }

--- a/app/serializers/token_serializer.rb
+++ b/app/serializers/token_serializer.rb
@@ -1,0 +1,13 @@
+# Takes a SiteChannelDetaisl
+
+class TokenSerializer < ActiveModel::Serializer
+  attributes :owner_identifier, :brave_publisher_id, :verification_token, :verification_id
+
+  def owner_identifier
+    object.channel.publisher.owner_identifier
+  end
+
+  def verification_id
+    object.channel.id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
         post "notifications", action: :notify
       end
     end
+    resources :tokens, only: %i(index)
   end
 
   resources :errors, only: [], path: "/" do

--- a/test/controllers/api/tokens_controller_test.rb
+++ b/test/controllers/api/tokens_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Api::TokensControllerTest < ActionDispatch::IntegrationTest
+  test "can get tokens with verifier channel identifiers as json" do
+    details = site_channel_details(:global_inprocess_details)
+
+    get "/api/tokens"
+
+    assert_equal 200, response.status
+
+    response_json = JSON.parse(response.body)
+
+    assert_match /#{details.channel.publisher.owner_identifier}/, response.body
+    assert_match /#{details.channel.id}/, response.body
+
+    too_old_details = site_channel_details(:to_verify_details)
+    refute_match /#{too_old_details.channel.publisher.owner_identifier}/, response.body
+    refute_match /#{too_old_details.channel.id}/, response.body
+  end
+
+  test "can paginate tokens and set page size" do
+    get "/api/tokens/?per_page=2"
+
+    assert_equal 200, response.status
+
+    response_json = JSON.parse(response.body)
+    assert_equal 2, response_json.length
+  end
+
+  test "can set max_age in days" do
+    get "/api/tokens/?max_age=141"
+
+    assert_equal 200, response.status
+
+    response_json = JSON.parse(response.body)
+    assert_equal 8, response_json.length
+
+    details = site_channel_details(:to_verify_details)
+    assert_match /#{details.channel.publisher.owner_identifier}/, response.body
+    assert_match /#{details.channel.id}/, response.body
+  end
+
+  test "can paginate tokens, set page size and number, and set max_age in days" do
+    get "/api/tokens/?per_page=2&page=4&max_age=141"
+
+    assert_equal 200, response.status
+
+    response_json = JSON.parse(response.body)
+    assert_equal 2, response_json.length
+  end
+
+  test "max_age must be an integer" do
+    get "/api/tokens/?max_age=foo"
+
+    assert_equal 400, response.status
+    assert_match "Invalid arguement", response.body
+  end
+
+end


### PR DESCRIPTION
Get the verification token information required by eyeshade. Will be a JSON array in the format of:

```json
[
  {
    "owner_identifier": "publishers#uuid:2dad1d64-570e-42b5-a5a8-f9affe30964b",
    "brave_publisher_id": "some_site.com",
    "verification_token": "511e9702aeb09d28ad7fe7696b7439467e85843655ad9900272bda355b40a8af",
    "verification_id": "1b157ac5-68c0-4458-bb76-f5d9ac72deba"
  }
]
```
Supports pagination (`page` and `per_page`) and a `max_age` parameter (in days) that sets how far back to consider tokens as active. The default is 42 days (6 weeks).

fixes #615

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))