### PR TITLE
Use https:// for referral promo links always (emails + dashboard)

### DIFF
--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -234,7 +234,7 @@ body[data-controller="u2f_registrations"]
       &-facebook
         background-image: url(asset-path("f-share.png"))
     &-slideout
-      width: 300px // 300px when using brave.com for base referral link
+      width: 340px
       .promo-info-item
         display: table-cell
       .referral-link-button

--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -31,16 +31,12 @@ module PromosHelper
     end
   end
 
-  def human_referral_url(referral_code)
-    base_human_referral_url + referral_code.downcase
-  end
-
   def referral_url(referral_code)
-    "https://" + human_referral_url(referral_code)
+    base_referral_url + referral_code.downcase
   end
 
   def tweet_url(referral_code)
-    referral_link = human_referral_url(referral_code)
+    referral_link = referral_url(referral_code)
     twitter_preamble = "https://twitter.com/intent/tweet/?text="
     tweet_content = I18n.t("promo.shared.tweet_content") + "&url=http%3A%2F%2F" + referral_link
     tweet_content_url = tweet_content.gsub(/\s/, '%20')
@@ -49,13 +45,13 @@ module PromosHelper
   end
 
   def facebook_url(referral_code)
-    referral_link = human_referral_url(referral_code)
+    referral_link = referral_url(referral_code)
     base_facebook_link = "https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2F"
     sharable_facebook_link = base_facebook_link + referral_link
     sharable_facebook_link
   end
 
-  def base_human_referral_url
+  def base_referral_url
     Rails.application.secrets[:base_referral_url].to_s + "/"
   end
 

--- a/app/views/promo_mailer/new_channel_registered_2018q1.html.slim
+++ b/app/views/promo_mailer/new_channel_registered_2018q1.html.slim
@@ -7,7 +7,7 @@ p = t("promo_mailer.promo_activated_2018q1_verified.body_one")
 
 a.promo--item-label.promo--item-label-link-name = on_channel_type(@channel)
 .promo--referral-link-container
-  .promo--referral-link = link_to(human_referral_url(@channel.promo_registration.referral_code), referral_url(@channel.promo_registration.referral_code))
+  .promo--referral-link = link_to(referral_url(@channel.promo_registration.referral_code), referral_url(@channel.promo_registration.referral_code))
 = link_to(t("promo.shared.tweet").upcase, tweet_url(@channel.promo_registration.referral_code), target: :_blank, style: "background-image: url(#{attachments["icn-twitter.png"]&.url})", class: 'promo--share-button promo--share-button-twitter')
 = link_to(t("promo.shared.share").upcase, facebook_url(@channel.promo_registration.referral_code), target: :_blank, style: "background-image: url(#{attachments["icn-fb.png"]&.url})", class: 'promo--share-button promo--share-button-facebook')
 br style="clear: both"

--- a/app/views/promo_mailer/promo_activated_2018q1_verified.html.slim
+++ b/app/views/promo_mailer/promo_activated_2018q1_verified.html.slim
@@ -8,7 +8,7 @@ p = t("promo_mailer.promo_activated_2018q1_verified.body_one")
 - @promo_enabled_channels.each do |channel|
   a.promo--item-label.promo--item-label-link-name = on_channel_type(channel)
   .promo--referral-link-container
-    .promo--referral-link = link_to(human_referral_url(channel.promo_registration.referral_code), referral_url(channel.promo_registration.referral_code))
+    .promo--referral-link = link_to(referral_url(channel.promo_registration.referral_code), referral_url(channel.promo_registration.referral_code))
   = link_to(t("promo.shared.tweet").upcase, tweet_url(channel.promo_registration.referral_code), target: :_blank, style: "background-image: url(#{attachments["icn-twitter.png"]&.url})", class: 'promo--share-button promo--share-button-twitter')
   = link_to(t("promo.shared.share").upcase, facebook_url(channel.promo_registration.referral_code), target: :_blank, style: "background-image: url(#{attachments["icn-fb.png"]&.url})", class: 'promo--share-button promo--share-button-facebook')
   br style="clear: both"

--- a/app/views/promo_registrations/_activated_verified.html.slim
+++ b/app/views/promo_registrations/_activated_verified.html.slim
@@ -18,7 +18,7 @@
     .promo--referral-link-container-container class="promo--referral-link-container-container-#{n%2}"
       .promo--item-label.promo--item-label-link-name = on_channel_type(channel)
       .promo--referral-link-container
-        span.promo--referral-link id="#{channel.promo_registration.referral_code.downcase}" = human_referral_url(channel.promo_registration.referral_code)
+        span.promo--referral-link id="#{channel.promo_registration.referral_code.downcase}" = referral_url(channel.promo_registration.referral_code)
         button.copy-button.promo--copy-button data-clipboard-target="##{channel.promo_registration.referral_code.downcase}" = t("promo.shared.copy")
         = link_to("".upcase, tweet_url(channel.promo_registration.referral_code), target: :_blank, class: 'promo--share-button promo--share-button-twitter promo--share-button-desktop')
         = link_to("".upcase, facebook_url(channel.promo_registration.referral_code), target: :_blank, class: 'promo--share-button promo--share-button-facebook promo--share-button-desktop')

