### PR TITLE
Speed up tests and ensure Capybara tests don't alter the test data

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,22 +33,38 @@ module ActiveSupport
   class TestCase
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
+    self.use_transactional_tests = true
 
     # Add more helper methods to be used by all tests here...
   end
 end
 
+module Capybara
+  module Rails
+    class TestCase < ::ActiveSupport::TestCase
+      self.use_transactional_tests = false
+
+      setup do
+        DatabaseCleaner.start
+      end
+
+      teardown do
+        DatabaseCleaner.clean
+      end
+
+    end
+  end
+end
+
 module ActionDispatch
   class IntegrationTest
-    self.use_transactional_tests = false
+    self.use_transactional_tests = true
 
     setup do
       WebMock.disable_net_connect!
-      DatabaseCleaner.start
     end
 
     teardown do
-      DatabaseCleaner.clean
       WebMock.allow_net_connect!
     end
 


### PR DESCRIPTION
Use transactional tests instead of DatabaseCleaner non-capybara tests. This speeds up the full test suite on my system from 46s to 26s.

Use DatabaseCleaner with truncation for Capybara tests. The old setup was not correctly running the Capybara tests in a transaction due to the way Selenium runs in a separate thread. That allowed changes to leak and create the flappy tests, at least in the case of #676.

It remains to be seen if there are any more flappy tests.

Fixes #676

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))