### PR TITLE
Show balance by channel on publishers/home

### DIFF
--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -646,9 +646,10 @@ body[data-controller="publishers"]
 
         &.channel-verified
           .channel-status
-            background: url(asset-path("icn-verified.png")) no-repeat top left
-            padding: 3px 0 12px 38px
-            margin-top: -4px
+            background: url(asset-path("bat-logo@1x.png")) no-repeat top left
+            background-size: 30px 28.5px
+            padding: 1px 0 12px 38px
+            margin-top: -11px
 
 
         &--intro
@@ -753,6 +754,24 @@ body[data-controller="publishers"]
         padding: 60px
         background: #fff
         border-radius: 0
+
+  .bat-channel
+    &--amount
+      font-size: 28px
+      font-weight: bolder
+      display: inline
+      line-height: 1
+    &--currency
+      font-size: 14px
+      display: inline
+      color: #2f3032
+      line-height: 1
+      padding-left: 3px
+    &--period
+      line-height: 1
+      color: #999999
+      font-size: 11px
+      font-weight: bolder
 
   &[data-action="email_verified"],
   &[data-action="choose_new_channel_type"]

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -61,6 +61,22 @@ module PublishersHelper
     I18n.t("helpers.publisher.balance_error")
   end
 
+  def publisher_channel_balance(publisher, channel_identifier, currency)
+    if balance = (
+        publisher.wallet &&
+        publisher.wallet.channel_balances &&
+        publisher.wallet.channel_balances[channel_identifier]
+    )
+      '%.2f' % balance.convert_to(currency)
+    else
+      I18n.t("helpers.publisher.balance_error")
+    end
+  rescue => e
+    require "sentry-raven"
+    Raven.capture_exception(e)
+    I18n.t("helpers.publisher.balance_error")
+  end
+
   def publisher_uri(publisher)
     "https://#{publisher.brave_publisher_id}"
   end

--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -10,12 +10,32 @@ class PublisherWalletGetter < BaseApiClient
 
   def perform
     return perform_offline if Rails.application.secrets[:api_eyeshade_offline]
-    response = connection.get do |request|
+
+    wallet_response = connection.get do |request|
       request.headers["Authorization"] = api_authorization_header
       request.url("/v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet")
     end
-    response_hash = JSON.parse(response.body)
-    Eyeshade::Wallet.new(wallet_json: response_hash)
+
+    channel_responses = {}
+    publisher.channels.each do |channel|
+      identifier =  channel.details.channel_identifier
+      channel_responses[identifier] = connection.get do |request|
+        request.headers["Authorization"] = api_authorization_header
+        request.url("/v2/publishers/#{URI.escape(identifier)}/balance")
+      end
+    end
+
+    wallet_hash = JSON.parse(wallet_response.body)
+
+    channel_hash = {}
+    channel_responses.each do |identifier, response|
+      channel_hash[identifier] = JSON.parse(response.body)
+    end
+
+    Eyeshade::Wallet.new(
+      wallet_json: wallet_hash,
+      channel_json: channel_hash
+    )
   rescue Faraday::Error => e
     Rails.logger.warn("PublisherWalletGetter #perform error: #{e}")
     nil
@@ -23,6 +43,24 @@ class PublisherWalletGetter < BaseApiClient
 
   def perform_offline
     Rails.logger.info("PublisherWalletGetter returning offline stub balance.")
+
+    channel_json = {}
+    @publisher.channels.each do |channel|
+      channel_json[channel.details.channel_identifier] = {
+        "amount" => "9001.00",
+        "currency" => "USD",
+        "altcurrency" => "BAT",
+        "probi" => "38077497398351695427000",
+        "rates" => {
+          "BTC" => 0.00005418424016883016,
+          "ETH" => 0.000795331082073117,
+          "USD" => 0.2363863335301452,
+          "EUR" => 0.20187818378874756,
+          "GBP" => 0.1799810085548496
+        }
+      }
+    end
+
     Eyeshade::Wallet.new(
       wallet_json: {
         "status" => {
@@ -49,7 +87,8 @@ class PublisherWalletGetter < BaseApiClient
             "preferredCurrency" => 'USD',
             "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
-      }
+      },
+      channel_json: channel_json
     )
   end
 

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -21,7 +21,7 @@ script id="choose-channel-type" type="text/html"
     h4.balance-header = t ".balance_pending"
     .balance
       .pull-left
-        = image_tag("bat-logo@1x.png", class: "")
+        = image_tag("bat-logo@2x.png", class: "", width: 60, height: 57)
       .pull-left.amounts
         .bat
           span.bat-amount#bat_amount= publisher_humanize_balance(current_publisher, "BAT")
