### PR TITLE
Move userMenu script to application and protect if menu isn't on page

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,6 +1,7 @@
 import 'analytics';
 import 'modal';
 import 'copyButton';
+import 'userMenu';
 import 'utils/request';
 import 'u2f/registrationPage';
 import 'u2f/authenticationPage';

--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -4,7 +4,6 @@ import {
   submitForm
 } from '../utils/request';
 import dynamicEllipsis from '../utils/dynamicEllipsis';
-import '../userMenu';
 
 function showPendingContactEmail(pendingEmail) {
   let pendingEmailNotice = document.getElementById('pending_email_notice');

--- a/app/javascript/userMenu.js
+++ b/app/javascript/userMenu.js
@@ -1,12 +1,15 @@
 document.addEventListener('DOMContentLoaded', function () {
   let userMenu = document.getElementsByClassName('user-menu')[0];
-  let userMenuTrigger = document.getElementsByClassName('user-menu-trigger')[0];
-  let userDropdown = document.getElementsByClassName('user-dropdown')[0];
 
-  // close the dropdown menu, if open
-  document.addEventListener('click', function (event) {
-    if (!userMenu.contains(event.srcElement) && userDropdown.offsetParent !== null) {
-      userMenuTrigger.click();
-    }
-  });
+  if (userMenu) {
+    let userMenuTrigger = document.getElementsByClassName('user-menu-trigger')[0];
+    let userDropdown = document.getElementsByClassName('user-dropdown')[0];
+
+    // close the dropdown menu, if open
+    document.addEventListener('click', function (event) {
+      if (!userMenu.contains(event.srcElement) && userDropdown.offsetParent !== null) {
+        userMenuTrigger.click();
+      }
+    });
+  }
 });


### PR DESCRIPTION
Load the script to close the user menu in the application code and protect it from being used unless the user-menu element is on the page.

Fixes #726

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))