### PR TITLE
Add channel selection popup from prompt

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -133,7 +133,12 @@ script id="choose-channel-type" type="text/html"
 
 .row id="add_channel_placeholder" class=(current_publisher.channels.visible.empty? ? '' : 'hidden')
   .col.col-details.col-md-12.col-xs-10.col-xs-center.col-sm-center
-    = link_to("+ #{t "shared.add_channel"}", choose_new_channel_type_publishers_path, class: 'channel-placeholder')
+    = link_to( \
+      "+ #{t "shared.add_channel"}", \
+      choose_new_channel_type_publishers_path, \
+      data: { "js-confirm-with-modal": "choose-channel-type" }, \
+      class: 'channel-placeholder' \
+    )
 
 - current_publisher.channels.visible.each do |channel|
   .row.channel-row id=("channel_row_#{channel.id}")


### PR DESCRIPTION
The channel selection popup was firing from the header, however it must also fire from the prompt when no channel has been added. This ensures it fires from both locations:

![brave payments 2018-02-26 10-59-11](https://user-images.githubusercontent.com/8752/36689444-4012494e-1ae4-11e8-8681-5d57314e2ad7.png)
