### PR TITLE
Add escape hatch for wordpress users to use DNS verification method

### DIFF
--- a/app/assets/stylesheets/pages/site-channels.scss
+++ b/app/assets/stylesheets/pages/site-channels.scss
@@ -36,3 +36,9 @@
     text-decoration: none;
   }
 }
+
+#wordpress_escape_hatch {
+  opacity: .7;
+  font-size: 12px;
+  margin-top: -25px;
+}

--- a/app/views/site_channels/verification_wordpress.html.slim
+++ b/app/views/site_channels/verification_wordpress.html.slim
@@ -9,9 +9,10 @@
   .single-panel--content
     .single-panel--padded-content.text-left
       h3.single-panel--headline.text-center= t ".heading"
-
+      .single-panel.text-center
+        p#wordpress_escape_hatch = t(".escape_hatch_html", { :href => link_to(t(".verify_dns_record"), verification_dns_record_site_channel_path) })
+        
       .col-small-centered.text-left
-
         .site-channels--https-check
           = render :partial => 'https_check', :locals => { current_channel: current_channel }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -529,7 +529,9 @@ en:
         that this may take a few days due to our current backlog.</p>
       review_options: I'd like to review my options
     verification_wordpress:
-      heading: Hello. It looks like you are using Wordpress!
+      escape_hatch_html: Not using wordpress, or unable to verify your site with the plugin? %{href}
+      verify_dns_record: Verify via a DNS record.
+      heading: Hello. It looks like you are using WordPress!
       install_plugin_html: |
         <p><strong><a href="https://wordpress.org/plugins/brave-payments-verification/" class="download-link">Install the plugin</a></strong>
         that makes the entire process a snap.</p>


### PR DESCRIPTION
Submitter Checklist:
Resolves #736 

This is a temporary measure until #711 fully addresses the verification UI problems.

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
