### PR TITLE
Add missing authorizer methods to site_channel_details

### DIFF
--- a/app/models/site_channel_details.rb
+++ b/app/models/site_channel_details.rb
@@ -46,6 +46,16 @@ class SiteChannelDetails < ApplicationRecord
     brave_publisher_id
   end
 
+  # Unused for Site Channels
+  def authorizer_email
+    nil
+  end
+
+  # Unused for Site Channels
+  def authorizer_name
+    nil
+  end
+
   def brave_publisher_id_error_description
     case self.brave_publisher_id_error_code.to_sym
       when :taken

--- a/app/models/twitch_channel_details.rb
+++ b/app/models/twitch_channel_details.rb
@@ -15,11 +15,11 @@ class TwitchChannelDetails < ApplicationRecord
     "twitch#channel:#{name}"
   end
 
-  def authorizerEmail
+  def authorizer_email
     email
   end
 
-  def authorizerName
+  def authorizer_name
     display_name
   end
 

--- a/app/models/youtube_channel_details.rb
+++ b/app/models/youtube_channel_details.rb
@@ -15,11 +15,11 @@ class YoutubeChannelDetails < ApplicationRecord
     "youtube#channel:#{youtube_channel_id}"
   end
 
-  def authorizerEmail
+  def authorizer_email
     auth_email
   end
 
-  def authorizerName
+  def authorizer_name
     auth_name
   end
 

--- a/app/services/publisher_channel_setter.rb
+++ b/app/services/publisher_channel_setter.rb
@@ -12,8 +12,8 @@ class PublisherChannelSetter < BaseApiClient
     verified_channels = publisher.channels.verified.collect do |channel|
       {
           "channelId" => channel.details.channel_identifier,
-          "authorizerEmail" => channel.details.authorizerEmail,
-          "authorizerName" => channel.details.authorizerName
+          "authorizerEmail" => channel.details.authorizer_email,
+          "authorizerName" => channel.details.authorizer_name
       }.compact
     end
 


### PR DESCRIPTION
Also underscores authorizer_email and authorizer_name for consistency with other ruby methods in the project. 

fixes #659

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))