### PR TITLE
Add comment explaining Channel#channel_id

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -66,6 +66,8 @@ class Channel < ApplicationRecord
     end
   end
 
+  # NOTE This method is should only be used in referral promo logic. Use {channel}.details.channel_identifer for everything else.
+  # This will return the channel_identifier without the youtube#channel: or twitch#channel: prefix
   def channel_id
     channel_type = self.details_type
     case channel_type


### PR DESCRIPTION
Resolves #686

I'll try and remedy this on promo services side, and write a PR that appends `youtube#channel:` and `twitch#channel` to the respective channel ids.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
