### PR TITLE
Resolve misc email UI problems

### DIFF
--- a/app/assets/stylesheets/mailer.scss
+++ b/app/assets/stylesheets/mailer.scss
@@ -15,7 +15,6 @@ body {
   line-height: 1.6;
   width: 600px;
   margin: 0 auto;
-  background: #eff2f5;
   color: #434447;
 }
 

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -3,7 +3,7 @@ html
   head
     meta http-equiv="Content-Type" content="text/html; charset=utf-8"
     = stylesheet_link_tag('mailer', media: 'all')
-  body
+  body style="background-color:#EFF2F5;"
     .main
       .header style="background-image: url(#{attachments["header-pattern.png"]&.url})"
         .brand

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -173,7 +173,7 @@ en:
       confirmation_link: Confirm your email change
       confirmation_link_help: Use this link to confirm that you would like to proceed with this change
     login_email:
-      subject: Brave Publisher login link
+      subject: Log In to Brave Payments
       body_html: |
         Click the private access link below to log in to your account with
         <strong>Brave Payments</strong>. This link can only be used once.


### PR DESCRIPTION
Resolves #532 
Resolves #533

For #533, The background color property was already set in Mailer.scss, and should display correctly, except gmail apparently filters out the css.

According to [stack overflow](https://stackoverflow.com/questions/9493922/gmail-html-email-background-color) there were a couple options:

* Wrap the body in a table with 100% width and height,
* Use inline css

I chose to use inline css.  We should test this on staging to make sure it works in gmail

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
