### PR TITLE
Prevent creating duplicate site channels for a publisher

### DIFF
--- a/app/controllers/site_channels_controller.rb
+++ b/app/controllers/site_channels_controller.rb
@@ -59,6 +59,10 @@ class SiteChannelsController < ApplicationController
 
       redirect_to(channel_next_step_path(@current_channel), notice: t("shared.channel_created"))
     else
+      if @current_channel.errors.details.has_key?(:brave_publisher_id)
+        flash[:warning] = t(".duplicate_channel", domain: @current_channel.details.brave_publisher_id)
+      end
+
       @channel = @current_channel
       render :action => "new"
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,6 +449,8 @@ en:
         verify: Make sure the verification file is placed in the folder and click verify.
         note: "Note: this process may take a few minutes to several hours depending on where your site is hosted."
       verify_button: Verify
+    create:
+      duplicate_channel: "%{domain} is already present."
     check_for_https:
       alert: Check for HTTPS complete
     https_check:


### PR DESCRIPTION
This adds a validation for a publisher trying to create a duplicate site channel to one already in process (verified channels were already prevented). The odd part of this PR is the validation is on the Channel, not on the SiteChannelDetails since it needs access to the Publisher which isn't available when the SiteChannelDetails haven't been saved.

Fixes #637 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