--- a/app/views/promo_registrations/_active.html.slim
+++ b/app/views/promo_registrations/_active.html.slim
@@ -18,12 +18,12 @@
     .promo--referral-link-container-container class="promo--referral-link-container-container-#{n%2}"
       .promo--item-label.promo--item-label-link-name = on_channel_type(channel)
       .promo--referral-link-container
-        span.promo--referral-link id="#{channel.promo_registration.referral_code.downcase}" = human_referral_url(channel.promo_registration.referral_code)
+        span.promo--referral-link id="#{channel.promo_registration.referral_code.downcase}" = referral_url(channel.promo_registration.referral_code)
         button.copy-button.promo--copy-button data-clipboard-target="##{channel.promo_registration.referral_code.downcase}" = t("promo.shared.copy")
         = link_to("".upcase, tweet_url(channel.promo_registration.referral_code), target: :_blank, class: 'promo--share-button promo--share-button-twitter promo--share-button-desktop')
         = link_to("".upcase, facebook_url(channel.promo_registration.referral_code), target: :_blank, class: 'promo--share-button promo--share-button-facebook promo--share-button-desktop')
-      = link_to(t("promo.shared.tweet").upcase, tweet_url(human_referral_url(channel.promo_registration.referral_code)), class: 'promo--share-button promo--share-button-mobile promo--share-button-twitter')
-      = link_to(t("promo.shared.share").upcase, facebook_url(human_referral_url(channel.promo_registration.referral_code)), class: 'promo--share-button promo--share-button-mobile promo--share-button-facebook')
+      = link_to(t("promo.shared.tweet").upcase, tweet_url(referral_url(channel.promo_registration.referral_code)), class: 'promo--share-button promo--share-button-mobile promo--share-button-twitter')
+      = link_to(t("promo.shared.share").upcase, facebook_url(referral_url(channel.promo_registration.referral_code)), class: 'promo--share-button promo--share-button-mobile promo--share-button-facebook')
     - n += 1
   p.promo--body-text-mobile
     span = t("promo.active.description_one")

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -157,12 +157,12 @@ script id="choose-channel-type" type="text/html"
               = link_to("", tweet_url(channel.promo_registration.referral_code), target: :_blank, class: "promo-share-button promo-share-button-twitter")
               = link_to("", facebook_url(channel.promo_registration.referral_code), target: :_blank, class: "promo-share-button promo-share-button-facebook")
               .referral-link-url.promo-info-item
-                span= human_referral_url(channel.promo_registration.referral_code)
+                span= referral_url(channel.promo_registration.referral_code)
               .referral-link-button.referral-link-button-desktop.promo-info-item
                 span= t("promo.shared.referral_link")
-              .referral-link-button.referral-link-button-mobile.promo-info-item.copy-button data-clipboard-text="#{human_referral_url(channel.promo_registration.referral_code)}"
+              .referral-link-button.referral-link-button-mobile.promo-info-item.copy-button data-clipboard-text="#{referral_url(channel.promo_registration.referral_code)}"
                 span= t("promo.shared.referral_link")
-              .referral-link-copy-button.promo-info-item.copy-button data-clipboard-text="#{human_referral_url(channel.promo_registration.referral_code)}"
+              .referral-link-copy-button.promo-info-item.copy-button data-clipboard-text="#{referral_url(channel.promo_registration.referral_code)}"
                 span= t("promo.shared.copy")
           - else
             .channel-status.pull-right

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -71,7 +71,7 @@ development:
   <<: *default
   api_promo_base_uri: "" # http://127.0.0.1:8194
   active_promo_id: "free-bats-2018q1"
-  base_referral_url: "brave.com"
+  base_referral_url: "https://brave.com"
   api_eyeshade_offline: true
   host_inspector_offline: true
   internal_email: brave-publishers@localhost.local

--- a/test/controllers/promo_registrations_controller_test.rb
+++ b/test/controllers/promo_registrations_controller_test.rb
@@ -73,7 +73,7 @@ class PromoRegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert email.to, publisher.email
 
     # verify the referral link sent matches the publisher's channel
-    assert_email_body_matches(matcher: human_referral_url(publisher.channels.first.promo_registration.referral_code), email: email)
+    assert_email_body_matches(matcher: referral_url(publisher.channels.first.promo_registration.referral_code), email: email)
 
     # verify create is rendered
     assert_select("[data-test=promo-activated-verified]")

--- a/test/mailers/promo_mailer_test.rb
+++ b/test/mailers/promo_mailer_test.rb
@@ -46,7 +46,7 @@ class PromoMailerTest < ActionMailer::TestCase
     assert_equal ['brave-publishers@localhost.local'], email.from
     assert_equal [publisher.email], email.to
 
-    referral_link = human_referral_url(referral_code)
+    referral_link = referral_url(referral_code)
     
     assert_email_body_matches(matcher: referral_link, email: email)
   end
@@ -78,7 +78,7 @@ class PromoMailerTest < ActionMailer::TestCase
       email.deliver_now
     end
 
-    referral_link = human_referral_url(referral_code)
+    referral_link = referral_url(referral_code)
     
     assert_email_body_matches(matcher: referral_link, email: email)  end
 end


### PR DESCRIPTION
Resolves #695 

* Remove PromosHelper#referral_url

* Rename PromosHelper#human_referral_url to #referral_url

* Only use the new #referral_url

* Up the width on the dashboard for the referral link since its longer

**Note:** We must add `https://` to the `BASE_REFERRAL_URL` env var when this is merged

cc @bbondy

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