@@ -166,7 +166,11 @@ script id="choose-channel-type" type="text/html"
                 span= t("promo.shared.copy")
           - else
             .channel-status.pull-right
-              span= t("publishers.shared.verified")
+              .bat-channel
+                h4.bat-channel--amount#bat_amount= publisher_channel_balance(current_publisher, channel.details.channel_identifier, "BAT")
+                span.bat-channel--currency= " BAT"
+                .bat-channel--period
+                  = t(".channel_balance_period")
         - elsif channel.verification_started? || channel.verification_failed?
           .channel-status.pull-right
             = channel_verification_details(channel)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,6 +315,7 @@ en:
         remove_verified: Remove Channel
         one_more_step: One more step to complete...
         lets_finish: Let's Finish
+      channel_balance_period: CURRENT PERIOD
     new_auth_token:
       signup_prompt: Don't have an account?
     omniauth_callbacks:

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -2,10 +2,12 @@ require "eyeshade/balance"
 
 module Eyeshade
   class Wallet
-    attr_reader :wallet_json, :status, :contribution_balance, :wallet_details
+    attr_reader :wallet_json, :status, :contribution_balance, :wallet_details,
+                :channel_json, :channel_balances
 
-    def initialize(wallet_json:)
+    def initialize(wallet_json:, channel_json:)
       @wallet_json = wallet_json
+      @channel_json = channel_json
       @status = wallet_json["status"].is_a?(Hash) ? wallet_json["status"] : {}
 
       balance_json = wallet_json["contributions"].is_a?(Hash) ? wallet_json["contributions"] : {}
@@ -14,6 +16,11 @@ module Eyeshade
       @contribution_balance = Eyeshade::Balance.new(balance_json: balance_json)
 
       @wallet_details = wallet_json["wallet"].is_a?(Hash) ? wallet_json["wallet"] : {}
+
+      @channel_balances = {}
+      @channel_json.each do |identifier, json|
+        @channel_balances[identifier] = Eyeshade::Balance.new(balance_json: json)
+      end
     end
   end
 end

--- a/test/controllers/publishers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/publishers/omniauth_callbacks_controller_test.rb
@@ -291,7 +291,7 @@ module Publishers
       )
     end
 
-    test "a publisher can add a youtube channel" do
+    test "a publisher can add a twitch channel" do
       publisher = publishers(:uphold_connected)
       request_login_email(publisher: publisher)
       url = publisher_url(publisher, token: publisher.reload.authentication_token)

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -34,7 +34,7 @@ class PublishersHelperTest < ActionView::TestCase
       attr_reader :default_currency, :wallet
 
       def initialize(wallet_json:)
-        @wallet = Eyeshade::Wallet.new(wallet_json: wallet_json) if wallet_json
+        @wallet = Eyeshade::Wallet.new(wallet_json: wallet_json, channel_json: {}) if wallet_json
         @default_currency = 'USD'
       end
     end
@@ -85,7 +85,7 @@ class PublishersHelperTest < ActionView::TestCase
       attr_reader :default_currency, :wallet
 
       def initialize(wallet_json:)
-        @wallet = Eyeshade::Wallet.new(wallet_json: wallet_json) if wallet_json
+        @wallet = Eyeshade::Wallet.new(wallet_json: wallet_json, channel_json: {}) if wallet_json
         @default_currency = 'USD'
       end
     end

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -144,6 +144,13 @@ class PublisherTest < ActiveSupport::TestCase
           with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
           to_return(status: 200, body: body, headers: {})
 
