### PR TITLE
Allow verification status to be recorded despite validation errors

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -102,7 +102,13 @@ class Channel < ApplicationRecord
   end
 
   def verification_failed!(details = nil)
-    update!(verified: false, verification_status: 'failed', verification_details: details)
+    # Clear changes so we don't bypass validations when saving without checking them
+    self.reload
+
+    self.verified = false
+    self.verification_status = 'failed'
+    self.verification_details = details
+    self.save!(validate: false)
   end
 
   def verification_succeeded!

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -133,6 +133,21 @@ class ChannelTest < ActiveSupport::TestCase
     assert_equal 'something happened', channel.verification_details
   end
 
+  test "verification_failed! updates verification status even with validation errors" do
+    channel = channels(:fake1)
+
+    refute channel.verified?
+    refute channel.verification_failed?
+    refute channel.verification_started?
+
+    channel.verification_failed!('something happened')
+
+    refute channel.verified?
+    assert channel.verification_failed?
+    refute channel.verification_started?
+    assert_equal 'something happened', channel.verification_details
+  end
+
   test "verification_succeeded! updates verification status" do
     channel = channels(:default)
 


### PR DESCRIPTION
Fixes #724

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))