### PR TITLE
Port site_channels to new styles

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -57,6 +57,8 @@ $braveError-Foreground: #dd0529;
 $braveWarning-Background: #FFF8D2;
 $braveWarning-Foreground: $braveGray-1;
 
+$braveOrange: #FF7A1D;
+
 $braveText-1: $braveGray-1;
 $braveText-2: $braveGray-2;
 $braveText-3: $braveGray-3;

--- a/app/assets/stylesheets/components/btn.scss
+++ b/app/assets/stylesheets/components/btn.scss
@@ -25,3 +25,21 @@
 
   // No need for an active state here
 }
+
+.btn-default {
+  color: $braveGray-1;
+  background: $braveGray-10;
+  border: 1px solid $braveGray-7;
+}
+
+.btn--wrapper--with-icon {
+  display: flex;
+  align-items: center;
+  > * {
+    margin-right: $spacer;
+  }
+}
+
+.btn-wide {
+  min-width: $spacer*10;
+}

--- a/app/assets/stylesheets/components/detailed-content.scss
+++ b/app/assets/stylesheets/components/detailed-content.scss
@@ -1,0 +1,26 @@
+.detailed-content {
+
+  &--small-label {
+    font-size: 0.8rem;
+    color: $braveGray-1;
+    font-weight: bold;
+  }
+
+  &--bold-content {
+    font-weight: bold;
+  }
+
+  &--code {
+    font-family: monospace;
+    font-size: 0.7rem;
+    color: $braveGray-4;
+    border: $braveGray-9 solid 1px;
+    border-radius: 2px;
+    word-break: break-all;
+    height: fit-content;
+    padding: $spacer*0.75;
+    margin-top: $spacer*0.5;
+    margin-bottom: $spacer*0.5;
+  }
+
+}

