### PR TITLE
Stop autoverify until user presses Verify

### DIFF
--- a/app/jobs/enqueue_site_channel_verifications.rb
+++ b/app/jobs/enqueue_site_channel_verifications.rb
@@ -17,6 +17,6 @@ class EnqueueSiteChannelVerifications < ApplicationJob
 
   # Get unverified channel ids created recently.
   def recent_unverified_site_channels_ids
-    SiteChannelDetails.recent_unverified_site_channels(max_age: MAX_AGE).select(:brave_publisher_id).distinct.pluck("channels.id")
+    SiteChannelDetails.recent_ready_to_verify_site_channels(max_age: MAX_AGE).select(:brave_publisher_id).distinct.pluck("channels.id")
   end
 end

--- a/app/models/site_channel_details.rb
+++ b/app/models/site_channel_details.rb
@@ -24,6 +24,11 @@ class SiteChannelDetails < ApplicationRecord
         .where("channels.created_at": max_age.ago..Time.now)
   }
 
+  scope :recent_ready_to_verify_site_channels, -> (max_age: 6.weeks) {
+    recent_unverified_site_channels(max_age: max_age).where("channels.verification_status": "started").
+        or(recent_unverified_site_channels(max_age: max_age).where("channels.verification_status": "failed"))
+  }
+
   # Channels with no verification_token will not be accessible once the user is no longer on the page, these
   # are considered abandoned. If we wait a day we can be reasonable sure the users session will have timed out.
   scope :abandoned, -> {

--- a/test/controllers/api/tokens_controller_test.rb
+++ b/test/controllers/api/tokens_controller_test.rb
@@ -33,7 +33,7 @@ class Api::TokensControllerTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
 
     response_json = JSON.parse(response.body)
-    assert_equal 8, response_json.length
+    assert_equal 10, response_json.length
 
     details = site_channel_details(:to_verify_details)
     assert_match /#{details.channel.publisher.owner_identifier}/, response.body

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -85,12 +85,25 @@ global_inprocess:
   details: global_inprocess_details (SiteChannelDetails)
   verified: false
 
+global_inprocess3:
+  publisher: global_media_group
+  details: global_inprocess3_details (SiteChannelDetails)
+  verified: false
+  verification_status: "started"
+
+global_inprocess4:
+  publisher: global_media_group
+  details: global_inprocess4_details (SiteChannelDetails)
+  verified: false
+  verification_status: "failed"
+
 global_abandoned:
   publisher: global_media_group
   created_at: <%= Time.now - 20.weeks %>
   updated_at: <%= Time.now - 20.weeks %>
   details: global_abandoned_details (SiteChannelDetails)
   verified: false
+  verification_status: "failed"
 
 small_media_group_to_delete:
   publisher: small_media_group

--- a/test/fixtures/site_channel_details.yml
+++ b/test/fixtures/site_channel_details.yml
@@ -33,6 +33,16 @@ global_inprocess_details:
   verification_token: "23d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
 ﻿ verification_method: wordpress
 
+global_inprocess3_details:
+  brave_publisher_id: "global3.org"
+  verification_token: "63d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
+﻿ verification_method: wordpress
+
+global_inprocess4_details:
+  brave_publisher_id: "global4.org"
+  verification_token: "63d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
+﻿ verification_method: wordpress
+
 global_verified_details:
   brave_publisher_id: "global.org"
   verification_token: "23d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"

--- a/test/jobs/enqueue_site_channel_verifications_test.rb
+++ b/test/jobs/enqueue_site_channel_verifications_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class EnqueueSiteChannelVerificationsTest < ActiveJob::TestCase
   test "#perform enqueue verifications" do
-    channel = channels(:default)
+    channel = channels(:global_inprocess3)
     assert_enqueued_with(job: VerifySiteChannel, args: [{ channel_id: channel.id }]) do
       EnqueueSiteChannelVerifications.perform_now
     end

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -43,7 +43,7 @@ class ChannelTest < ActiveSupport::TestCase
   end
 
   test "can get all visible site channels" do
-    assert_equal 2, publishers(:global_media_group).channels.visible_site_channels.length
+    assert_equal 4, publishers(:global_media_group).channels.visible_site_channels.length
   end
 
   test "can get all visible youtube channels" do
@@ -51,7 +51,7 @@ class ChannelTest < ActiveSupport::TestCase
   end
 
   test "can get all visible channels" do
-    assert_equal 4, publishers(:global_media_group).channels.visible.length
+    assert_equal 6, publishers(:global_media_group).channels.visible.length
   end
 
   test "can get all verified channels" do

--- a/test/models/site_channel_test.rb
+++ b/test/models/site_channel_test.rb
@@ -57,14 +57,22 @@ class SiteChannelTest < ActiveSupport::TestCase
 
     brave_publisher_ids = SiteChannelDetails.recent_unverified_site_channels(max_age: 12.weeks).pluck(:brave_publisher_id)
 
-    assert_equal 6, brave_publisher_ids.length
+    assert_equal 8, brave_publisher_ids.length
     assert brave_publisher_ids.include?("stale.org")
 
     # Default max_age of 6 weeks
     brave_publisher_ids = SiteChannelDetails.recent_unverified_site_channels.pluck(:brave_publisher_id)
 
-    assert_equal 5, brave_publisher_ids.length
+    assert_equal 7, brave_publisher_ids.length
     refute brave_publisher_ids.include?("stale.org")
   end
 
+  test "recent unverified site_channels ready to verify can be found" do
+    brave_publisher_ids = SiteChannelDetails.recent_ready_to_verify_site_channels(max_age: 12.weeks).pluck(:brave_publisher_id)
+
+    assert_equal 2, brave_publisher_ids.length
+    refute brave_publisher_ids.include?("stale.org")
+    assert brave_publisher_ids.include?("global3.org")
+    assert brave_publisher_ids.include?("global4.org")
+  end
 end


### PR DESCRIPTION
This will only enqueue channels for verification once the user has pressed Verify and the `verification_status` has been set to `starting`. In the event of a failure channels with a `verification_status` of `failed` will also be enqueued in order to try again. This will keep channels that have been paused from being verified. 

Fixes #731

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))