### PR TITLE
Correct flash message on channel remove

### DIFF
--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -4,6 +4,7 @@ import {
   submitForm
 } from '../utils/request';
 import dynamicEllipsis from '../utils/dynamicEllipsis';
+import flash from '../utils/flash';
 
 function showPendingContactEmail(pendingEmail) {
   let pendingEmailNotice = document.getElementById('pending_email_notice');
@@ -51,6 +52,8 @@ function removeChannel(channelId) {
         let addChannelPlaceholder = document.getElementById("add_channel_placeholder");
         addChannelPlaceholder.classList.remove("hidden");
       }
+      flash.clear();
+      flash.append('warning', 'Channel removed.');
     });
 }
 

--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -53,7 +53,7 @@ function removeChannel(channelId) {
         addChannelPlaceholder.classList.remove("hidden");
       }
       flash.clear();
-      flash.append('warning', channelRow.getAttribute('data-remove-message'));
+      flash.append('info', channelRow.getAttribute('data-remove-message'));
     });
 }
 

--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -53,7 +53,7 @@ function removeChannel(channelId) {
         addChannelPlaceholder.classList.remove("hidden");
       }
       flash.clear();
-      flash.append('warning', 'Channel removed.');
+      flash.append('warning', channelRow.getAttribute('data-remove-message'));
     });
 }
 

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -141,7 +141,7 @@ script id="choose-channel-type" type="text/html"
     )
 
 - current_publisher.channels.visible.each do |channel|
-  .row.channel-row id=("channel_row_#{channel.id}")
+  .row.channel-row id=("channel_row_#{channel.id}") data-remove-message=(t("shared.channel_removed"))
     .col.col-details.col-md-12.col-xs-10.col-xs-center.col-sm-center
       div class=("sub-panel channel-panel channel-#{channel_verification_status(channel)}")
         .channel-panel--intro

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     cancel: Cancel
     channel_created: Channel created.
     channel_not_found: Channel not found
+    channel_removed: Channel removed.
     continue: Continue
     download: Download
     existing_account: Already have an account?


### PR DESCRIPTION
Fixes https://github.com/brave-intl/publishers/issues/536

/cc @nvonpentz I pulled out the removed channel message from the locale then added to the element below, so I can set the flash message correctly inside the javascript. 

`.row.channel-row id=("channel_row_#{channel.id}") data-remove-message= t("shared.channel_removed")`

https://github.com/brave-intl/publishers/blob/8109d1ed6780a6c14a2f1cc674683de3244e3318/app/views/publishers/home.html.slim#L144

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
