### PR TITLE
Add Create API calls for Owners and Site Channels

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -15,6 +15,10 @@ class Api::BaseController < ActionController::API
 
   before_action :authenticate
 
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    render(json: { message: e.message }, status: :unprocessable_entity)
+  end
+
   private
 
   # before_action filter to protect API controller actions.
@@ -53,5 +57,10 @@ class Api::BaseController < ActionController::API
 
   def render_unauthorized
     render(json: { message: "authentication failed 🎷" }, status: 403)
+  end
+
+  def ensure_json_content_type
+    return if request.content_type == 'application/json'
+    render(json: { message: "Content-Type must be application/json" }, status: 406)
   end
 end

--- a/app/controllers/api/channels_controller.rb
+++ b/app/controllers/api/channels_controller.rb
@@ -1,9 +1,12 @@
 class Api::ChannelsController < Api::BaseController
   before_action :require_owner,
-                only: %i(verify notify show)
+                only: %i(verify notify show create)
 
   before_action :require_channel,
                 only: %i(verify notify show)
+
+  before_action :ensure_json_content_type,
+                only: %i(create)
 
   include PublishersHelper
 
@@ -54,21 +57,41 @@ class Api::ChannelsController < Api::BaseController
   end
 
   def show
-    render(json: @channel.details)
+    render(json: @channel.details, status: :ok)
+  end
+
+  def create
+    channel = Channel.new(publisher: @owner, verified: true, created_via_api: true)
+
+    channel.details = SiteChannelDetails.new(site_channel_details_params)
+
+    SiteChannelDomainSetter.new(channel_details: channel.details).perform
+
+    channel.save!
+
+    # once the channel has been saved send it to eyeshade
+    begin
+      PublisherChannelSetter.new(publisher: @owner).perform
+    rescue => e
+      require "sentry-raven"
+      Raven.capture_exception(e)
+    end
+
+    render(json: channel.details, status: :ok)
   end
 
   private
 
   def require_owner
     owner_id = publisher_id_from_owner_identifier(params[:owner_id])
-    @owner = Publisher.find(owner_id)
+    @owner = Publisher.where(id: owner_id).first
 
     return @owner if @owner
     response = {
         error: "Invalid owner",
         message: "Can't find an owner with ID #{params[:owner_id]}"
     }
-    render(json: response, status: 404)
+    render(json: response, status: :not_found)
   end
 
   def require_channel
@@ -80,6 +103,13 @@ class Api::ChannelsController < Api::BaseController
       error: "Invalid channel",
       message: "Can't find a channel with ID #{params[:channel_id]}"
     }
-    render(json: response, status: 404)
+    render(json: response, status: :not_found)
+  end
+
+  private
+
+  def site_channel_details_params
+    details_params = params[:channel].permit(:brave_publisher_id)
+    details_params
   end
 end

--- a/app/controllers/api/owners_controller.rb
+++ b/app/controllers/api/owners_controller.rb
@@ -2,11 +2,29 @@ class Api::OwnersController < Api::BaseController
   include PublishersHelper
   include ActionController::Serialization
 
+  before_action :ensure_json_content_type,
+                only: %i(create)
+
   def index
     owners = Publisher.where.not(email: nil).order(:created_at)
 
     page_num = params[:page] || 1
     page_size = params[:per_page] || Rails.application.secrets[:default_api_page_size] || 100
     paginate json: owners, per_page: page_size, page: page_num
+  end
+
+  def create
+    owner = Publisher.new(owner_params)
+    owner.save!
+    render(json: owner, status: :ok)
+  end
+
+  private
+
+  def owner_params
+    owner_params = params[:owner].permit(:email, :name, :phone)
+    owner_params[:visible] = ActiveRecord::Type::Boolean.new.deserialize(params[:owner].permit(:show_verification_status)[:show_verification_status])
+    owner_params[:created_via_api] = true
+    owner_params
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,9 +69,9 @@ Rails.application.routes.draw do
 
   root "static#index"
 
-  namespace :api do
-    resources :owners, format: false, only: %i(index), constraints: { owner_id: %r{[^\/]+} } do
-      resources :channels, only: %i(), constraints: { channel_id: %r{[^\/]+} } do
+  namespace :api, defaults: { format: :json } do
+    resources :owners, only: %i(index create), constraints: { owner_id: %r{[^\/]+} } do
+      resources :channels, only: %i(create), constraints: { channel_id: %r{[^\/]+} } do
         get "/", action: :show
         patch "verifications", action: :verify
         post "notifications", action: :notify


### PR DESCRIPTION
Implemented from slack conversations with @mrose17. @mrose17 should review before merging.

The `owner` `create` call creates verified Publishers and accepts `email`, `name`, and `phone` values. `phone` will be normalized. The created publisher will be email verified.

The `channel` `create` call creates a new site channel for the publisher specified in the route, and accepts the single `brave_publisher_id` value. After creating the new channel it is sent to eyeshade using the `SiteChannelDomainSetter`.

Payloads must be json.

Fixes #638

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))