--- a/app/assets/stylesheets/components/modal.scss
+++ b/app/assets/stylesheets/components/modal.scss
@@ -56,11 +56,12 @@
 .md-close {
   position: absolute;
   right: 30px;
-  top: 24px;
+  top: 7px;
 }
 
 
 .md-confirm-buttons {
+  margin-top: $spacer*2;
   text-align: right;
 
   .btn {

--- a/app/assets/stylesheets/components/progress-train.scss
+++ b/app/assets/stylesheets/components/progress-train.scss
@@ -1,0 +1,71 @@
+$progress-train-lines: $braveGray-8;
+$progress-train-label: $braveGray-4;
+$progress-train-fill: $braveBrand;
+$progress-train-active: #333;
+
+.progress-train--wrapper {
+  text-align: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding-top: 5px;
+  white-space: nowrap;
+  @include media-breakpoint-down(xs) {
+    display: none;
+  }
+}
+
+.progress-train--item {
+  display: inline-block;
+  vertical-align: middle;
+  svg {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 -3px;
+    padding: 0;
+  }
+  .progress-connector {
+    stroke: $progress-train-lines;
+  }
+  .fill-circle {
+    .background-circle {
+      fill: #fff;
+    }
+    .outer-circle {
+      fill: none;
+      stroke: $progress-train-lines;
+    }
+    .inner-circle {
+      stroke: none;
+    }
+  }
+  label {
+    display: inline-block;
+    margin: 0;
+    font-size: 14px;
+    line-height: 14px;
+    padding: 0 5px;
+    color: $progress-train-label;
+    @include media-breakpoint-down(md) {
+      display: none;
+    }
+  }
+  &.unstarted, &.finished {
+    label {
+      font-weight: 100;
+    }
+  }
+  &.started {
+    label {
+      font-weight: 300;
+      color: $progress-train-active
+    }
+  }
+  &.started, &.finished {
+    svg.fill-circle {
+      .inner-circle {
+        fill: $progress-train-fill;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/components/two-options.scss
+++ b/app/assets/stylesheets/components/two-options.scss
@@ -1,0 +1,72 @@
+.two-options {
+  &--wrapper {
+    display: flex;
+    align-items: center;
+    @include media-breakpoint-down(md) {
+      justify-content: center;
+      flex-direction: column;
+    }
+  }
+  &--option-a {
+    flex: 0 1 auto;
+    align-self: flex-start;
+    @include media-breakpoint-down(md) {
+      align-self: center;
+    }
+  }
+  &--or {
+    text-align: center;
+    flex: 1 1 auto;
+    font-weight: bold;
+    @include media-breakpoint-down(md) {
+      padding: $spacer*3 0 $spacer*2.5;
+    }
+  }
+  &--option-b {
+    flex: 0 1 auto;
+    align-self: flex-start;
+    @include media-breakpoint-down(md) {
+      align-self: center;
+    }
+  }
+
+  &--option-a-header {
+    position: relative;
+    white-space: nowrap;
+    &::before {
+      content: "A.";
+      position: absolute;
+      left: -$spacer*2;
+      @include media-breakpoint-down(xs) {
+        content: '';
+      }
+    }
+  }
+  &--option-b-header {
+    position: relative;
+    &::before {
+      content: "B.";
+      position: absolute;
+      left: -$spacer*2;
+      @include media-breakpoint-down(xs) {
+        content: '';
+      }
+    }
+  }
+  &--subheader {
+    font-size: 1.0rem;
+    &--recommended {
+      color: $braveSuccess;
+    }
+  }
+  &--image-wrapper {
+    min-height: $spacer*13;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    @include media-breakpoint-down(md) {
+      min-height: auto;
+      padding: $spacer*2;
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/site-channels.scss
+++ b/app/assets/stylesheets/pages/site-channels.scss
@@ -1,0 +1,28 @@
+.site-channels--body-list {
+  margin-left: -40px;
+  margin-bottom: $spacer*3;
+  @include media-breakpoint-down(xs) {
+    margin-left: -20px;
+  }
+
+  li {
+    margin-bottom: $spacer*2;
+  }
+}
+
+.site-channels--https-check {
+  margin-left: -22px;
+  margin-bottom: $spacer*2;
+  @include media-breakpoint-down(xs) {
+    margin-left: 0;
+  }
+
+  img {
+    margin-top: -1px;
+    margin-right: $spacer*0.5;
+  }
+}
+
+.site-channels--padded-group {
+  margin: $spacer*2 0;
+}

--- a/app/assets/stylesheets/theme/content.scss
+++ b/app/assets/stylesheets/theme/content.scss
@@ -1,0 +1,3 @@
+.dimmed {
+  opacity: 0.2;
+}

--- a/app/assets/stylesheets/theme/form.scss
+++ b/app/assets/stylesheets/theme/form.scss
@@ -1,0 +1,8 @@
+.form-control--code {
+  font-family: monospace;
+  font-size: 0.7rem;
+  color: $braveGray-4;
+  word-break: break-all;
+  height: fit-content;
+  padding: $spacer*0.75;
+}

--- a/app/assets/stylesheets/theme/nav.scss
+++ b/app/assets/stylesheets/theme/nav.scss
@@ -214,3 +214,9 @@
     margin-left: $spacer * 2;
   }
 }
+
+.nav--title {
+  margin-top: 8px;
+  font-weight: bold;
+  color: $braveBrand;
+}

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -44,6 +44,10 @@ $brave-panels-borderRadius: 8px;
         @include make-col-offset(2.5);
       }
     }
+
+    &--collapsed {
+      min-height: auto;
+    }
   }
 
   &--content {
@@ -115,7 +119,8 @@ $brave-panels-borderRadius: 8px;
   }
 
   &--padded-content {
-    padding: $spacer*2;
+    position: relative;
+    padding: $spacer*4 $spacer*2;
     margin-top: auto;
     margin-bottom: auto;
 
@@ -167,6 +172,9 @@ $brave-panels-borderRadius: 8px;
     line-height: 0;
     @include media-breakpoint-down(xs) {
       display: none;
+    }
+    &--top {
+      align-self: flex-start;
     }
   }
   &--text {

--- a/app/assets/stylesheets/theme/text.scss
+++ b/app/assets/stylesheets/theme/text.scss
@@ -1,10 +1,29 @@
 b, strong {
-  color: $braveBrand;
   font-weight: 600;
+}
+
+.error {
+  color: $braveBrand;
 }
 
 h6 {
   color: $braveAccent;
   font-weight: bolder;
   font-size: 1.1rem;
+}
+
+.note-text {
+  font-size: 0.9rem;
+  color: $braveGray-5; 
+}
+
+.color-orange {
+  color: $braveOrange;
+}
+
+textarea[readonly].color-orange {
+  background: inherit;
+  &:focus {
+    color: $braveOrange;
+  }
 }

--- a/app/controllers/site_channels_controller.rb
+++ b/app/controllers/site_channels_controller.rb
@@ -60,6 +60,7 @@ class SiteChannelsController < ApplicationController
       redirect_to(channel_next_step_path(@current_channel), notice: t("shared.channel_created"))
     else
       @channel = @current_channel
+      flash.now[:warning_model_errors] = @channel.details
       render :action => "new"
     end
   end
@@ -91,14 +92,16 @@ class SiteChannelsController < ApplicationController
     @channel = current_channel
     @channel.details.inspect_brave_publisher_id
     @channel.save!
-    redirect_to(site_last_verification_method_path(@channel), alert: t(".alert"))
+    flash[:notice] = t(".alert")
+    redirect_to(site_last_verification_method_path(@channel))
   end
 
   def verify
     VerifySiteChannel.perform_later(channel_id: current_channel.id)
     current_channel.verification_started!
 
-    redirect_to(home_publishers_path, alert: t(".alert"))
+    flash[:notice] = t(".alert")
+    redirect_to home_publishers_path
   end
 
   private

--- a/app/javascript/modal.js
+++ b/app/javascript/modal.js
@@ -152,15 +152,14 @@ function confirmWithModal(confirmableLink) {
  */
 document.addEventListener('DOMContentLoaded', function() {
   var confirmableLinks = document.querySelectorAll('[data-js-confirm-with-modal]');
-  var confirmableLink;
   for (var i=0;i<confirmableLinks.length;i++) {
-    confirmableLink = confirmableLinks[i];
+    let confirmableLink = confirmableLinks[i];
     confirmableLink.addEventListener('click', function(event) {
-      var userVerified = event.target.getAttribute('data-user-verified');
+      var userVerified = confirmableLink.getAttribute('data-user-verified');
       if (userVerified === null) {
         event.preventDefault();
         event.stopPropagation();
-        confirmWithModal(event.target);
+        confirmWithModal(confirmableLink);
       }
     });
   }

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,7 +1,0 @@
--# Locals: :record
-- if record.errors.any?
-  - content_for(:content_form_errors) do
-    - record.errors.each do |attribute, message|
-      .alert.alert-warning
-        strong= "#{record.class.human_attribute_name(attribute)}:"
-        span= " #{message}"

--- a/app/views/application/_panel_flash_messages.html.slim
+++ b/app/views/application/_panel_flash_messages.html.slim
@@ -21,7 +21,7 @@
         - if icon_partial
           .icon-and-text--icon
             = render icon_partial
-        .icon-and-text--text
+        .icon-and-text--text data-test-panel-flash-message=""
           = flash[name]
     - "#{name}_html_safe".tap do |html_safe_name|
       - if flash[html_safe_name]
@@ -29,5 +29,17 @@
           - if icon_partial
             .icon-and-text--icon
               = render icon_partial
-          .icon-and-text--text
+          .icon-and-text--text data-test-panel-flash-message=""
             == flash[html_safe_name]
+    - "#{name}_model_errors".tap do |flash_model_key|
+      - if flash[flash_model_key] && flash[flash_model_key].errors.any?
+        .single-panel--content.icon-and-text--wrapper class="single-panel--content--#{name}"
+          - if icon_partial
+            .icon-and-text--icon
+              = render icon_partial
+          .icon-and-text--text data-test-panel-flash-message=""
+            p= t "activerecord.shared.errors"
+            - flash[flash_model_key].errors.each do |attribute, message|
+              p
+                strong.error= "#{flash[flash_model_key].class.human_attribute_name(attribute)}:"
+                span= " #{message}"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -75,6 +75,25 @@ html
       / The postfix is available for all three flash names and for rendering
       / below the navigation bar or in a panel.
       /
+      / ## Flash messages of model errors
+      /
+      / When a model fails to save you may want to show its validation errors
+      / to the user. To do this in the flash you can use the `_model_errors`
+      / postfix. For exmaple:
+      /
+      /     if publisher.save
+      /       redirect_to success_url
+      /     else
+      /       flash.now[:warning_model_errors] = publisher
+      /       render action: :new
+      /     end
+      /
+      / Because the rendering expects that you pass a literal model, this
+      / utility can only be used with `flash.now`.
+      /
+      / The postfix is available for all three flash names and for rendering
+      / below the navigation bar or in a panel.
+      /
       - if content_for?(:application_flash)
         / This branch permits the panel_flash_messages parital to disable
         / navigation bar flash messages.
@@ -90,9 +109,14 @@ html
                 - if flash[html_safe_name]
                   .alert.flash class="alert-#{flash_class}"
                     == flash[html_safe_name]
-          - if content_for(:content_form_errors)
-            .alert.alert-warning= t "activerecord.shared.errors"
-            = yield(:content_form_errors)
+              - "#{name}_model_errors".tap do |name|
+                - if flash[name] && flash[name].errors.any?
+                  .alert.flash class="alert-#{flash_class}"
+                    p= t "activerecord.shared.errors"
+                    - flash[name].errors.each do |attribute, message|
+                      p
+                        strong.error= "#{flash[name].class.human_attribute_name(attribute)}:"
+                        span= " #{message}"
 
       = content_for?(:content) ? yield(:content) : yield
 
@@ -105,11 +129,12 @@ html
         / FIXME: This provides alternate modal markup during the Bootstrap 4 migration.
         / When Bootstrap 4 becomes the default, this should also become the default.
         - if content_for?(:head_style_tags) || params.has_key?(:bootstrap4)
-          .single-panel--wrapper
-            .single-panel--medium.md-panel
-              .md-content
-              = link_to "#", class: "md-close js-deny"
-                = render "application/icon_x"
+          .single-panel--wrapper.single-panel--wrapper--collapsed
+            .single-panel--content.md-panel
+              .single-panel--padded-content
+                .md-content
+                = link_to "#", class: "md-close js-deny"
+                  = render "application/icon_x"
         - else
           .col.col-10.col-md-8.col-sm-10.col-xs-12.col-center.sub-panel.sub-panel--panel--modal
             .md-content

--- a/app/views/layouts/promo_registrations.html.slim
+++ b/app/views/layouts/promo_registrations.html.slim
@@ -1,5 +1,6 @@
 - content_for(:head_style_tags) do
   = stylesheet_link_tag("application", media: "all")
+
 - content_for(:nav) do
   .nav.nav--promo
     = link_to(root_path) do

--- a/app/views/layouts/site_channels.html.slim
+++ b/app/views/layouts/site_channels.html.slim
@@ -1,7 +1,23 @@
+- content_for(:head_style_tags) do
+  = stylesheet_link_tag("application", media: "all")
+
+= content_for :nav do
+  nav.navbar.navbar-default.navbar-static-top.top-nav-collapse
+    .container-fluid
+      .menu-container
+        .nav.float-left
+          h5.nav--title= t("shared.add_channel")
+        .nav.float-right
+          = link_to(t("shared.cancel"), home_publishers_path, class: 'btn btn-secondary btn-outline-primary')
+        = yield(:site_channel_progress)
+
 - content_for(:content) do
   .main-content
-    #content.container
+    .panels-container
       = yield
 
 = render \
-  template: "layouts/application"
+  template: "layouts/application",
+  locals: { \
+    viewport_initial_scale: "1.0" \
+  }

--- a/app/views/layouts/static.html.slim
+++ b/app/views/layouts/static.html.slim
@@ -17,8 +17,5 @@ html
         .alert.alert-warning.flash= flash[:alert]
       - if flash[:notice]
         .alert.alert-success.flash= flash[:notice]
-      - if content_for(:content_form_errors)
-        .alert.alert-warning= t "activerecord.shared.errors"
-        = yield(:content_form_errors)
 
     = content_for?(:content) ? yield(:content) : yield

--- a/app/views/publishers/_remove_channel_modal.html.slim
+++ b/app/views/publishers/_remove_channel_modal.html.slim
@@ -3,7 +3,7 @@
   p
     = "#{t ".intro"}:"
     br
-    strong
+    strong.error
       = channel.publication_title
   p
     = t ".confirmation"

--- a/app/views/publishers/change_email.html.slim
+++ b/app/views/publishers/change_email.html.slim
@@ -13,7 +13,7 @@
           .form-group
             = f.email_field :pending_email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email")
             .text-left
-              strong= t ".login_email_note"
+              strong.error= t ".login_email_note"
           - if params[:captcha]
             = hidden_field_tag(:captcha)
           - if @should_throttle

--- a/app/views/site_channels/_https_check.html.slim
+++ b/app/views/site_channels/_https_check.html.slim
@@ -1,11 +1,11 @@
 - if current_channel.details.supports_https?
   .note-text
-    = image_tag("verified-icon@2x.png", alt: t(".https"), class: "https-check-icon")
+    = image_tag("verified-icon@1x.png", alt: t(".https"), class: "https-check-icon", width: 11.5, height: 14)
     = t ".https"
 - else
-  .note-text
-    = image_tag("x.png", alt: t(".no_https_alt"), class: "https-check-icon")
+  p.note-text
+    = image_tag("x.png", alt: t(".no_https_alt"), class: "https-check-icon", width: 12, height: 12)
     = t ".no_https"
   = form_for(current_channel.details, method: :patch, url: check_for_https_site_channel_path(current_channel)) do |f|
-    = f.submit(t(".button"), class: "btn btn-primary btn-sm btn-check-https")
+    = f.submit(t(".button"), class: "btn btn-wide btn-primary")
 .clearfix

--- a/app/views/site_channels/_progress.html.slim
+++ b/app/views/site_channels/_progress.html.slim
@@ -1,13 +1,13 @@
-.div.progress-train
+.progress-train--wrapper
   = render :partial => 'progress_item',
-          :locals => { fill: progress[:info],
-                       text: t(".info"),
-                       include_connector: false }
+           :locals => { fill: progress[:info],
+                        text: t(".info"),
+                        include_connector: false }
   = render :partial => 'progress_item',
-          :locals => { fill: progress[:verify],
-                       text: t(".verify"),
-                       include_connector: true }
+           :locals => { fill: progress[:verify],
+                        text: t(".verify"),
+                        include_connector: true }
   = render :partial => 'progress_item',
-          :locals => { fill: progress[:instruction],
-                       text: t(".instruction"),
-                       include_connector: true }
+           :locals => { fill: progress[:instruction],
+                        text: t(".instruction"),
+                        include_connector: true }

--- a/app/views/site_channels/_progress_item.html.erb
+++ b/app/views/site_channels/_progress_item.html.erb
@@ -12,7 +12,7 @@
                        'started'
                    end
 %>
-<div class="progress-item <%= progress_class %>">
+<div class="progress-train--item <%= progress_class %>">
   <% if include_connector %>
     <svg xmlns="http://www.w3.org/2000/svg" width="<%= connector_length %>" height="<%= diameter %>" class="progress-connector">
       <line x1="0" x2="<%= connector_length %>" y1="<%= radius %>" y2="<%= radius %>" />

--- a/app/views/site_channels/new.html.slim
+++ b/app/views/site_channels/new.html.slim
@@ -1,24 +1,29 @@
-- content_for(:navbar_content) do
-  = render :partial => 'progress', :locals => {progress: {info: 100, verify: 0, instruction: 0}, publisher: current_publisher}
+= content_for :site_channel_progress
+  = render partial: 'progress', locals: { \
+    progress: {info: 100, verify: 0, instruction: 0}, \
+    publisher: current_publisher \
+  }
 
-= render(partial: "model_errors", locals: { record: @channel.details })
+.single-panel--wrapper
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content
+      h3.single-panel--headline= t ".heading"
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    | &nbsp;
-
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.process-panel.process-panel-narrow.col-center
-    .content-panel
-      h3= t ".heading"
-      = form_for @channel, { method: :post, url: site_channels_path, html: { id: "enter_domain_info" }} do |f|
-        fieldset
-          = f.fields_for :details, @channel.details do |d|
-            .form-group
-              = d.label(:brave_publisher_id_unnormalized, class: "control-label")
-              = d.text_field(:brave_publisher_id_unnormalized, autofocus: true, class: "form-control", placeholder: "example.com", required: true)
-            - if @should_throttle
+      .col-small-centered.text-left
+        = form_for @channel, { method: :post, url: site_channels_path, html: { id: "enter_domain_info" }} do |f|
+          fieldset
+            = f.fields_for :details, @channel.details do |d|
               .form-group
-                = recaptcha_tags
-        .panel-controls
-          = f.submit(t("shared.continue"), class: "btn btn-primary", :"data-piwik-action" => "ContactInfoClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ContactInfoFlow")
+                = d.label(:brave_publisher_id_unnormalized, class: "control-label")
+                = d.text_field(:brave_publisher_id_unnormalized, autofocus: true, class: "form-control", placeholder: "example.com", required: true)
+              - if @should_throttle
+                .form-group
+                  = recaptcha_tags
+            = f.submit( \
+              t("shared.continue"), \
+              class: "btn btn-block btn-primary", \
+              "data-piwik-action": "ContactInfoClicked", \
+              "data-piwik-name": "Clicked", \
+              "data-piwik-value": "ContactInfoFlow" \
+            )

--- a/app/views/site_channels/verification_choose_method.html.slim
+++ b/app/views/site_channels/verification_choose_method.html.slim
@@ -1,28 +1,33 @@
-- content_for(:navbar_content) do
-  = render :partial => 'progress', :locals => {progress: {info: 0, verify: 100, instruction: 0}, publisher: current_publisher}
+= content_for :site_channel_progress
+  = render partial: 'progress', locals: { \
+    progress: {info: 0, verify: 100, instruction: 0}, \
+    publisher: current_publisher \
+  }
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    = current_channel.details.brave_publisher_id
+.single-panel--wrapper.single-panel--wrapper--large
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content
+      h3.single-panel--headline= t ".heading"
 
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.process-panel.col-center
-    .content-panel
-      h3= t ".heading"
-      .verification-methods
-        .verification-method.optionA
-          h4= t ".trusted_file.heading"
-          h5.recommended= t ".trusted_file.subheading"
-          .img-container= image_tag("choose-file@1x.png", class: "choose-trusted-file")
-          div= link_to(t(".trusted_file.button"), verification_public_file_site_channel_path(current_channel), class: "btn btn-primary", :"data-piwik-action" => "ChosePublicFileClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")
+      .col-medium-centered.text-left
+        .two-options--wrapper
+          .two-options--option-a
+            h4.two-options--option-a-header= t ".trusted_file.heading"
+            .two-options--subheader.two-options--subheader--recommended= t ".trusted_file.subheading"
+            .two-options--image-wrapper
+              = image_tag("choose-file@2x.png", class: "two-options--image", width: 234, height: 137)
+            div= link_to(t(".trusted_file.button"), verification_public_file_site_channel_path(current_channel), class: "btn btn-block btn-primary", :"data-piwik-action" => "ChosePublicFileClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")
 
-        .or
-          strong= t ".or"
+          .two-options--or
+            = t ".or"
 
-        .verification-method.optionB
-          h4= t ".dns.heading"
-          h5= t ".dns.subheading"
-          .img-container= image_tag("choose-dns@1x.png", class: "choose-dns")
-          div= link_to(t(".dns.button"), verification_dns_record_site_channel_path(current_channel), class: "btn btn-secondary", :"data-piwik-action" => "ChoseDNSClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")
+          .two-options--option-b
+            h4.two-options--option-b-header= t ".dns.heading"
+            .two-options--subheader= t ".dns.subheading"
+            .two-options--image-wrapper
+              = image_tag("choose-dns@2x.png", class: "two-options--image", width: 253, height: 96)
+            div= link_to(t(".dns.button"), verification_dns_record_site_channel_path(current_channel), class: "btn btn-block btn-outline-primary", :"data-piwik-action" => "ChoseDNSClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")
 
-      .fine-print.text-center= t(".support_queue.body_html", support_queue_link: link_to(t(".support_queue.link"), verification_support_queue_site_channel_path(current_channel), :"data-piwik-action" => "ChoseSupportClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow"))
+      .single-panel--footer.single-panel--footer--secondary
+        = t(".support_queue.body_html", support_queue_link: link_to(t(".support_queue.link"), verification_support_queue_site_channel_path(current_channel), :"data-piwik-action" => "ChoseSupportClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow"))

--- a/app/views/site_channels/verification_dns_record.html.slim
+++ b/app/views/site_channels/verification_dns_record.html.slim
@@ -1,15 +1,16 @@
-- content_for(:navbar_content) do
-  = render :partial => 'progress', :locals => {progress: {info: 0, verify: 0, instruction: 100}, publisher: current_publisher}
+= content_for :site_channel_progress
+  = render :partial => 'progress', :locals => { \
+    progress: {info: 0, verify: 0, instruction: 100}, \
+    publisher: current_publisher \
+  }
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    = current_channel.details.brave_publisher_id
+.single-panel--wrapper.single-panel--wrapper--large
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content.text-left
+      h3.single-panel--headline.text-center= t ".heading", brave_publisher_id: current_channel.details.brave_publisher_id
 
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.process-panel.col-center
-    .content-panel
-      .dns-record id="dns_records"
-        h3= t ".heading", brave_publisher_id: current_channel.details.brave_publisher_id
+      .col-small-centered.text-left
 
         p
           span= "#{t ".help"} "
@@ -24,32 +25,50 @@
           strong= current_channel.details.brave_publisher_id
           span= " #{t ".instruction_3"}"
 
-        .form-group
-          label.control-label= "#{t ".record.type"}:"
-          span.color-orange.form-control#type TXT
-          button.btn.btn-xs.btn-default.copy-button data-clipboard-target="#type"
-            = t ".copy_to_clipboard"
-        .form-group
-          label.control-label= "#{t ".record.value"}:"
-          textarea.color-orange.dns-record-value.form-control#value readonly="true"
-            = site_channel_verification_dns_record(current_channel)
-          button.btn.btn-xs.btn-default.copy-button data-clipboard-target="#value"
-            = t ".copy_to_clipboard"
-        .form-group
-          p= t ".verify"
-          p.note-text= t ".record.note"
+        .site-channels--padded-group
+          .form-group
+            label.control-label= "#{t ".record.type"}:"
+            input.color-orange.form-control#type value="TXT"
+          .form-group
+            button.btn.btn-sm.btn-default.copy-button data-clipboard-target="#type"
+              = t ".copy_to_clipboard"
 
-        .form-group
-          .form-horizontal
-            .form-group
-              .col-xs-10.col-md-6
-                = form_for(current_channel.details, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
-                  = f.submit(t(".button"), class: "btn btn-block btn-primary btn-sm", :"data-piwik-action" => "DNSVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "DNSFlow")
-              .col-xs-2.col-md-2
-                = popover_menu do
-                  h5= t ".helper.heading"
-                  .help-block= t ".helper.body"
-                  ul.pull-left
+        .site-channels--padded-group
+          .form-group
+            label.control-label= "#{t ".record.value"}:"
+            textarea.color-orange.form-control.form-control--code#value readonly="true"
+              = site_channel_verification_dns_record(current_channel)
+          .form-group
+            button.btn.btn-sm.btn-default.copy-button data-clipboard-target="#value"
+              = t ".copy_to_clipboard"
+
+        p= t ".verify"
+        p.note-text= t ".record.note"
+
+        div.btn--wrapper--with-icon
+          = form_for( \
+            current_channel.details, \
+            method: :patch, \
+            url: verify_site_channel_path(current_channel) \
+          ) do |f|
+            = f.submit( \
+              t(".button"), \
+              class: "btn btn-wide btn-primary", \
+              "data-piwik-action": "DNSVerificationClicked", \
+              "data-piwik-name": "Clicked", \
+              "data-piwik-value": "DNSFlow" \
+            )
+          a href="#" data-js-confirm-with-modal="dns-services"
+            span.icon= render "icon_help"
+
+          script id="dns-services" type="text/html"
+            .text-left
+              h5.single-panel--headline= t ".helper.heading"
+              p.help-block= t ".helper.body"
+
+              .row
+                .col.col-12.col-sm-4
+                  ul
                     li
                       a target="_blank" href="https://help.1and1.com/domains-c36931/manage-domains-c79822/dns-c37586/add-or-remove-txt-records-a792509.html" 1&1
                     li
@@ -66,7 +85,8 @@
                       a target="_blank" href="https://help.dyn.com/standard-dns/managing-resource-records-in-dyn-standard-dns/#record_txt" Dyn or Nettica
                     li
                       a target="_blank" href="https://www.dynadot.com/community/help/question/create-TXT-record" Dynadot
-                  ul.pull-left
+                .col.col-12.col-sm-4
+                  ul
                     li
                       a target="_blank" href="https://fusion.easydns.com/index.php?/Knowledgebase/Article/View/140/7/dns-entries" EasyDNS
                     li
@@ -83,7 +103,8 @@
                       a target="_blank" href="https://help.hover.com/hc/en-us/articles/217282457-How-to-Edit-DNS-records-A-CNAME-MX-TXT-and-SRV-Updated-Aug-2015-" Hover
                     li
                       a target="_blank" href="https://help.iwantmyname.com/customer/en/portal/articles/1769981" IWantMyName
-                  ul.pull-left
+                .col.col-12.col-sm-4
+                  ul
                     li
                       a target="_blank" href="https://www.name.com/support/articles/206127137-Adding-DNS-records-and-templates" Name.com
                     li
@@ -96,5 +117,6 @@
                       a target="_blank" href="https://forum.web.com/register/faq/?p_sid=&p_lva=&p_li=&p_accessibility=0&p_redirect=&p_page=1&p_cv=&p_pv=1.1&p_prods=1&p_cats=+&p_hidden_prods=&prod_lvl1=1&cat_lvl1=+&p_search_text=&p_new_search=1#AccountInformation/What_Is_a_DNS_Record.htm?Highlight=add a dns record" Register.com
                     li
                       a target="_blank" href="https://support.office.com/en-us/article/Create-DNS-records-at-Aabaco-Small-Business-for-Office-365-53d1daba-6a4f-4814-8a68-8ad3d031463e#bkmk_verify" Yahoo/Aabaco
-                  div
-                    a#contact-link.pull-right href="mailto:support+publishers@basicattentiontoken.org"= t ".helper.contact"
+
+              div
+                a#contact-link.float-right href="mailto:support+publishers@basicattentiontoken.org"= t ".helper.contact"

--- a/app/views/site_channels/verification_github.html.slim
+++ b/app/views/site_channels/verification_github.html.slim
@@ -1,37 +1,43 @@
-- content_for(:navbar_content) do
-  = render :partial => 'progress', :locals => {progress: {info: 0, verify: 0, instruction: 100}, publisher: current_publisher}
+= content_for :site_channel_progress
+  = render :partial => 'progress', :locals => { \
+    progress: {info: 0, verify: 0, instruction: 100}, \
+    publisher: current_publisher \
+  }
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    = current_channel.details.brave_publisher_id
+.single-panel--wrapper.single-panel--wrapper--large
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content.text-left
+      h3.single-panel--headline.text-center= t "site_channels.shared.trusted_file"
 
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.process-panel.col-center
-    .content-panel
-      h3= t "site_channels.shared.trusted_file"
-      = render :partial => 'https_check', :locals => { current_channel: current_channel }
+      .col-small-centered.text-left
 
-      div class=(current_channel.details.supports_https? ? "instructions" : "instructions dimmed")
-        ol
-          li
-            p= t ".nojekyll_html"
-          li
-            p= t "site_channels.shared.verification_file.download_html", download_link: link_to(t("shared.download"), download_verification_file_site_channel_path, class: "download-link")
-            .pull-left
-              = image_tag("file@1x.png", class: "instruction-img")
-            .pull-right
-              .file-name-header= t("site_channels.shared.verification_file.name")
-              .file-name= @public_file_name
-              .file-content-header= t "site_channels.shared.verification_file.contents"
-              .file-content
-                = simple_format h site_channel_filter_public_file_content(current_channel, @public_file_content)
-            .clearfix
-          li
-            p= t "site_channels.shared.verification_file.upload_html"
-            = image_tag("upload@1x.png", class: "instruction-img")
-          li
-            p= t "site_channels.shared.verification_file.verify"
-            p.note-text= t "site_channels.shared.verification_file.note"
-            .panel-controls
-              = form_for(current_channel, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
-                = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-primary", :"data-piwik-action" => "GithubVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "GithubFlow")
+        .site-channels--https-check
+          = render :partial => 'https_check', :locals => { current_channel: current_channel }
+
+        div class=(current_channel.details.supports_https? ? "instructions" : "instructions dimmed")
+          ol.site-channels--body-list
+            li
+              p= t ".nojekyll_html"
+            li
+              p= t "site_channels.shared.verification_file.download_html", download_link: link_to(t("shared.download"), download_verification_file_site_channel_path, class: "download-link")
+              .icon-and-text--wrapper
+                .icon-and-text--icon.icon-and-text--icon--top
+                  = image_tag("file@1x.png", class: "instruction-img")
+                .icon-and-text--text
+                  .detailed-content--small-label= t("site_channels.shared.verification_file.name")
+                  .detailed-content--bold-content= @public_file_name
+                  p
+                    .detailed-content--small-label= t "site_channels.shared.verification_file.contents"
+                    .detailed-content--code
+                      = simple_format h site_channel_filter_public_file_content(current_channel, @public_file_content)
+            li
+              p= t "site_channels.shared.verification_file.upload_html"
+              = image_tag("upload@1x.png", class: "instruction-img")
+            li
+              p= t "site_channels.shared.verification_file.verify"
+              p.note-text= t "site_channels.shared.verification_file.note"
+
+          .panel-controls
+            = form_for(current_channel, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
+              = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-wide btn-primary", :"data-piwik-action" => "GithubVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "GithubFlow")

--- a/app/views/site_channels/verification_public_file.html.slim
+++ b/app/views/site_channels/verification_public_file.html.slim
@@ -1,35 +1,41 @@
-- content_for(:navbar_content) do
-  = render :partial => 'progress', :locals => {progress: {info: 0, verify: 0, instruction: 100}, publisher: current_publisher}
+= content_for :site_channel_progress
+  = render :partial => 'progress', :locals => { \
+    progress: {info: 0, verify: 0, instruction: 100}, \
+    publisher: current_publisher \
+  }
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    = current_channel.details.brave_publisher_id
+.single-panel--wrapper.single-panel--wrapper--large
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content.text-left
+      h3.single-panel--headline.text-center= t "site_channels.shared.trusted_file"
 
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.process-panel.col-center
-    .content-panel
-      h3= t "site_channels.shared.trusted_file"
-      = render :partial => 'https_check', :locals => { publisher: current_channel.details }
+      .col-small-centered.text-left
 
-      div class=(current_channel.details.supports_https? ? "instructions" : "instructions dimmed")
-        ol
-          li
-            p= t "site_channels.shared.verification_file.download_html", download_link: link_to(t("shared.download"), download_verification_file_site_channel_path, class: "download-link")
-            .pull-left
-              = image_tag("file@1x.png", class: "instruction-img")
-            .pull-right
-              .file-name-header= t("site_channels.shared.verification_file.name")
-              .file-name= @public_file_name
-              .file-content-header= t "site_channels.shared.verification_file.contents"
-              .file-content
-                = simple_format h publisher_filter_public_file_content(current_channel.details, @public_file_content)
-            .clearfix
-          li
-            p= t "site_channels.shared.verification_file.upload_html"
-            = image_tag("upload@1x.png", class: "instruction-img")
-          li
-            p= t "site_channels.shared.verification_file.verify"
-            p.note-text= t "site_channels.shared.verification_file.note"
-            .panel-controls
-              = form_for(current_channel.details, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
-                = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-primary", :"data-piwik-action" => "PublicFileVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "PublicFileFlow")
+        .site-channels--https-check
+          = render :partial => 'https_check', :locals => { publisher: current_channel.details }
+
+        div class=(current_channel.details.supports_https? ? "instructions" : "instructions dimmed")
+          ol.site-channels--body-list
+            li
+              p= t "site_channels.shared.verification_file.download_html", download_link: link_to(t("shared.download"), download_verification_file_site_channel_path, class: "download-link")
+              .icon-and-text--wrapper
+                .icon-and-text--icon.icon-and-text--icon--top
+                  = image_tag("file@2x.png", class: "instruction-img", width: 63, height: 78)
+                .icon-and-text--text
+                  .detailed-content--small-label= t("site_channels.shared.verification_file.name")
+                  .detailed-content--bold-content= @public_file_name
+                  p
+                    .detailed-content--small-label= t "site_channels.shared.verification_file.contents"
+                    .detailed-content--code
+                      = simple_format h publisher_filter_public_file_content(current_channel.details, @public_file_content)
+            li
+              p= t "site_channels.shared.verification_file.upload_html"
+              = image_tag("upload@2x.png", class: "instruction-img", width: 234, height: 137)
+            li
+              p= t "site_channels.shared.verification_file.verify"
+              p.note-text= t "site_channels.shared.verification_file.note"
+
+          .panel-controls
+            = form_for(current_channel.details, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
+              = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-wide btn-primary", :"data-piwik-action" => "PublicFileVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "PublicFileFlow")

--- a/app/views/site_channels/verification_support_queue.html.slim
+++ b/app/views/site_channels/verification_support_queue.html.slim
@@ -1,16 +1,18 @@
-- content_for(:navbar_content) do
-  = render :partial => 'progress', :locals => {progress: {info: 0, verify: 0, instruction: 100}, publisher: current_publisher}
+= content_for :site_channel_progress
+  = render :partial => 'progress', :locals => { \
+    progress: {info: 0, verify: 0, instruction: 100}, \
+    publisher: current_publisher \
+  }
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    = current_channel.details.brave_publisher_id
-
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.info-panel.col-center
-    .content-panel
-      h3.text-center
+.single-panel--wrapper.single-panel--wrapper--large
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content
+      h3.single-panel--headline
         = t ".heading"
 
-      = t ".help_html"
-      .text-center.panel-controls
-        = link_to(t(".review_options"), verification_choose_method_site_channel_path(current_channel), class: "btn btn-primary", :"data-piwik-action" => "ReturnToOptionsClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")
+      .col-small-centered.text-left
+        == t ".help_html"
+
+      p.single-panel--footer
+        = link_to(t(".review_options"), verification_choose_method_site_channel_path(current_channel), class: "btn btn-wide btn-primary", :"data-piwik-action" => "ReturnToOptionsClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")

--- a/app/views/site_channels/verification_wordpress.html.slim
+++ b/app/views/site_channels/verification_wordpress.html.slim
@@ -1,27 +1,32 @@
-- content_for(:navbar_content) do
-  = render :partial => 'progress', :locals => {progress: {info: 0, verify: 0, instruction: 100}, publisher: current_publisher}
+= content_for :site_channel_progress
+  = render :partial => 'progress', :locals => { \
+    progress: {info: 0, verify: 0, instruction: 100}, \
+    publisher: current_publisher \
+  }
 
-.publisher-domain-panel.publisher-panel.col-center
-  .publisher-domain-name
-    = current_channel.details.brave_publisher_id
+.single-panel--wrapper.single-panel--wrapper--large
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content.text-left
+      h3.single-panel--headline.text-center= t ".heading"
 
-.publisher-main-panel.publisher-panel.col-center
-  .sub-panel.process-panel.col-center
-    .content-panel
-      h3= t ".heading"
-      = render :partial => 'https_check', :locals => { current_channel: current_channel }
+      .col-small-centered.text-left
 
-      div class=(current_channel.details.supports_https? ? "instructions" : "instructions dimmed")
-        ol
-          li
-            = t ".install_plugin_html"
-          li
-            p.li-text= t ".verification_token"
-            .file-content-header= t ".wordpress_token"
-            .verification-code= "brave-ledger-verification=#{site_channel_filtered_verification_token(current_channel)}"
-          li
-            p.li-text= t ".verify"
-            p.note-text= t("site_channels.shared.verification_file.note")
-            .panel-controls
-              = form_for(current_channel.details, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
-                = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-primary", :"data-piwik-action" => "WordpressVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "WordpressFlow")
+        .site-channels--https-check
+          = render :partial => 'https_check', :locals => { current_channel: current_channel }
+
+        div class=(current_channel.details.supports_https? ? "instructions" : "instructions dimmed")
+          ol.site-channels--body-list
+            li
+              = t ".install_plugin_html"
+            li
+              p= t ".verification_token"
+              .detailed-content--small-label= t ".wordpress_token"
+              .detailed-content--code= "brave-ledger-verification=#{site_channel_filtered_verification_token(current_channel)}"
+            li
+              p= t ".verify"
+              p.note-text= t("site_channels.shared.verification_file.note")
+
+          .panel-controls
+            = form_for(current_channel.details, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
+              = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-wide btn-primary", :"data-piwik-action" => "WordpressVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "WordpressFlow")

--- a/app/views/totp_registrations/new.html.slim
+++ b/app/views/totp_registrations/new.html.slim
@@ -23,7 +23,7 @@
                 '
                 em= t ".step_2_alt"
                 '
-                strong= @totp_registration.secret.scan(/.{4}/).join(" ")
+                strong.error= @totp_registration.secret.scan(/.{4}/).join(" ")
                 .text-center
                   .totp-svg== qr_code_svg @provisioning_url
               li.form-group

--- a/app/views/two_factor_registrations/index.html.slim
+++ b/app/views/two_factor_registrations/index.html.slim
@@ -41,14 +41,14 @@
                 class: "btn btn-block btn-outline-secondary",
                 data: { "js-confirm-with-modal": "disable-totp-prompt" }
             script#disable-totp-prompt type="text/html"
-              .col-medium-center
+              .col-medium-center.text-left
                 h4= t ".totp.confirm_disable.header"
                 p
                   = t ".totp.confirm_disable.intro"
                   - if current_publisher.u2f_registrations.any?
                     - current_publisher.u2f_registrations.each do |u2f_registration|
                       br
-                      strong
+                      strong.error
                         | Security key
                         = " \"#{u2f_registration.name.presence || t(".totp.name_default")}\""
                       = " (registered #{l(u2f_registration.created_at.to_date, format: :short)})"

--- a/app/views/u2f_registrations/_u2f_registration.html.slim
+++ b/app/views/u2f_registrations/_u2f_registration.html.slim
@@ -1,5 +1,5 @@
 div
-  strong= "#{u2f_registration.name.presence || t(".name_default")}:"
+  strong.error= "#{u2f_registration.name.presence || t(".name_default")}:"
   = " registered on #{l(u2f_registration.created_at.to_date, format: :long)}"
   = " | "
   = link_to \
@@ -8,18 +8,18 @@ div
     method: :delete,
     data: { "js-confirm-with-modal": "disable-u2f-prompt-#{u2f_registration.id}" }
   script id="disable-u2f-prompt-#{u2f_registration.id}" type="text/html"
-    .col-medium-center
+    .col-medium-center.text-left
       h4 = t(".confirm_disable.header")
       p
         = t(".confirm_disable.intro")
         - if current_publisher.totp_registration || current_publisher.u2f_registrations.length > 1
           - if current_publisher.totp_registration
             br
-            strong = t(".confirm_disable.remaining_totp")
+            strong.error= t(".confirm_disable.remaining_totp")
           - current_publisher.u2f_registrations.each do |remaining_u2f_registration|
             - if u2f_registration != remaining_u2f_registration
               br
-              strong
+              strong.error
                 | Security key
                 = " \"#{remaining_u2f_registration.name.presence || t(".name_default")}\""
               = " (registered #{l(remaining_u2f_registration.created_at.to_date, format: :short)})"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -439,12 +439,13 @@ en:
       trusted_file: Place a Trusted File into your Domain
       verification_file:
         download_html: |
-          %{download_link} the verification file.
+          <strong>%{download_link}</strong> the verification file.
         name: "File name:"
         contents: "File contents:"
         upload_html: |
           Upload the verification file to the '<strong>.well-known</strong>' folder on your domain (create the folder if you don't have one).
-          <span class="file-note">* Do not change the file name or file content.</span>
+          <br />
+          <span class="error">* Do not change the file name or file content.</span>
         verify: Make sure the verification file is placed in the folder and click verify.
         note: "Note: this process may take a few minutes to several hours depending on where your site is hosted."
       verify_button: Verify
@@ -509,7 +510,7 @@ en:
         heading: Need help with adding a TXT record in your DNS account?
         body: |
           Listed below are some of the most popular DNS hosting services with links to their TXT record help pages.
-          If you don't see yours listed below, try searching for \"add TXT record\" in your DNS account support area.
+          If you don't see yours listed below, try searching for "add TXT record" in your DNS account support area.
         contact: Contact Brave Support
     verification_github:
       nojekyll_html: |
@@ -525,7 +526,7 @@ en:
     verification_wordpress:
       heading: Hello. It looks like you are using Wordpress!
       install_plugin_html: |
-        <p class="li-text"><a href="https://wordpress.org/plugins/brave-payments-verification/" class="download-link">Install the plugin</a>
+        <p><strong><a href="https://wordpress.org/plugins/brave-payments-verification/" class="download-link">Install the plugin</a></strong>
         that makes the entire process a snap.</p>
         <p class="note-text">(Plugin location: <a href="https://wordpress.org/plugins/brave-payments-verification/">
         https://wordpress.org/plugins/brave-payments-verification/</a>)</p>

--- a/test/controllers/site_channels_controller_test.rb
+++ b/test/controllers/site_channels_controller_test.rb
@@ -85,7 +85,7 @@ class SiteChannelsControllerTest < ActionDispatch::IntegrationTest
         post site_channels_url, params: create_params
       end
 
-      assert_select('div#flash') do |element|
+      assert_select('[data-test-panel-flash-message]') do |element|
         assert_match("The domain you entered is already verified and added to a different account", element.text)
       end
     ensure


### PR DESCRIPTION
<details>
  <summary>Click to expand screenshots (new on the left side)</summary>

<strong>A: Repaired modal on 2FA registration page @960px</strong>
<img width="1920" alt="screen shot 2018-03-07 at 5 09 12 pm" src="https://user-images.githubusercontent.com/8752/37127386-5816f8c6-222a-11e8-8afc-c891dd57cc7b.png">

**B: site_channel/new @960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 10 19 pm" src="https://user-images.githubusercontent.com/8752/37127412-746b7d58-222a-11e8-943c-e48ad60aac67.png">

**C: site_channel/new @75% of 960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 11 00 pm" src="https://user-images.githubusercontent.com/8752/37127432-8a623520-222a-11e8-8c32-fbecbeebd3a3.png">

**D: site_channel/new with model error @75% of 960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 12 06 pm" src="https://user-images.githubusercontent.com/8752/37127460-b5c3759e-222a-11e8-9d3e-3930d4a68f23.png">

**E: site_channel/verification_choose_method @960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 14 13 pm" src="https://user-images.githubusercontent.com/8752/37127518-ff9262a2-222a-11e8-87ad-415ba180e0c4.png">

**F: site_channel/verification_choose_method @75% of 960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 13 47 pm" src="https://user-images.githubusercontent.com/8752/37127503-ef069c32-222a-11e8-8a78-fe115a44ca48.png">

**G: site_channel/verification_support_queue @960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 15 29 pm" src="https://user-images.githubusercontent.com/8752/37127574-40ce8ea8-222b-11e8-82e5-6698e5a0a468.png">

**H: site_channel/verification_support_queue @Pixel2**
<img width="1920" alt="screen shot 2018-03-07 at 5 17 06 pm" src="https://user-images.githubusercontent.com/8752/37127621-6e4fad80-222b-11e8-9620-76ec09d1b345.png">

**I: site_channel/verification_public_file @75% of 960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 18 22 pm" src="https://user-images.githubusercontent.com/8752/37127649-954a9148-222b-11e8-869f-65c5df67f1bd.png">

**J: site_channel/verification_dns_record @75% of 960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 19 25 pm" src="https://user-images.githubusercontent.com/8752/37127675-b334893e-222b-11e8-8d41-3bc757824e5f.png">

**K: site_channel/verification_dns_record @Pixel2**
<img width="1920" alt="screen shot 2018-03-07 at 5 21 20 pm" src="https://user-images.githubusercontent.com/8752/37127752-fc903e66-222b-11e8-99a5-cef5747259b0.png">

**L: site_channel/verification_dns_record help modal @960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 20 44 pm" src="https://user-images.githubusercontent.com/8752/37127730-e4905e04-222b-11e8-9c18-ec20faa13538.png">

**M: site_channel/verification_github @960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 20 04 pm" src="https://user-images.githubusercontent.com/8752/37127702-cd733c14-222b-11e8-9e55-b14be02c2cdb.png">

**N: site_channel/verification_wordpress @960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 22 03 pm" src="https://user-images.githubusercontent.com/8752/37127767-12845b9e-222c-11e8-83ab-fe6b432136ff.png">

**O: successful creation @960px**
<img width="1920" alt="screen shot 2018-03-07 at 5 22 29 pm" src="https://user-images.githubusercontent.com/8752/37127775-1ff6705a-222c-11e8-8465-5b3288abd45c.png">

</details>

TODO:

* [x] DRY the progress bar stuff
* [x] Review tests
* [x] Screenshots