### PR TITLE
Allow two owners two create the same unverified site channel

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -136,10 +136,12 @@ class Channel < ApplicationRecord
   end
 
   def site_channel_details_brave_publisher_id_unique_for_publisher
-    dup_channels = self.class.visible_site_channels
-                       .where('site_channel_details.brave_publisher_id': details.brave_publisher_id).where.not(id: id)
 
-    if dup_channels.any?
+    dupicate_unverified_channels = publisher.channels.visible_site_channels
+                                                     .where(site_channel_details: { brave_publisher_id: self.details.brave_publisher_id })
+                                                     .where.not(id: id)
+
+    if dupicate_unverified_channels.any?
       errors.add(:brave_publisher_id, "must be unique")
     end
   end


### PR DESCRIPTION
Resolves #748 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
