### PR TITLE
Add "Complete Verification Later" button

### DIFF
--- a/app/assets/stylesheets/pages/site-channels.scss
+++ b/app/assets/stylesheets/pages/site-channels.scss
@@ -26,3 +26,13 @@
 .site-channels--padded-group {
   margin: $spacer*2 0;
 }
+
+.site-channels--finish-later {
+  padding-left: 40px;
+  color: $braveBrand;
+  &:hover,
+  &:focus {
+    color: $braveBrand-Dark;
+    text-decoration: none;
+  }
+}

--- a/app/views/site_channels/verification_dns_record.html.slim
+++ b/app/views/site_channels/verification_dns_record.html.slim
@@ -58,6 +58,7 @@
               "data-piwik-name": "Clicked", \
               "data-piwik-value": "DNSFlow" \
             )
+            = link_to(t("site_channels.shared.finish_verification_later"), home_publishers_path, class: "site-channels--finish-later")
           a href="#" data-js-confirm-with-modal="dns-services"
             span.icon= render "icon_help"
 

--- a/app/views/site_channels/verification_github.html.slim
+++ b/app/views/site_channels/verification_github.html.slim
@@ -41,3 +41,4 @@
           .panel-controls
             = form_for(current_channel, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
               = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-wide btn-primary", :"data-piwik-action" => "GithubVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "GithubFlow")
+              = link_to(t("site_channels.shared.finish_verification_later"), home_publishers_path, class: "site-channels--finish-later")

--- a/app/views/site_channels/verification_public_file.html.slim
+++ b/app/views/site_channels/verification_public_file.html.slim
@@ -39,3 +39,4 @@
           .panel-controls
             = form_for(current_channel.details, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
               = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-wide btn-primary", :"data-piwik-action" => "PublicFileVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "PublicFileFlow")
+              = link_to(t("site_channels.shared.finish_verification_later"), home_publishers_path, class: "site-channels--finish-later")

--- a/app/views/site_channels/verification_support_queue.html.slim
+++ b/app/views/site_channels/verification_support_queue.html.slim
@@ -16,3 +16,4 @@
 
       p.single-panel--footer
         = link_to(t(".review_options"), verification_choose_method_site_channel_path(current_channel), class: "btn btn-wide btn-primary", :"data-piwik-action" => "ReturnToOptionsClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "ChooserFlow")
+        = link_to(t("site_channels.shared.finish_verification_later"), home_publishers_path, class: "site-channels--finish-later")

--- a/app/views/site_channels/verification_wordpress.html.slim
+++ b/app/views/site_channels/verification_wordpress.html.slim
@@ -30,3 +30,4 @@
           .panel-controls
             = form_for(current_channel.details, method: :patch, url: verify_site_channel_path(current_channel)) do |f|
               = f.submit(t("site_channels.shared.verify_button"), class: "btn btn-wide btn-primary", :"data-piwik-action" => "WordpressVerificationClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "WordpressFlow")
+              = link_to(t("site_channels.shared.finish_verification_later"), home_publishers_path, class: "site-channels--finish-later")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -451,6 +451,7 @@ en:
         verify: Make sure the verification file is placed in the folder and click verify.
         note: "Note: this process may take a few minutes to several hours depending on where your site is hosted."
       verify_button: Verify
+      finish_verification_later: Complete Verification Later
     create:
       duplicate_channel: "%{domain} is already present."
     check_for_https:


### PR DESCRIPTION
Fixes #710 

Link takes you back to the dashboard. When you resume you will be back to the previous page.

Wordpress:
![screen shot 2018-03-19 at 4 36 14 pm](https://user-images.githubusercontent.com/29154/37620863-d297bd20-2b93-11e8-9505-e76181a1a468.png)

Hover state on link:

![screen shot 2018-03-19 at 4 39 04 pm](https://user-images.githubusercontent.com/29154/37620968-121c6bc6-2b94-11e8-8d39-ffc66be3aa69.png)


Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
