### PR TITLE
Add validations for pending_email

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -145,7 +145,7 @@ class PublishersController < ApplicationController
       end
     end
 
-    render :change_email
+    redirect_to :change_email_publishers, alert: t("publishers.change_email.login_email_taken")
   end
 
   def update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,6 +232,7 @@ en:
       login_email: Login Email
       login_email_message: We need your valid email address for account access and recovery purposes.
       login_email_note: "* This will be your login from now on."
+      login_email_taken: "This email address is in use. Please enter a different email address."
     change_email_confirm:
       login_email_changed: Great!
       login_email_verified_html: |

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -57,7 +57,7 @@ class PublisherMailerTest < ActionMailer::TestCase
   test "verify_email raises error if there is no send address" do
     publisher = publishers(:default)
     publisher.pending_email = ""
-    publisher.email = ""
+    publisher.email = "alice_verified@default.org"
     publisher.save
 
     # verify error raised if no pending email
@@ -65,8 +65,7 @@ class PublisherMailerTest < ActionMailer::TestCase
       PublisherMailer.verify_email(publisher).deliver_now
     end
 
-    publisher.pending_email = "alice@default.org"
-    publisher.email = "alice@default.org"
+    publisher.pending_email = "alice_new@default.org"
     publisher.save
     
     # verify nothing raised if pending email exists

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -178,6 +178,26 @@ class PublisherTest < ActiveSupport::TestCase
     refute publisher.valid?
   end
 
+  test "a publisher pending_email address must not match an existing verified email address" do
+    publisher = Publisher.new
+
+    publisher.pending_email = "foo@bar.com"
+    assert publisher.valid?
+
+    publisher.pending_email = "alice@verified.org"
+    refute publisher.valid?
+  end
+
+  test "a publisher pending_email address must not match the verified email address" do
+    publisher = Publisher.new
+
+    publisher.email = "foo@bar.com"
+    assert publisher.valid?
+
+    publisher.pending_email = "foo@bar.com"
+    refute publisher.valid?
+  end
+
   test "a publisher can be destroyed if it is not verified" do
     publisher = Publisher.new
 

--- a/test/services/publisher_unverified_calculator_test.rb
+++ b/test/services/publisher_unverified_calculator_test.rb
@@ -5,7 +5,6 @@ class PublisherUnverifiedCalculatorTest < ActiveJob::TestCase
 
     publisher_dave = Publisher.create!(
       name: "Dave",
-      pending_email: "dave@brave.com",
       email: "dave@brave.com"
     )
 
@@ -27,7 +26,6 @@ class PublisherUnverifiedCalculatorTest < ActiveJob::TestCase
 
     publisher_alice = Publisher.create!(
       name: "Alice",
-      pending_email: "alice@brave.com",
       email: "alice@brave.com",
       phone: "15555555555",
       phone_normalized: "+15555555555"


### PR DESCRIPTION
- Prevents pending email from being set to an email that already is
  verified.

- Also handles the special case above where the pending email is being
  changed to the current email.

Partially addresses #664. To close it we need to update the dashboard to handle the returned validation error.

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))