### PR TITLE
Use a shared emailed_auth_token.html.slim for post sign_up and log_in

### DIFF
--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -403,16 +403,6 @@ body[data-controller="u2f_registrations"]
     margin-bottom: 20px
     color: #ff3f3f
 
-body[data-controller="publishers"]
-  &[data-action="create_done"]
-    .email-panel
-      background-image: url(asset-path("email-2@1x.png"))
-      background-position: top 65px right 50px
-      background-repeat: no-repeat
-    .email-address
-      color: #ff3f3f
-
-
   &[data-action="create_done"]
     .hidden_form > *,
     #verification_in_progress

--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -57,13 +57,6 @@ $brave-panels-borderRadius: 8px;
     justify-content: center;
     flex: 1;
 
-    &--email-sent {
-      @include media-breakpoint-up(md) {
-        background-image: url(asset-path("email-2@1x.png"));
-        background-position: top 59px right 60px;
-        background-repeat: no-repeat;
-      }
-    }
     &--platforms {
       padding-top: $spacer*2;
       padding-bottom: $spacer;
@@ -123,6 +116,16 @@ $brave-panels-borderRadius: 8px;
     padding: $spacer*4 $spacer*2;
     margin-top: auto;
     margin-bottom: auto;
+
+    &--email-sent {
+      padding-top: 125px;
+      margin-top: 30px;
+      @include media-breakpoint-up(md) {
+        background-image: url(asset-path("email-2@1x.png"));
+        background-position: center 20px;
+        background-repeat: no-repeat;
+      }
+    }
 
     align-items: center;
     justify-content: center;

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -72,7 +72,7 @@ class PublishersController < ApplicationController
     if verified_publisher
       @publisher = verified_publisher
       PublisherLoginLinkEmailer.new(email: email).perform
-      flash.now[:alert] = t(".email_already_active", email: email)
+      flash.now[:notice] = t(".email_already_active", email: email)
       render :emailed_auth_token
     elsif @publisher.save
       PublisherMailer.verify_email(@publisher).deliver_later

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -73,12 +73,10 @@ class PublishersController < ApplicationController
       @publisher = verified_publisher
       PublisherLoginLinkEmailer.new(email: email).perform
       flash.now[:alert] = t(".email_already_active", email: email)
-      params[:publisher_id] = @publisher.id
       render :emailed_auth_token
     elsif @publisher.save
       PublisherMailer.verify_email(@publisher).deliver_later
       PublisherMailer.verify_email_internal(@publisher).deliver_later if PublisherMailer.should_send_internal_emails?
-      params[:publisher_id] = @publisher.id
       render :emailed_auth_token
     else
       Rails.logger.error("Create publisher errors: #{@publisher.errors.full_messages}")

--- a/app/views/layouts/publishers.html.slim
+++ b/app/views/layouts/publishers.html.slim
@@ -1,4 +1,4 @@
-- %w(create new_auth_token create_auth_token sign_up create_done email_verified change_email change_email_confirm update_email complete_signup expired_auth_token choose_new_channel_type).include?(action_name).tap do |is_bootstrap4|
+- %w(create new_auth_token create_auth_token sign_up create_done email_verified change_email change_email_confirm update_email complete_signup expired_auth_token choose_new_channel_type resend_auth_email).include?(action_name).tap do |is_bootstrap4|
 
   - if is_bootstrap4
     - content_for(:head_style_tags) do

--- a/app/views/publishers/create_auth_token.html.slim
+++ b/app/views/publishers/create_auth_token.html.slim
@@ -1,9 +1,0 @@
-.single-panel--wrapper
-  = render "panel_flash_messages"
-  .single-panel--content
-    .single-panel--padded-content
-
-      h3.single-panel--headline= t ".heading"
-
-      .col-small-centered
-        p.text-center= t ".body"

--- a/app/views/publishers/emailed_auth_token.html.slim
+++ b/app/views/publishers/emailed_auth_token.html.slim
@@ -1,10 +1,9 @@
 .single-panel--wrapper.single-panel--wrapper--large
   = render "panel_flash_messages"
-  .single-panel--content.single-panel--content--email-sent
-    .single-panel--padded-content
+  .single-panel--content.single-panel--content
+    .single-panel--padded-content--email-sent
       h3.single-panel--headline= t ".heading"
 
       .col-small-centered
         = t ".body_html", email: @publisher_email, try_again_link: link_to(t(".try_again"), "#", onclick: "document.getElementById('resend_email_form').submit();")
-
-        = form_tag resend_email_verify_email_publishers_path, method: "post", class: "hidden", id: "resend_email_form"
+        = form_tag resend_auth_email_publishers_path(publisher_id: @publisher.id), method: "post", class: "hidden", id: "resend_email_form"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -266,19 +266,16 @@ en:
       invalid_email: There was an unexpected error creating your account. Please make sure you have provided a full email address.
       email_already_active: The email address you entered "%{email}" is an active account. We've emailed you a login link.
       access_throttled: You've attempted to sign up too many times and your access had been throttled. Try again later.
-    create_auth_token:
+    emailed_auth_token:
       missing_email: We seem to be missing some info. Please make sure you provided an email address.
       unfound_alert_html: |
         Couldn't find a publisher with that email address. Please try again, or you may
         <a data-method="post" data-href="%{create_publisher_path}" href="%{new_publisher_path}">create an account with the email %{email}</a>.
       heading: Login email sent!
       body: Please check your email for the login link.
-    create_done:
       heading: An email is on its way!
       body_html: |
-        <p>We're excited that you want to be in on Brave Payments. We just sent an email to
-        <strong class="email-address">%{email}</strong>. Click on the access link provided in the email to jump into
-        the verification process.</p>
+        <p>We just sent an access link to <strong class="email-address">%{email}</strong>.  Click on the link to log in to your account</p>
         <hr>
         <p>Don't see the email? Be sure to check your spam folder. Please wait for a few minutes and %{try_again_link}.</p>
       try_again: try again
@@ -335,8 +332,8 @@ en:
       email_verification_required: To continue please confirm your email address.
     require_verified_publisher:
       verification_required: To continue please confirm your email address and name.
-    resend_email_verify_email:
-      done: The confirmation email has been resent.
+    resend_auth_email:
+      done: The access email has been resent.
     sign_up:
       heading: Join Brave Payments
     remove_channel_modal:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     collection do
       get :sign_up
       get :create_done
-      post :resend_email_verify_email, action: :resend_email_verify_email
+      post :resend_auth_email, action: :resend_auth_email
       get :home
       get :log_in, action: :new_auth_token, as: :new_auth_token
       post :log_in, action: :create_auth_token, as: :create_auth_token

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -26,7 +26,9 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
         post(publishers_path, params: SIGNUP_PARAMS)
       end
     end
-    assert_redirected_to(create_done_publishers_path)
+    assert_response 200
+    assert_template :emailed_auth_token
+
     publisher = Publisher.order(created_at: :asc).last
     get(publisher_path(publisher))
     assert_redirected_to(root_path)
@@ -40,7 +42,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
       end
     end
     assert_response :success
-    assert_template :create_auth_token
+    assert_template :emailed_auth_token
   end
 
   test "sends an email with an access link" do
@@ -199,7 +201,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
   #     post(create_auth_token_publishers_path, params: params)
   #   end
   # end
-  #
+  
   # test "relogin for unverified publishers fails with the wrong email" do
   #   publisher = publishers(:default)
   #   assert_enqueued_jobs(0) do
@@ -208,7 +210,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
   #     post(create_auth_token_publishers_path, params: params)
   #   end
   # end
-  #
+  
   # test "relogin for verified publishers without an email sends to the publisher's email" do
   #   publisher = publishers(:verified)
   #   perform_enqueued_jobs do

--- a/test/features/log_in_test.rb
+++ b/test/features/log_in_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class LogInTest < Capybara::Rails::TestCase
+  include ActionMailer::TestHelper
   include Devise::Test::IntegrationHelpers
 
   test "can navigate to log in from landing page" do
@@ -19,7 +20,7 @@ class LogInTest < Capybara::Rails::TestCase
     fill_in 'publisher_email', with: email
     click_button('Log In')
 
-    assert_content page, "Login email sent! Please check your email for the login link."
+    assert_content page, "An email is on its way! We just sent an access link to #{email}"
   end
 
   test "after failed login, user can create an account instead" do
@@ -35,5 +36,19 @@ class LogInTest < Capybara::Rails::TestCase
     click_link("create an account with the email #{email}")
 
     assert_content page, "An email is on its way"
+  end
+
+  test "a user can resend log in email" do
+    email = 'alice@verified.org'
+
+    visit new_auth_token_publishers_path
+
+    assert_content page, "Log In"
+    fill_in 'publisher_email', with: email
+    click_button('Log In')
+
+    assert_enqueued_emails(1) do
+      click_link('try again')
+    end
   end
 end

--- a/test/features/sign_up_test.rb
+++ b/test/features/sign_up_test.rb
@@ -2,16 +2,17 @@ require "test_helper"
 
 class SignUpTest < Capybara::Rails::TestCase
   include Devise::Test::IntegrationHelpers
+  include ActionMailer::TestHelper
 
   test "can navigate to sign up from landing page" do
     visit root_path
     assert_content page, "Brave Payments"
-    click_link('Get Started')
+    click_link("Get Started")
     assert_content page, "Join Brave Payments"
   end
 
   test "new users are prompted to finish setting up their account and 2FA" do
-    name = 'Some name'
+    name = "Some name"
     publisher = publishers(:unprompted)
     sign_in publisher
 
@@ -19,12 +20,28 @@ class SignUpTest < Capybara::Rails::TestCase
 
     assert_content page, "Finish signing up"
 
-    fill_in 'publisher_name', with: name
-    click_button('Sign Up')
+    fill_in "publisher_name", with: name
+    click_button("Sign Up")
 
     assert_current_path(prompt_two_factor_registrations_path)
-    click_link('Skip for now')
+    click_link("Skip for now")
 
     assert_current_path(home_publishers_path)
+  end
+
+  test "a user can resend a log in email" do
+    email = "unique@verified.org"
+    assert Publisher.where(email: email).count == 0  # ensure we don't send log in link
+
+    visit sign_up_publishers_path
+    assert_content page, "Join Brave Payments"
+    fill_in "email", with: email
+
+    click_button("Get Started")
+    assert_content page, "An email is on its way! We just sent an access link to #{email}"
+
+    assert_enqueued_emails(2) do
+      click_link('try again')
+    end
   end
 end


### PR DESCRIPTION
Resolves #574 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
