### PR TITLE
Correctly add sentry debugging information for PublisherMailer # verify_email

### DIFF
--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -71,11 +71,10 @@ class PublisherMailer < ApplicationMailer
 
     if @publisher.pending_email.blank?
       begin
-        raise "SMTP To address must not be blank for PublisherMailer#verify_email"
+        raise "SMTP To address must not be blank for PublisherMailer#verify_email for publisher #{@publisher.id}"
       rescue => e
         require 'sentry-raven'
-        Raven.capture_exception(e,
-                                publisher: @publisher)
+        Raven.capture_exception(e)
       end
     end
     mail(

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -68,8 +68,13 @@ class PublisherMailer < ApplicationMailer
   def verify_email(publisher)
     @publisher = publisher
     @private_reauth_url = generate_publisher_private_reauth_url(@publisher)
-
-    if @publisher.pending_email.blank?
+    
+    if @publisher.pending_email.present?
+      mail(
+          to: @publisher.pending_email,
+          subject: default_i18n_subject
+      )
+    else
       begin
         raise "SMTP To address must not be blank for PublisherMailer#verify_email for publisher #{@publisher.id}"
       rescue => e
@@ -77,12 +82,8 @@ class PublisherMailer < ApplicationMailer
         Raven.capture_exception(e)
       end
     end
-    mail(
-        to: @publisher.pending_email,
-        subject: default_i18n_subject
-    )
   end
-
+  
   # TODO: Refactor
   # Like the above but without the verify_email link
   def verify_email_internal(publisher)

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -54,14 +54,14 @@ class PublisherMailerTest < ActionMailer::TestCase
     assert_equal [publisher.pending_email], email.to
   end
 
-  test "verify_email raises error if there is no send address" do
+  test "verify_email error is rescued if there is no send address" do
     publisher = publishers(:default)
     publisher.pending_email = ""
     publisher.email = "alice_verified@default.org"
     publisher.save
 
     # verify error raised if no pending email
-    assert_raises do
+    assert_nothing_raised do
       PublisherMailer.verify_email(publisher).deliver_now
     end
 


### PR DESCRIPTION
Progresses towards #404 

As [anticipated](https://github.com/brave-intl/publishers/issues/404#issuecomment-353000312) by @ayumi, the debugging information I put in the `PublisherMailer#verify_email` method to address this [bug](https://sentry.io/brave-software/publishers-production-t2/issues/435856730/), does not work.  We're still getting this error so I've moved the publisher identifying information into the error message.

If there is a better way to do this, or better debugging information besides the `{publisher}.id` please comment.


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
