### PR TITLE
Improve messaging when claiming a claimed Twitch account

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -72,7 +72,7 @@ module Publishers
 
       if existing_channel
         if existing_channel.publisher == current_publisher
-          redirect_to home_publishers_path, notice: t(".channel_already_registered")
+          redirect_to home_publishers_path, notice: t(".channel_already_registered", { channel_title: existing_channel.details.display_name })
           return
         else
           redirect_to home_publishers_path, flash: { taken_channel_id: existing_channel.id }

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -321,6 +321,19 @@ module PublishersHelper
     end
   end
 
+  def channel_name(channel)
+    case channel.details
+    when SiteChannelDetails
+      I18n.t("helpers.publisher.channel_name.website")
+    when YoutubeChannelDetails
+      I18n.t("helpers.publisher.channel_name.youtube")
+    when TwitchChannelDetails
+      I18n.t("helpers.publisher.channel_name.twitch")
+    else
+      I18n.t("helpers.publisher.channel_name.unknown")
+    end
+  end
+
   def show_taken_channel_registration?(channel)
     case channel.details
     when YoutubeChannelDetails

--- a/app/views/application/_channel_taken.html.slim
+++ b/app/views/application/_channel_taken.html.slim
@@ -62,6 +62,7 @@ javascript:
        .registered-by
          label= t(".modal.registered_by") + ":"
          .value= channel_registered_by
+   p= t(".modal.try_logging_out", channel_name: channel_name(channel))
    p= t(".modal.contact_support_html", {support_email: support_email})
 
    .panel-section

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
         registration_date: Date
         registered_by: Added by
         contact_support_html: Contact <a href='mailto:%{support_email}'>our support</a> if this was processed in error.
+        try_logging_out: If this account is not the one you wanted to claim, please log out of %{channel_name} and try again.
         ok: OK
     nav:
       security: Security
@@ -100,6 +101,11 @@ en:
         website: Website
         twitch: Twitch channel
         unknown: Channel
+      channel_name:
+        youtube: YouTube
+        website: the website
+        twitch: Twitch
+        unknown: the website
       create_uphold_wallet: Create Uphold Wallet
       not_verified: Unverified
       reconnect_to_uphold: Reconnect to Uphold
@@ -319,7 +325,7 @@ en:
       require_publisher:
         log_in_and_retry: Please log in to Brave Payments and retry the operation
       register_twitch_channel:
-        channel_already_registered: This Twitch channel has already been registered.
+        channel_already_registered: You have already claimed the Twitch account %{channel_title}. If you would like to claim a second account, please sign out of Twitch and try again.
     require_unauthenticated_publisher:
       already_logged_in: You can't do that because you have an active session. Please exit or clear your cookies.
     require_verified_email:


### PR DESCRIPTION
Because Twitch offers no way for publishers to force the Twitch OAuth approval prompt to appear, we need to message to users that they may want to log out of their Twitch account to claim the correct account.

I confirmed Twitch does not honor the `prompt=consent` argument.

The improved messaging follows:

**User claims a Twitch account owned by someone else**

<img width="1694" alt="screen shot 2018-02-28 at 11 14 54 am" src="https://user-images.githubusercontent.com/8752/36807994-3557c66e-1c79-11e8-9495-8cee1a79a652.png">

**User claims a Twitch account they have already claimed**

<img width="1694" alt="screen shot 2018-02-28 at 11 06 03 am" src="https://user-images.githubusercontent.com/8752/36808025-3b9076ca-1c79-11e8-872e-cf104e12d862.png">