### PR TITLE
[WIP] Do not allow dup channels for same owner and domain

### DIFF
--- a/app/models/site_channel_details.rb
+++ b/app/models/site_channel_details.rb
@@ -8,6 +8,8 @@ class SiteChannelDetails < ApplicationRecord
   # formats to support more publishers.
   validates :brave_publisher_id, uniqueness: { if: -> { !errors.include?(:brave_publisher_id_unnormalized) && brave_publisher_id.present? && brave_publisher_id_changed? && verified_publisher_id_exists? } }
 
+  validates :same_publisher_brave_publisher_id_unique, if: -> { !errors.include?(:brave_publisher_id_unnormalized) && brave_publisher_id.present? && brave_publisher_id_changed? }
+
   # - normalized and unnormalized domains
   # - normalized domains and domain-related errors
   validates :brave_publisher_id, absence: true, if: -> { !errors.include?(:brave_publisher_id_unnormalized) && brave_publisher_id_unnormalized.present? }
@@ -81,6 +83,12 @@ class SiteChannelDetails < ApplicationRecord
       self.supports_https = false
       self.detected_web_host = nil
       self.host_connection_verified = false
+    end
+  end
+
+  def same_publisher_brave_publisher_id_unique
+    if self.class.joins(:channel).where(brave_publisher_id: brave_publisher_id, "channels.publisher_id": channel.publisher_id).any?
+      errors.add(:brave_publisher_id, "must be unique within your account")
     end
   end
 

--- a/app/models/site_channel_details.rb
+++ b/app/models/site_channel_details.rb
@@ -8,7 +8,7 @@ class SiteChannelDetails < ApplicationRecord
   # formats to support more publishers.
   validates :brave_publisher_id, uniqueness: { if: -> { !errors.include?(:brave_publisher_id_unnormalized) && brave_publisher_id.present? && brave_publisher_id_changed? && verified_publisher_id_exists? } }
 
-  validates :same_publisher_brave_publisher_id_unique, if: -> { !errors.include?(:brave_publisher_id_unnormalized) && brave_publisher_id.present? && brave_publisher_id_changed? }
+  validate :same_publisher_brave_publisher_id_unique, if: -> { !errors.include?(:brave_publisher_id_unnormalized) && brave_publisher_id.present? && brave_publisher_id_changed? }
 
   # - normalized and unnormalized domains
   # - normalized domains and domain-related errors
@@ -86,12 +86,6 @@ class SiteChannelDetails < ApplicationRecord
     end
   end
 
-  def same_publisher_brave_publisher_id_unique
-    if self.class.joins(:channel).where(brave_publisher_id: brave_publisher_id, "channels.publisher_id": channel.publisher_id).any?
-      errors.add(:brave_publisher_id, "must be unique within your account")
-    end
-  end
-
   private
 
   def verified_publisher_id_exists?
@@ -115,6 +109,12 @@ class SiteChannelDetails < ApplicationRecord
 
     if brave_publisher_id_was != brave_publisher_id
       errors.add(:brave_publisher_id, "can not change once initialized")
+    end
+  end
+
+  def same_publisher_brave_publisher_id_unique
+    if self.class.joins(:channel).where(brave_publisher_id: brave_publisher_id, "channels.publisher_id": channel.publisher_id).any?
+      errors.add(:brave_publisher_id, "must be unique within your account")
     end
   end
 end

--- a/test/controllers/site_channels_controller_test.rb
+++ b/test/controllers/site_channels_controller_test.rb
@@ -138,6 +138,35 @@ class SiteChannelsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "can't create duplicate Site Channel with the same brave_publisher_id" do
+    prev_host_inspector_offline = Rails.application.secrets[:host_inspector_offline]
+    begin
+      Rails.application.secrets[:host_inspector_offline] = true
+
+      publisher = publishers(:verified)
+
+      sign_in publishers(:verified)
+
+      create_params = {
+          channel: {
+              details_attributes: {
+                brave_publisher_id_unnormalized: "something.org"
+              }
+          }
+      }
+
+      assert_difference("Channel.count") do
+        post site_channels_url, params: create_params
+      end
+
+      assert_no_difference("Channel.count") do
+        post site_channels_url, params: create_params
+      end
+    ensure
+      Rails.application.secrets[:host_inspector_offline] = prev_host_inspector_offline
+    end
+  end
+
   # ToDo:
   # test "a site channel's domain can be updated via an ajax patch" do
   #   publisher = publishers(:verified)

--- a/test/models/site_channel_test.rb
+++ b/test/models/site_channel_test.rb
@@ -20,7 +20,7 @@ class SiteChannelTest < ActiveSupport::TestCase
 
     # Exists, but not verified
     new_details = SiteChannelDetails.new(brave_publisher_id: "default.org")
-    assert new_details.valid?
+    refute new_details.valid?
 
     # Exists and is verified
     new_details = SiteChannelDetails.new(brave_publisher_id: "verified.org")


### PR DESCRIPTION
Submitter Checklist:

- [ ] #637
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] @ayumi 

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
