### PR TITLE
Add Twitch support for the referral promo

### DIFF
--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -58,4 +58,17 @@ module PromosHelper
   def base_human_referral_url
     Rails.application.secrets[:base_referral_url].to_s + "/"
   end
+
+  def on_channel_type(channel)
+    case channel.details_type
+    when "YoutubeChannelDetails"
+      "#{channel.publication_title.upcase} #{t("promo.shared.on_youtube")}"
+    when "TwitchChannelDetails"
+      "#{channel.publication_title.upcase} #{t("promo.shared.on_twitch")}"
+    when "SiteChannelDetails"
+      "#{channel.publication_title.upcase}"
+    else
+      raise
+    end
+  end
 end

--- a/app/services/promo_registrar.rb
+++ b/app/services/promo_registrar.rb
@@ -69,6 +69,8 @@ class PromoRegistrar < BaseApiClient
     case channel.details_type
     when "YoutubeChannelDetails"
       return youtube_request_body(channel)
+    when "TwitchChannelDetails"
+      return twitch_request_body(channel)
     when "SiteChannelDetails"
       return site_request_body(channel)
     else
@@ -85,6 +87,18 @@ class PromoRegistrar < BaseApiClient
       "channel_type": "youtube",
       "thumbnail_url": channel.details.thumbnail_url,
       "description": channel.details.description.presence
+    }.to_json
+  end
+
+  def twitch_request_body(channel)
+    {
+      "owner_id": @publisher.id,
+      "promo": @promo_id,
+      "channel": channel.channel_id, 
+      "title": channel.publication_title,
+      "channel_type": "twitch",
+      "thumbnail_url": channel.details.thumbnail_url,
+      "description": nil
     }.to_json
   end
 

--- a/app/views/promo_mailer/new_channel_registered_2018q1.html.slim
+++ b/app/views/promo_mailer/new_channel_registered_2018q1.html.slim
@@ -5,7 +5,7 @@ p.salutation= t("publisher_mailer.shared.salutation", name: @publisher.name)
 
 p = t("promo_mailer.promo_activated_2018q1_verified.body_one")
 
-a.promo--item-label.promo--item-label-link-name = @channel.details_type == "YoutubeChannelDetails" ? "#{@channel.publication_title.upcase} #{t("promo.shared.on_youtube")}" : "#{@channel.publication_title.upcase}"
+a.promo--item-label.promo--item-label-link-name = on_channel_type(@channel)
 .promo--referral-link-container
   .promo--referral-link = link_to(human_referral_url(@channel.promo_registration.referral_code), referral_url(@channel.promo_registration.referral_code))
 = link_to(t("promo.shared.tweet").upcase, tweet_url(@channel.promo_registration.referral_code), target: :_blank, style: "background-image: url(#{attachments["icn-twitter.png"]&.url})", class: 'promo--share-button promo--share-button-twitter')

--- a/app/views/promo_mailer/promo_activated_2018q1_verified.html.slim
+++ b/app/views/promo_mailer/promo_activated_2018q1_verified.html.slim
@@ -6,7 +6,7 @@ p.salutation= t("publisher_mailer.shared.salutation", name: @publisher.name)
 p = t("promo_mailer.promo_activated_2018q1_verified.body_one")
 
 - @promo_enabled_channels.each do |channel|
-  a.promo--item-label.promo--item-label-link-name = channel.details_type == "YoutubeChannelDetails" ? "#{channel.publication_title.upcase} #{t("promo.shared.on_youtube")}" : "#{channel.publication_title.upcase}"
+  a.promo--item-label.promo--item-label-link-name = on_channel_type(channel)
   .promo--referral-link-container
     .promo--referral-link = link_to(human_referral_url(channel.promo_registration.referral_code), referral_url(channel.promo_registration.referral_code))
   = link_to(t("promo.shared.tweet").upcase, tweet_url(channel.promo_registration.referral_code), target: :_blank, style: "background-image: url(#{attachments["icn-twitter.png"]&.url})", class: 'promo--share-button promo--share-button-twitter')

--- a/app/views/promo_registrations/_activated_verified.html.slim
+++ b/app/views/promo_registrations/_activated_verified.html.slim
@@ -16,7 +16,7 @@
   - n = 0
   - @promo_enabled_channels.each do |channel|
     .promo--referral-link-container-container class="promo--referral-link-container-container-#{n%2}"
-      .promo--item-label.promo--item-label-link-name = channel.details_type == "YoutubeChannelDetails" ? "#{channel.publication_title.upcase} #{t("promo.shared.on_youtube")}" : "#{channel.publication_title.upcase}"
+      .promo--item-label.promo--item-label-link-name = on_channel_type(channel)
       .promo--referral-link-container
         span.promo--referral-link id="#{channel.promo_registration.referral_code.downcase}" = human_referral_url(channel.promo_registration.referral_code)
         button.copy-button.promo--copy-button data-clipboard-target="##{channel.promo_registration.referral_code.downcase}" = t("promo.shared.copy")

--- a/app/views/promo_registrations/_active.html.slim
+++ b/app/views/promo_registrations/_active.html.slim
@@ -16,7 +16,7 @@
   - n = 0
   - @promo_enabled_channels.each do |channel|
     .promo--referral-link-container-container class="promo--referral-link-container-container-#{n%2}"
-      .promo--item-label.promo--item-label-link-name = channel.details_type == "YoutubeChannelDetails" ? "#{channel.publication_title.upcase} #{t("promo.shared.on_youtube")}" : "#{channel.publication_title.upcase}"
+      .promo--item-label.promo--item-label-link-name = on_channel_type(channel)
       .promo--referral-link-container
         span.promo--referral-link id="#{channel.promo_registration.referral_code.downcase}" = human_referral_url(channel.promo_registration.referral_code)
         button.copy-button.promo--copy-button data-clipboard-target="##{channel.promo_registration.referral_code.downcase}" = t("promo.shared.copy")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,7 @@ en:
       copy: "Copy"
       brave_payments_tm: "Brave Payments™"
       on_youtube: "on YouTube"
+      on_twitch: "on Twitch"
       tos_1: "This referral promo is capped at $1 million in tokens. A qualified referral is a user who downloads the Brave browser using the promo link specific to your channel or web site and uses the browser (minimally) over a 30 day period."
       tos_2_html: |
         The promotional offers set forth the current terms and conditions for your participation in the Brave Referral Program and are hereby incorporated by reference into the Brave Publisher Terms Of Service.  See Publisher <strong><a href="https://basicattentiontoken.org/publisher-terms-of-service/">Terms of Service</a></strong> for additional details and restrictions.


### PR DESCRIPTION
Resolves #667 

* Add PromoRegistrar# twitch_request_body

* Add PromosHelper# on_channel_type to display 'on Twitch' or 'on YouTube' next to channel name

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
