### PR TITLE
Add link for legacy youtube login on new_auth_token page

### DIFF
--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -16,5 +16,7 @@
           = f.submit(t("shared.log_in"), class: "btn btn-block btn-primary")
 
       .single-panel--footer.single-panel--footer--secondary
-        ' #{t(".signup_prompt")}
-        = link_to t("publishers.shared.sign_up"), sign_up_publishers_path
+        p
+          ' #{t(".signup_prompt")}
+          = link_to t("publishers.shared.sign_up"), sign_up_publishers_path
+        p = link_to t("publishers.new_auth_token.legacy_youtube_login"), publisher_youtube_login_omniauth_authorize_path, class: "text-muted"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,7 @@ en:
       channel_balance_period: CURRENT PERIOD
     new_auth_token:
       signup_prompt: Don't have an account?
+      legacy_youtube_login: Legacy YouTube Login
     omniauth_callbacks:
       register_youtube_channel:
         channel_already_registered: You have already registered this YouTube channel.


### PR DESCRIPTION
Resolves #700 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
