### PR TITLE
Test: Update flash test selector and Fix SiteChannelsControllerTest

### DIFF
--- a/app/views/application/_panel_flash_messages.html.slim
+++ b/app/views/application/_panel_flash_messages.html.slim
@@ -21,7 +21,7 @@
         - if icon_partial
           .icon-and-text--icon
             = render icon_partial
-        .icon-and-text--text data-test-panel-flash-message=""
+        .icon-and-text--text data-test-flash-message=""
           = flash[name]
     - "#{name}_html_safe".tap do |html_safe_name|
       - if flash[html_safe_name]
@@ -29,7 +29,7 @@
           - if icon_partial
             .icon-and-text--icon
               = render icon_partial
-          .icon-and-text--text data-test-panel-flash-message=""
+          .icon-and-text--text data-test-flash-message=""
             == flash[html_safe_name]
     - "#{name}_model_errors".tap do |flash_model_key|
       - if flash[flash_model_key] && flash[flash_model_key].errors.any?
@@ -37,7 +37,7 @@
           - if icon_partial
             .icon-and-text--icon
               = render icon_partial
-          .icon-and-text--text data-test-panel-flash-message=""
+          .icon-and-text--text data-test-flash-message=""
             p= t "activerecord.shared.errors"
             - flash[flash_model_key].errors.each do |attribute, message|
               p

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -103,15 +103,15 @@ html
           - [:alert, :notice, :warning].each do |name|
             - {alert: 'danger', notice: 'info', warning: 'warning'}[name].tap do |flash_class|
               - if flash[name]
-                .alert.flash class="alert-#{flash_class}"
+                .alert.flash class="alert-#{flash_class}" data-test-flash-message=flash_class
                   = flash[name]
               - "#{name}_html_safe".tap do |html_safe_name|
                 - if flash[html_safe_name]
-                  .alert.flash class="alert-#{flash_class}"
+                  .alert.flash class="alert-#{flash_class}" data-test-flash-message=flash_class
                     == flash[html_safe_name]
               - "#{name}_model_errors".tap do |name|
                 - if flash[name] && flash[name].errors.any?
-                  .alert.flash class="alert-#{flash_class}"
+                  .alert.flash class="alert-#{flash_class}" data-test-flash-message=flash_class
                     p= t "activerecord.shared.errors"
                     - flash[name].errors.each do |attribute, message|
                       p

--- a/test/controllers/site_channels_controller_test.rb
+++ b/test/controllers/site_channels_controller_test.rb
@@ -85,8 +85,8 @@ class SiteChannelsControllerTest < ActionDispatch::IntegrationTest
         post site_channels_url, params: create_params
       end
 
-      assert_select('[data-test-panel-flash-message]') do |element|
-        assert_match("The domain you entered is already verified and added to a different account", element.text)
+      assert_select("[data-test-flash-message]") do |element|
+        assert_match(I18n.t("site_channels.create.duplicate_channel", domain: "verified.org"), element.text)
       end
     ensure
       Rails.application.secrets[:host_inspector_offline] = prev_host_inspector_offline
@@ -127,7 +127,7 @@ class SiteChannelsControllerTest < ActionDispatch::IntegrationTest
         post site_channels_url, params: create_params
       end
 
-      assert_select('div#flash') do |element|
+      assert_select("[data-test-flash-message]") do |element|
         assert_match("newsite.org is already present.", element.text)
       end
     ensure


### PR DESCRIPTION
#709 to prevent site channel dupes referenced a flash selector which was replaced in #703.

This PR consolidates flash test selectors btwn panel flash and application layout flash, and fixes the test.

auditors: @lgebhardt @nvonpentz 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
