### PR TITLE
Readme: Prefixed twitch setup link with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ These steps based on [directions at the omniauth-google-oauth2 gem](https://gith
 Setup a google API project:
 
 * Login to your Twitch account (dev), or the Brave Twitch account (staging, production)
-* Go to [https://dev.twitch.tv/dashboard](dev.twitch.tv/dashboard)
+* Go to [https://dev.twitch.tv/dashboard](https://dev.twitch.tv/dashboard)
 * Select "Get Started" for "App"
 * Give the project a name such as "publishers-dev"
 * Give the app a name and application category.


### PR DESCRIPTION
The [twitch setup](https://github.com/brave-intl/publishers#twitch-api-setup)  incorrectly links to https://github.com/brave-intl/publishers/blob/staging/dev.twitch.tv/dashboard it should be https://dev.twitch.tv/dashboard

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
