### PR TITLE
Require the login email input to be populated

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -190,6 +190,12 @@ class PublishersController < ApplicationController
 
   def create_auth_token
     email = publisher_create_auth_token_params[:email]
+
+    if email.blank?
+      flash[:warning] = t(".missing_email")
+      return redirect_to new_auth_token_publishers_path
+    end
+
     @publisher = Publisher.new(publisher_create_auth_token_params)
     @should_throttle = should_throttle_create_auth_token? || params[:captcha]
     throttle_legit =
@@ -281,7 +287,7 @@ class PublishersController < ApplicationController
     if current_publisher.promo_stats_status == :update
       PublisherPromoStatsFetcher.new(publisher: current_publisher).perform
     end
-    
+
     # ensure the wallet has been fetched, which will check if Uphold needs to be re-authorized
     # ToDo: rework this process?
     current_publisher.wallet

--- a/app/views/publishers/new_auth_token.html.slim
+++ b/app/views/publishers/new_auth_token.html.slim
@@ -7,7 +7,7 @@
       .col-small-centered
         = form_for @publisher, url: create_auth_token_publishers_path do |f|
           .form-group
-            = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email")
+            = f.email_field :email, autofocus: true, class: "form-control", placeholder: t("publishers.shared.enter_email"), required: true
           - if params[:captcha]
             = hidden_field_tag(:captcha)
           - if @should_throttle

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,6 +267,7 @@ en:
       email_already_active: The email address you entered "%{email}" is an active account. We've emailed you a login link.
       access_throttled: You've attempted to sign up too many times and your access had been throttled. Try again later.
     create_auth_token:
+      missing_email: We seem to be missing some info. Please make sure you provided an email address.
       unfound_alert_html: |
         Couldn't find a publisher with that email address. Please try again, or you may
         <a data-method="post" data-href="%{create_publisher_path}" href="%{new_publisher_path}">create an account with the email %{email}</a>.


### PR DESCRIPTION
Fixes brave-intl/publishers#719

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