+      publisher.channels.each do |channel|
+        body = "{ \"amount\":\"9001.00\", \"currency\":\"USD\", \"altcurrency\":\"BAT\", \"probi\":\"38077497398351695427000\", \"rates\":{ \"BTC\":0.00005418424016883016, \"ETH\":0.000795331082073117, \"USD\":0.2363863335301452, \"EUR\":0.20187818378874756, \"GBP\":0.1799810085548496 } }"
+        stub_request(:get, /v2\/publishers\/#{URI.escape(channel.details.channel_identifier)}\/balance/).
+            with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+            to_return(status: 200, body: body, headers: {})
+      end
+
       publisher.wallet
       refute publisher.uphold_verified
 

--- a/test/services/publisher_wallet_getter_test.rb
+++ b/test/services/publisher_wallet_getter_test.rb
@@ -1,40 +1,66 @@
 require "test_helper"
-require "webmock/minitest"
 
 class PublisherWalletGetterTest < ActiveJob::TestCase
+
+  before(:example) do
+    @prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+  end
+
+  after(:example) do
+    Rails.application.secrets[:api_eyeshade_offline] = @prev_offline
+  end
+
   test "when offline returns a wallet with fake data" do
-    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
-    begin
-      Rails.application.secrets[:api_eyeshade_offline] = true
+    Rails.application.secrets[:api_eyeshade_offline] = true
 
-      publisher = publishers(:verified)
-      result = PublisherWalletGetter.new(publisher: publisher).perform
+    publisher = publishers(:verified)
+    result = PublisherWalletGetter.new(publisher: publisher).perform
 
-      assert result.kind_of?(Eyeshade::Wallet)
-
-    ensure
-      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
-    end
+    assert result.kind_of?(Eyeshade::Wallet)
   end
 
   test "when online returns a wallet" do
-    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
-    begin
-      Rails.application.secrets[:api_eyeshade_offline] = false
+    Rails.application.secrets[:api_eyeshade_offline] = false
 
-      publisher = publishers(:google_verified)
-      wallet = "{\"wallet\":\"abc123\"}"
+    publisher = publishers(:google_verified)
+    publisher.channels.delete_all
+    wallet = "{\"wallet\":\"abc123\"}"
 
-      stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
-        to_return(status: 200, body: wallet, headers: {})
+    stub_request(:get, %r{v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet}).
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 200, body: wallet, headers: {})
 
-      result = PublisherWalletGetter.new(publisher: publisher).perform
+    result = PublisherWalletGetter.new(publisher: publisher).perform
 
-      assert result.kind_of?(Eyeshade::Wallet)
-      assert_equal JSON.parse(wallet), result.wallet_json
-    ensure
-      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
-    end
+    assert result.kind_of?(Eyeshade::Wallet)
+    assert_equal JSON.parse(wallet), result.wallet_json
   end
+
+  test "when online returns a wallet with channel data" do
+    Rails.application.secrets[:api_eyeshade_offline] = false
+
+    publisher = publishers(:completed)
+    wallet = "{\"wallet\":\"abc123\"}"
+
+    stub_request(:get, %r{v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet}).
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 200, body: wallet, headers: {})
+
+    publisher.channels.each do |channel|
+      stub_request(:get, %r{v2/publishers/#{URI.escape(channel.details.channel_identifier)}/balance}).
+          with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+          to_return(status: 200, body: '{}', headers: {})
+    end
+
+    result = PublisherWalletGetter.new(publisher: publisher).perform
+
+    assert result.kind_of?(Eyeshade::Wallet)
+    assert_equal JSON.parse(wallet), result.wallet_json
+
+    assert_equal(
+      publisher.channels.inject({}) { |t,i| t[i.details.channel_identifier] = {}; t },
+      result.channel_json
+    )
+  end
+
 end

--- a/test/unit/wallet_test.rb
+++ b/test/unit/wallet_test.rb
@@ -28,10 +28,11 @@ class WalletTest < ActiveSupport::TestCase
             "preferredCurrency" => 'USD',
             "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
-      }
+      },
+      channel_json: {}
   )
 
-  empty_wallet = Eyeshade::Wallet.new(wallet_json: {})
+  empty_wallet = Eyeshade::Wallet.new(wallet_json: {}, channel_json: {})
 
   test "supports status" do
     assert(test_wallet.status)


### PR DESCRIPTION
Closes https://github.com/brave-intl/publishers/issues/632. Previous PRs that addressed part of that ticket are https://github.com/brave-intl/publishers/pull/653 and https://github.com/brave-intl/publishers/pull/671.

Show the BAT balance for each verified channel.

* When the balance is unknown the `0.00` number would be replaced by the work `Unknown` in the same font/size.
* The promo screens are unchanged. I will confer with @nvonpentz on these.
* ~Introduces [Typhoeus](https://github.com/typhoeus/typhoeus) to allow the publisher wallet and channel requests to Eyeshade to run in parallel.~ I've removed typhoeus and moved to work to another branch. It requires some new testing infra (webmock doesn't support the easy path). WIP (works in dev) is at: https://github.com/mixonic/publishers/tree/show-balance-in-parallel
* Use a high-res image for the BAT logo on near the publisher wallet balance.

![localhost_3000_publishers_home 2](https://user-images.githubusercontent.com/8752/36761497-2d98c1bc-1bd4-11e8-909d-14bd2e1cc70c.png)

TODO:

* [x] Confirm offline mode still works well
* [x] Add some testing
* [x] Confirm that "CURRENT PERIOD" is always the correct text on this page