### PR TITLE
WIP - Add MailChimpRegistrar service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem "email_validator", "~> 1.6"
 # HTTP library wrapper
 gem "faraday", "~> 0.9.2", require: false
 
+# MailChimp API Wrapper
+gem "gibbon"
+
 # Make logs less mad verbose
 gem "lograge", "~> 0.4"
 
@@ -122,6 +125,9 @@ group :test do
 
   # Locking to 5.10.3 to workaround issue in 5.11.1 (https://github.com/seattlerb/minitest/issues/730)
   gem 'minitest', '5.10.3'
+
+  # API recording and playback
+  gem "vcr"
 
   gem "webmock", "~> 3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,9 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
+    gibbon (3.2.0)
+      faraday (>= 0.9.1)
+      multi_json (>= 1.11.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
@@ -370,6 +373,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
+    vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -415,6 +419,7 @@ DEPENDENCIES
   domain_name
   email_validator (~> 1.6)
   faraday (~> 0.9.2)
+  gibbon
   i18n-tasks (~> 0.9.12)
   listen (~> 3.0.5)
   lograge (~> 0.4)
@@ -448,6 +453,7 @@ DEPENDENCIES
   slim-rails (~> 3.1)
   tzinfo-data
   u2f (~> 1.0)
+  vcr
   web-console
   webmock (~> 3.0)
   webpacker (~> 3.0)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -113,6 +113,8 @@ class PublishersController < ApplicationController
       update_params[:agreed_to_tos] = Time.now
     end
 
+    update_mailchimp(publisher: @publisher)
+
     if @publisher.update(update_params)
       # let eyeshade know about the new Publisher
       begin
@@ -171,6 +173,8 @@ class PublishersController < ApplicationController
       PublisherMailer.confirm_email_change(publisher).deliver_later
       PublisherMailer.confirm_email_change_internal(publisher).deliver_later if PublisherMailer.should_send_internal_emails?
     end
+
+    update_mailchimp(publisher: publisher)
 
     respond_to do |format|
       format.json {
@@ -378,8 +382,16 @@ class PublishersController < ApplicationController
       session[:publisher_created_through_youtube_auth] = publisher_created_through_youtube_auth
     end
 
+    if confirm_email.present?
+      prior_email = publisher.email
+    end
+
     if PublisherTokenAuthenticator.new(publisher: publisher, token: token, confirm_email: confirm_email).perform
       if confirm_email.present? && publisher.email == confirm_email && !publisher_created_through_youtube_auth
+
+        # Register the new email address with mailchimp, and clear the publisher interests on the old member
+        update_mailchimp(publisher: publisher, prior_email: prior_email)
+
         flash[:alert] = t(".email_confirmed", email: publisher.email)
       end
 
@@ -456,5 +468,9 @@ class PublishersController < ApplicationController
     return if current_publisher.two_factor_prompted_at.present? || two_factor_enabled?(current_publisher)
     current_publisher.update! two_factor_prompted_at: Time.now
     redirect_to prompt_two_factor_registrations_path
+  end
+
+  def update_mailchimp(publisher:, prior_email: nil)
+    RegisterPublisherWithMailChimpJob.perform_later(publisher_id: publisher.id, prior_email: prior_email)
   end
 end

--- a/app/jobs/register_publisher_with_mail_chimp_job.rb
+++ b/app/jobs/register_publisher_with_mail_chimp_job.rb
@@ -1,0 +1,11 @@
+class RegisterPublisherWithMailChimpJob < ApplicationJob
+  queue_as :default
+
+  def perform(publisher_id:, prior_email: nil)
+    publisher = Publisher.find(publisher_id)
+    MailChimpRegistrar.new(publisher: publisher, prior_email: prior_email).perform
+  rescue => e
+    require "sentry-raven"
+    Raven.capture_exception(e)
+  end
+end

--- a/app/jobs/register_publisher_with_mail_chimp_job.rb
+++ b/app/jobs/register_publisher_with_mail_chimp_job.rb
@@ -1,5 +1,5 @@
 class RegisterPublisherWithMailChimpJob < ApplicationJob
-  queue_as :default
+  queue_as :low_priority
 
   def perform(publisher_id:, prior_email: nil)
     publisher = Publisher.find(publisher_id)

--- a/app/services/mail_chimp_registrar.rb
+++ b/app/services/mail_chimp_registrar.rb
@@ -1,0 +1,76 @@
+require "mail_chimp/api"
+
+# Registers each email address with MailChimp
+class MailChimpRegistrar < BaseService
+
+  def initialize(publisher:, prior_email: nil)
+    @publisher = publisher
+    @prior_email = prior_email
+  end
+
+  def perform
+    return if Rails.application.secrets[:mailchimp_api_offline]
+
+    register_publisher(publisher: @publisher, prior_email: @prior_email)
+
+  rescue => e
+    require "sentry-raven"
+    Rails.logger.error("MailChimpRegistrar #perform error: #{e}")
+    Raven.capture_exception("MailChimpRegistrar #perform error: #{e}")
+    nil
+  end
+
+  private
+
+  # Creates or updates a MailChimp list member for the publisher. Interests are initialized for new members, but
+  # not for existing. This allows the members to manage their interests. One implication is new interests will not
+  # be set for existing publishers. If prior_email is set the prior member's interests will be copied over, and reset
+  # on the prior member. This is used when updating the email address for a publisher.
+  def register_publisher(publisher:, prior_email: nil)
+    existing_member_response = MailChimp::Api.get_member(email: publisher.email)
+
+    assign_interests = {}
+    clear_interests = {}
+
+    # publisher_interests are all interests in select categories
+    publisher_interests = []
+    Rails.application.secrets[:mailchimp_publishers_interest_category_ids].each do |category_id|
+      int_results = MailChimp::Api.publishers_list.interest_categories(category_id).interests.retrieve
+      publisher_interests = publisher_interests + int_results.body[:interests]
+    end
+
+    if existing_member_response
+      assign_interests = existing_member_response.body[:interests]
+    else
+      if prior_email
+        prior_member_response = MailChimp::Api.get_member(email: prior_email)
+      end
+
+      # If a prior member existed we should copy over the publishers interests, otherwise default to true
+      if prior_member_response
+
+        publisher_interests.each do |interest|
+          prior_interest = prior_member_response.body[:interests][interest[:id].to_sym]
+
+          assign_interests[interest[:id]] = prior_interest.nil? ? true : prior_interest
+          clear_interests[interest[:id]] = false
+        end
+      else
+        publisher_interests.each do |interest|
+          assign_interests[interest[:id]] = true
+        end
+      end
+    end
+
+    merge_fields = MailChimp::Api.publisher_merge_fields(publisher: publisher)
+
+    result = MailChimp::Api.upsert_member(email: publisher.email, merge_fields: merge_fields, interests: assign_interests)
+
+    # clear the publisher interests on the prior member
+    if prior_email && clear_interests
+      MailChimp::Api.upsert_member(email: prior_email, merge_fields: merge_fields, interests: clear_interests)
+    end
+
+    result
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative "boot"
+require "csv"
 
 require "rails/all"
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -66,6 +66,11 @@ default: &default
   api_promo_key: <%= ENV["API_PROMO_KEY"] %>
   active_promo_id: <%= ENV["ACTIVE_PROMO_ID"] %>
   base_referral_url: <%= ENV["BASE_REFERRAL_URL"] %>
+  # MailChimp
+  mailchimp_api_key: <%= ENV["MAILCHIMP_API_KEY"] %>
+  mailchimp_api_offline: <%= ENV["MAILCHIMP_API_KEY"].blank? %>
+  mailchimp_publishers_list_id: <%= ENV["MAILCHIMP_PUBLISHERS_LIST_ID"] %>
+  mailchimp_publishers_interest_category_ids: <%= ENV["MAILCHIMP_PUBLISHERS_INTEREST_CATEGORY_IDS"].nil? ? [] : CSV.parse(ENV["MAILCHIMP_PUBLISHERS_INTEREST_CATEGORY_IDS"]) %>
 
 development:
   <<: *default
@@ -108,6 +113,12 @@ test:
   bat_twitter_url: "https://twitter.com/@attentiontoken"
   bat_reddit_url: "https://www.reddit.com/r/BATProject/"
   bat_rocketchat_url: "https://basicattentiontoken.rocket.chat/"
+  # MailChimp
+  # a real api_key is needed for recording new VCR based tests
+  mailchimp_api_offline: true
+  mailchimp_api_key: <%= ENV["MAILCHIMP_API_KEY"] || "fakeapikey-us12" %>
+  mailchimp_publishers_list_id: "b83e0cae3d"
+  mailchimp_publishers_interest_category_ids: <%= ["e3302586ea","da6c0a395e"] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/lib/mail_chimp/api.rb
+++ b/lib/mail_chimp/api.rb
@@ -1,0 +1,62 @@
+require 'digest'
+
+module MailChimp
+  class Api
+    def self.get_lists
+      gibbon_request.lists.retrieve
+    end
+
+    def self.upsert_member(email:, merge_fields:, interests:, status_if_new: "subscribed")
+      email_md5 = md5_hashed_email_address(email)
+
+      body = {
+          email_address: email,
+          status_if_new: status_if_new
+      }
+
+      body[:merge_fields] = merge_fields if merge_fields.is_a?(Hash) && merge_fields.length > 0
+      body[:interests] = interests if interests.is_a?(Hash) && interests.length > 0
+
+      publishers_list.members(email_md5).upsert(body: body)
+    end
+
+    def self.get_member(email:)
+      email_md5 = md5_hashed_email_address(email)
+      publishers_list.members(email_md5).retrieve
+    rescue Gibbon::MailChimpError => e
+      if e.status_code == 404
+        return nil
+      else
+        raise e
+      end
+    end
+
+    def self.publisher_merge_fields(publisher:)
+      merge_fields = {}
+      merge_fields[:NAME] = publisher.name unless publisher.name.blank?
+      merge_fields[:PHONE] = publisher.phone_normalized unless publisher.phone_normalized.blank?
+      merge_fields
+    end
+
+    private
+    def self.publishers_list
+      gibbon_request.lists(Rails.application.secrets[:mailchimp_publishers_list_id])
+    end
+
+    def self.publishers_interest_category
+      publishers_list.interest_categories(Rails.application.secrets[:mailchimp_publishers_interest_category_id])
+    end
+
+    def self.gibbon_request
+      Gibbon::Request.new(api_key: Rails.application.secrets[:mailchimp_api_key],
+                          debug: Rails.application.secrets[:mailchimp_api_debug],
+                          symbolize_keys: true)
+    end
+
+    def self.md5_hashed_email_address(email)
+      md5 = Digest::MD5.new
+      md5 << email.downcase
+      md5
+    end
+  end
+end

--- a/lib/tasks/mail_chimp/info.rake
+++ b/lib/tasks/mail_chimp/info.rake
@@ -1,0 +1,27 @@
+namespace :mailchimp do
+  desc "Initialize the Publishers List and Groups"
+  task :info, [:api_key] => [:environment] do |t, args|
+    @api_key = args[:api_key] ? args[:api_key] : Rails.application.secrets[:mailchimp_api_key]
+
+    def gibbon_request
+      Gibbon::Request.new(api_key: @api_key,
+                          debug: Rails.application.secrets[:mailchimp_api_debug],
+                          symbolize_keys: true)
+    end
+
+    lists = gibbon_request.lists.retrieve.body[:lists].collect do | list |
+      {
+        id: list[:id],
+        name: list[:name],
+        categories: gibbon_request.lists(list[:id]).interest_categories.retrieve.body[:categories].collect do | category |
+          {
+           id: category[:id],
+           title: category[:title]
+          }
+        end
+      }
+    end
+
+    puts JSON.pretty_generate(lists)
+  end
+end

--- a/lib/tasks/mail_chimp/refresh.rake
+++ b/lib/tasks/mail_chimp/refresh.rake
@@ -1,0 +1,12 @@
+namespace :mailchimp do
+  desc "Update MailChimp with latest values from Publishers, creating new members if needed"
+  task :refresh => :environment do
+    publishers = Publisher.email_verified
+
+    publishers.each do |publisher|
+      RegisterPublisherWithMailChimpJob.perform_later(publisher_id: publisher.id)
+    end
+
+    puts "\nDone. Enqueued #{publishers.count} publishers to update at MailChimp."
+  end
+end

--- a/test/cassettes/change_email_publisher_verified.yml
+++ b/test/cassettes/change_email_publisher_verified.yml
@@ -1,0 +1,334 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      X-Request-Id:
+      - 71b980ff-64a2-437f-beb6-ffd9f1a0f940
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/ProblemDetailDocument.json>; rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:14:36 GMT
+      Content-Length:
+      - '234'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"type":"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/","title":"Resource
+        Not Found","status":404,"detail":"The requested resource could not be found.","instance":"71b980ff-64a2-437f-beb6-ffd9f1a0f940"}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:14:36 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 925c39bc-3232-4d38-a7f5-0939d4d46525
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json>;
+        rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:14:36 GMT
+      Content-Length:
+      - '3423'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"interests":[{"category_id":"e3302586ea","list_id":"b83e0cae3d","id":"d20f89f89a","name":"Monthly
+        Recurring Notice","subscriber_count":"1","display_order":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"DELETE"}]},{"category_id":"e3302586ea","list_id":"b83e0cae3d","id":"0e482e836d","name":"Product
+        Updates","subscriber_count":"0","display_order":4,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"DELETE"}]}],"list_id":"b83e0cae3d","category_id":"e3302586ea","total_items":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"},{"rel":"create","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"POST","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/POST.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:14:36 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - e78db760-207f-4d87-a1d8-97b9559d223a
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json>;
+        rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:14:36 GMT
+      Content-Length:
+      - '3409'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"interests":[{"category_id":"da6c0a395e","list_id":"b83e0cae3d","id":"477ca79775","name":"Promotions","subscriber_count":"1","display_order":5,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"DELETE"}]},{"category_id":"da6c0a395e","list_id":"b83e0cae3d","id":"1d6c7e03b8","name":"Product
+        Updates","subscriber_count":"0","display_order":6,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"DELETE"}]}],"list_id":"b83e0cae3d","category_id":"da6c0a395e","total_items":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"},{"rel":"create","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"POST","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/POST.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:14:36 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 7db1fcad-9584-4738-aaf4-623a134e11d5
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy",
+        <https://us12.admin.mailchimp.com/lists/members/view?id=219236513>; rel="dashboard"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:14:36 GMT
+      Content-Length:
+      - '2820'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"id":"a0d4b24018216108cb0c94f1b9974a67","email_address":"alice@verified.org","unique_email_id":"ec4f3cdd92","email_type":"html","status":"subscribed","merge_fields":{"ADDRESS":"","PHONE":"+14159001421","BIRTHDAY":"","NAME":"Alice
+        the Verified"},"interests":{"d20f89f89a":true,"0e482e836d":false,"477ca79775":true,"1d6c7e03b8":false,"42728538c3":true,"843e4b354b":false},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"73.60.209.229","timestamp_opt":"2018-04-02T13:23:11+00:00","member_rating":2,"last_changed":"2018-04-02T14:14:06+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"list_id":"b83e0cae3d","_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"PUT","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"DELETE"},{"rel":"activity","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/activity","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/goals","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/notes","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:14:36 GMT
+- request:
+    method: put
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"alice.changed@verified.org","status_if_new":"subscribed","merge_fields":{"NAME":"Alice
+        the Verified","PHONE":"+14159001421"},"interests":{"d20f89f89a":true,"0e482e836d":false,"477ca79775":true,"1d6c7e03b8":false}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 062c94a2-11d5-4d3a-bbb8-6fc7e30416b8
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy",
+        <https://us12.admin.mailchimp.com/lists/members/view?id=221807997>; rel="dashboard"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:14:36 GMT
+      Content-Length:
+      - '2829'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"id":"f92dffc7b8a4ba76f262ec659381c366","email_address":"alice.changed@verified.org","unique_email_id":"204e1527a6","email_type":"html","status":"subscribed","merge_fields":{"ADDRESS":"","PHONE":"+14159001421","BIRTHDAY":"","NAME":"Alice
+        the Verified"},"interests":{"d20f89f89a":true,"0e482e836d":false,"477ca79775":true,"1d6c7e03b8":false,"42728538c3":false,"843e4b354b":false},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"73.60.209.229","timestamp_opt":"2018-04-02T14:14:36+00:00","member_rating":2,"last_changed":"2018-04-02T14:14:36+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"list_id":"b83e0cae3d","_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366","method":"PUT","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366","method":"DELETE"},{"rel":"activity","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366/activity","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366/goals","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/f92dffc7b8a4ba76f262ec659381c366/notes","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:14:36 GMT
+- request:
+    method: put
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"alice@verified.org","status_if_new":"subscribed","merge_fields":{"NAME":"Alice
+        the Verified","PHONE":"+14159001421"},"interests":{"d20f89f89a":false,"0e482e836d":false,"477ca79775":false,"1d6c7e03b8":false}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 8915d16d-dca1-47d5-8bbb-c7ca75823bdd
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy",
+        <https://us12.admin.mailchimp.com/lists/members/view?id=219236513>; rel="dashboard"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:14:37 GMT
+      Content-Length:
+      - '2822'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"id":"a0d4b24018216108cb0c94f1b9974a67","email_address":"alice@verified.org","unique_email_id":"ec4f3cdd92","email_type":"html","status":"subscribed","merge_fields":{"ADDRESS":"","PHONE":"+14159001421","BIRTHDAY":"","NAME":"Alice
+        the Verified"},"interests":{"d20f89f89a":false,"0e482e836d":false,"477ca79775":false,"1d6c7e03b8":false,"42728538c3":true,"843e4b354b":false},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"73.60.209.229","timestamp_opt":"2018-04-02T13:23:11+00:00","member_rating":2,"last_changed":"2018-04-02T14:14:37+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"list_id":"b83e0cae3d","_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"PUT","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"DELETE"},{"rel":"activity","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/activity","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/goals","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/notes","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:14:37 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 82b659c9-1e82-44b1-a935-1e06de180b15
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy",
+        <https://us12.admin.mailchimp.com/lists/members/view?id=219236513>; rel="dashboard"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:14:37 GMT
+      Content-Length:
+      - '2822'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"id":"a0d4b24018216108cb0c94f1b9974a67","email_address":"alice@verified.org","unique_email_id":"ec4f3cdd92","email_type":"html","status":"subscribed","merge_fields":{"ADDRESS":"","PHONE":"+14159001421","BIRTHDAY":"","NAME":"Alice
+        the Verified"},"interests":{"d20f89f89a":false,"0e482e836d":false,"477ca79775":false,"1d6c7e03b8":false,"42728538c3":true,"843e4b354b":false},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"73.60.209.229","timestamp_opt":"2018-04-02T13:23:11+00:00","member_rating":2,"last_changed":"2018-04-02T14:14:37+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"list_id":"b83e0cae3d","_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"PUT","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67","method":"DELETE"},{"rel":"activity","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/activity","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/goals","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/a0d4b24018216108cb0c94f1b9974a67/notes","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:14:37 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/register_new_publisher_completed.yml
+++ b/test/cassettes/register_new_publisher_completed.yml
@@ -1,0 +1,192 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      X-Request-Id:
+      - 49af90d2-e301-4913-87e3-1f0e5b5489af
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/ProblemDetailDocument.json>; rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 30 Mar 2018 20:30:34 GMT
+      Content-Length:
+      - '234'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"type":"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/","title":"Resource
+        Not Found","status":404,"detail":"The requested resource could not be found.","instance":"49af90d2-e301-4913-87e3-1f0e5b5489af"}'
+    http_version: 
+  recorded_at: Fri, 30 Mar 2018 20:30:34 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - c1399099-db3c-40c8-9876-f115a2d5c741
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json>;
+        rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 30 Mar 2018 20:30:35 GMT
+      Content-Length:
+      - '3423'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"interests":[{"category_id":"e3302586ea","list_id":"b83e0cae3d","id":"d20f89f89a","name":"Monthly
+        Recurring Notice","subscriber_count":"0","display_order":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"DELETE"}]},{"category_id":"e3302586ea","list_id":"b83e0cae3d","id":"0e482e836d","name":"Product
+        Updates","subscriber_count":"0","display_order":4,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"DELETE"}]}],"list_id":"b83e0cae3d","category_id":"e3302586ea","total_items":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"},{"rel":"create","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"POST","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/POST.json"}]}'
+    http_version: 
+  recorded_at: Fri, 30 Mar 2018 20:30:35 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 4ec3ae3f-e9d5-47df-aad3-51e7a908a713
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json>;
+        rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 30 Mar 2018 20:30:35 GMT
+      Content-Length:
+      - '3409'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"interests":[{"category_id":"da6c0a395e","list_id":"b83e0cae3d","id":"477ca79775","name":"Promotions","subscriber_count":"0","display_order":5,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"DELETE"}]},{"category_id":"da6c0a395e","list_id":"b83e0cae3d","id":"1d6c7e03b8","name":"Product
+        Updates","subscriber_count":"0","display_order":6,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"DELETE"}]}],"list_id":"b83e0cae3d","category_id":"da6c0a395e","total_items":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"},{"rel":"create","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"POST","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/POST.json"}]}'
+    http_version: 
+  recorded_at: Fri, 30 Mar 2018 20:30:35 GMT
+- request:
+    method: put
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"alice@completed.org","status_if_new":"subscribed","merge_fields":{"NAME":"Alice
+        the Completed","PHONE":"+14159001421"},"interests":{"d20f89f89a":true,"0e482e836d":true,"477ca79775":true,"1d6c7e03b8":true}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 78e5b31a-a6b6-43b6-b4ac-e073d4674914
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy",
+        <https://us12.admin.mailchimp.com/lists/members/view?id=218012493>; rel="dashboard"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 30 Mar 2018 20:30:45 GMT
+      Content-Length:
+      - '2821'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"id":"d628dbabcb265bddf82441e0ee6b001d","email_address":"alice@completed.org","unique_email_id":"d0645b11c2","email_type":"html","status":"subscribed","merge_fields":{"ADDRESS":"","PHONE":"+14159001421","BIRTHDAY":"","NAME":"Alice
+        the Completed"},"interests":{"d20f89f89a":true,"0e482e836d":true,"477ca79775":true,"1d6c7e03b8":true,"42728538c3":false,"843e4b354b":false},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"73.60.209.229","timestamp_opt":"2018-03-30T20:30:44+00:00","member_rating":2,"last_changed":"2018-03-30T20:30:45+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"list_id":"b83e0cae3d","_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"PUT","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"DELETE"},{"rel":"activity","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/activity","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/goals","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/notes","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"}]}'
+    http_version: 
+  recorded_at: Fri, 30 Mar 2018 20:30:45 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/update_publisher_completed.yml
+++ b/test/cassettes/update_publisher_completed.yml
@@ -1,0 +1,193 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - '08a708bc-3008-476a-87ee-adf615dd6bfc'
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy",
+        <https://us12.admin.mailchimp.com/lists/members/view?id=221825129>; rel="dashboard"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:49:30 GMT
+      Content-Length:
+      - '2822'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"id":"d628dbabcb265bddf82441e0ee6b001d","email_address":"alice@completed.org","unique_email_id":"d0645b11c2","email_type":"html","status":"subscribed","merge_fields":{"ADDRESS":"","PHONE":"+14159001421","BIRTHDAY":"","NAME":"Alice
+        the Completed"},"interests":{"d20f89f89a":true,"0e482e836d":false,"477ca79775":true,"1d6c7e03b8":false,"42728538c3":true,"843e4b354b":false},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"73.60.209.229","timestamp_opt":"2018-04-02T14:47:37+00:00","member_rating":2,"last_changed":"2018-04-02T14:49:05+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"list_id":"b83e0cae3d","_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"PUT","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"DELETE"},{"rel":"activity","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/activity","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/goals","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/notes","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:49:30 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 757c5c28-1b8c-4f49-855a-765b22435366
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json>;
+        rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:49:30 GMT
+      Content-Length:
+      - '3423'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"interests":[{"category_id":"e3302586ea","list_id":"b83e0cae3d","id":"d20f89f89a","name":"Monthly
+        Recurring Notice","subscriber_count":"2","display_order":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/d20f89f89a","method":"DELETE"}]},{"category_id":"e3302586ea","list_id":"b83e0cae3d","id":"0e482e836d","name":"Product
+        Updates","subscriber_count":"0","display_order":4,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests/0e482e836d","method":"DELETE"}]}],"list_id":"b83e0cae3d","category_id":"e3302586ea","total_items":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"},{"rel":"create","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/e3302586ea/interests","method":"POST","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/POST.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:49:30 GMT
+- request:
+    method: get
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 94aa2044-9fa6-493d-b53c-9ed9c81af36e
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Interests/Collection.json>;
+        rel="describedBy"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:49:30 GMT
+      Content-Length:
+      - '3409'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"interests":[{"category_id":"da6c0a395e","list_id":"b83e0cae3d","id":"477ca79775","name":"Promotions","subscriber_count":"2","display_order":5,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/477ca79775","method":"DELETE"}]},{"category_id":"da6c0a395e","list_id":"b83e0cae3d","id":"1d6c7e03b8","name":"Product
+        Updates","subscriber_count":"0","display_order":6,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/PATCH.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests/1d6c7e03b8","method":"DELETE"}]}],"list_id":"b83e0cae3d","category_id":"da6c0a395e","total_items":2,"_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Interests.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/InterestCategories/Response.json"},{"rel":"create","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/interest-categories/da6c0a395e/interests","method":"POST","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Interests/POST.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:49:30 GMT
+- request:
+    method: put
+    uri: https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d
+    body:
+      encoding: UTF-8
+      string: '{"email_address":"alice@completed.org","status_if_new":"subscribed","merge_fields":{"NAME":"Alice
+        the Completed","PHONE":"+14159001421"},"interests":{"d20f89f89a":true,"0e482e836d":false,"477ca79775":true,"1d6c7e03b8":false,"42728538c3":true,"843e4b354b":false}}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Authorization:
+      - Basic <ENCODED API KEY>
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 314364e2-5ef4-4f99-856a-815623325972
+      Link:
+      - <https://us12.api.mailchimp.com/schema/3.0/Lists/Members/Instance.json>; rel="describedBy",
+        <https://us12.admin.mailchimp.com/lists/members/view?id=221825129>; rel="dashboard"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 02 Apr 2018 14:49:30 GMT
+      Content-Length:
+      - '2822'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"id":"d628dbabcb265bddf82441e0ee6b001d","email_address":"alice@completed.org","unique_email_id":"d0645b11c2","email_type":"html","status":"subscribed","merge_fields":{"ADDRESS":"","PHONE":"+14159001421","BIRTHDAY":"","NAME":"Alice
+        the Completed"},"interests":{"d20f89f89a":true,"0e482e836d":false,"477ca79775":true,"1d6c7e03b8":false,"42728538c3":true,"843e4b354b":false},"stats":{"avg_open_rate":0,"avg_click_rate":0},"ip_signup":"","timestamp_signup":"","ip_opt":"73.60.209.229","timestamp_opt":"2018-04-02T14:47:37+00:00","member_rating":2,"last_changed":"2018-04-02T14:49:05+00:00","language":"","vip":false,"email_client":"","location":{"latitude":0,"longitude":0,"gmtoff":0,"dstoff":0,"country_code":"","timezone":""},"list_id":"b83e0cae3d","_links":[{"rel":"self","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json"},{"rel":"parent","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/CollectionResponse.json","schema":"https://us12.api.mailchimp.com/schema/3.0/CollectionLinks/Lists/Members.json"},{"rel":"update","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"PATCH","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PATCH.json"},{"rel":"upsert","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"PUT","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Response.json","schema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/PUT.json"},{"rel":"delete","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d","method":"DELETE"},{"rel":"activity","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/activity","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Activity/Response.json"},{"rel":"goals","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/goals","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Goals/Response.json"},{"rel":"notes","href":"https://us12.api.mailchimp.com/3.0/lists/b83e0cae3d/members/d628dbabcb265bddf82441e0ee6b001d/notes","method":"GET","targetSchema":"https://us12.api.mailchimp.com/schema/3.0/Definitions/Lists/Members/Notes/CollectionResponse.json"}]}'
+    http_version: 
+  recorded_at: Mon, 02 Apr 2018 14:49:30 GMT
+recorded_with: VCR 4.0.0

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -311,6 +311,73 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_nil(publisher.pending_email)
   end
 
+  test "publisher updating contact email address will trigger RegisterPublisherWithMailChimpJobs" do
+    perform_enqueued_jobs do
+      post(publishers_path, params: SIGNUP_PARAMS)
+    end
+    publisher = Publisher.order(created_at: :asc).last
+    url = publisher_url(publisher, token: publisher.authentication_token)
+    get(url)
+    follow_redirect!
+    assert_performed_with(job: RegisterPublisherWithMailChimpJob) do
+      patch(complete_signup_publishers_path, params: COMPLETE_SIGNUP_PARAMS)
+    end
+
+    # verify two emails (one internal) have been sent
+    assert ActionMailer::Base.deliveries.count == 2
+
+    # update the publisher email
+    assert_performed_with(job: RegisterPublisherWithMailChimpJob) do
+      patch(publishers_path,
+            params: { publisher: {pending_email: 'alice-pending@example.com' } },
+            headers: { 'HTTP_ACCEPT' => "application/json" })
+    end
+
+    publisher.reload
+
+    # verify pending email has been updated
+    assert_equal 'alice-pending@example.com', publisher.pending_email
+
+    # verify original email still is used
+    assert_equal 'alice@example.com', publisher.email
+
+    # verify 3 emails have been sent after update
+    assert ActionMailer::Base.deliveries.count == 5
+
+    # verify notification email sent to original address
+    email = ActionMailer::Base.deliveries.find do |message|
+      message.to == publisher.email
+      message.subject == I18n.t('publisher_mailer.notify_email_change.subject', publication_title: publisher.name)
+    end
+    assert_not_nil(email)
+
+    # verify brave gets an internal email copy of confirmation email
+    email = ActionMailer::Base.deliveries.find do |message|
+      message.to.first == Rails.application.secrets[:internal_email]
+      message.subject == "<Internal> #{I18n.t('publisher_mailer.confirm_email_change.subject', publication_title: publisher.name)}"
+    end
+    assert_not_nil(email)
+
+    # verify confirmation email sent to pending address
+    email = ActionMailer::Base.deliveries.find do |message|
+      message.to == publisher.pending_email
+      message.subject == I18n.t('publisher_mailer.confirm_email_change.subject', publication_title: publisher.name)
+    end
+    assert_not_nil(email)
+
+    url = publisher_url(publisher, confirm_email: publisher.pending_email, token: publisher.authentication_token)
+    assert_enqueued_with(job: RegisterPublisherWithMailChimpJob) do
+      get(url)
+    end
+    publisher.reload
+
+    # verify email changes after confirmation
+    assert_equal('alice-pending@example.com', publisher.email)
+
+    # verify pending email is removed after confirmation
+    assert_nil(publisher.pending_email)
+  end
+
   test "after verification, a publisher's `uphold_state_token` is set and will be used for Uphold authorization" do
     publisher = publishers(:completed)
     sign_in publisher

--- a/test/services/mail_chimp_registrar_test.rb
+++ b/test/services/mail_chimp_registrar_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+require "webmock/minitest"
+require 'vcr'
+
+class MailChimpRegistrarTest < ActiveJob::TestCase
+  def md5_hashed_email_address(email)
+    md5 = Digest::MD5.new
+    md5 << email.downcase
+    md5
+  end
+
+  test "registers a new member and assigns all publishers interests" do
+    prev_mailchimp_api_offline = Rails.application.secrets[:mailchimp_api_offline]
+    Rails.application.secrets[:mailchimp_api_offline] = false
+
+    begin
+      publisher = publishers(:completed)
+
+      email_md5 = md5_hashed_email_address(publisher.email)
+
+      VCR.use_cassette("register_new_publisher_completed", :match_requests_on => [:method, :uri, :body]) do
+        result = MailChimpRegistrar.new(publisher: publisher).perform
+
+        assert_equal publisher.email, result.body[:email_address]
+        # Brave payments
+        assert result.body[:interests][:"d20f89f89a"]
+        assert result.body[:interests][:"0e482e836d"]
+        # Marketing
+        assert result.body[:interests][:"477ca79775"]
+        assert result.body[:interests][:"1d6c7e03b8"]
+        # Advertisers
+        refute result.body[:interests][:"42728538c3"]
+        refute result.body[:interests][:"843e4b354b"]
+      end
+    ensure
+      Rails.application.secrets[:mailchimp_api_offline] = prev_mailchimp_api_offline
+    end
+  end
+
+  test "updates a registered member and does not modify publishers interests" do
+    prev_mailchimp_api_offline = Rails.application.secrets[:mailchimp_api_offline]
+    Rails.application.secrets[:mailchimp_api_offline] = false
+
+    begin
+      publisher = publishers(:completed)
+
+      email_md5 = md5_hashed_email_address(publisher.email)
+
+      VCR.use_cassette("update_publisher_completed", :match_requests_on => [:method, :uri, :body]) do
+        result = MailChimpRegistrar.new(publisher: publisher).perform
+        # Brave payments
+        assert result.body[:interests][:"d20f89f89a"]
+        refute result.body[:interests][:"0e482e836d"]
+        # Marketing
+        assert result.body[:interests][:"477ca79775"]
+        refute result.body[:interests][:"1d6c7e03b8"]
+        # Advertisers
+        assert result.body[:interests][:"42728538c3"]
+        refute result.body[:interests][:"843e4b354b"]
+      end
+    ensure
+      Rails.application.secrets[:mailchimp_api_offline] = prev_mailchimp_api_offline
+    end
+  end
+
+  test "initializes interests from a prior member and clears interests on prior member" do
+    prev_mailchimp_api_offline = Rails.application.secrets[:mailchimp_api_offline]
+    Rails.application.secrets[:mailchimp_api_offline] = false
+
+    begin
+      publisher = publishers(:verified)
+      publisher.email = "alice.changed@verified.org"
+      publisher.save
+
+      email_md5 = md5_hashed_email_address(publisher.email)
+
+      VCR.use_cassette("change_email_publisher_verified", :match_requests_on => [:method, :uri, :body]) do
+        result = MailChimpRegistrar.new(publisher: publisher, prior_email: "alice@verified.org").perform
+
+        assert result.body[:interests][:"d20f89f89a"]
+        refute result.body[:interests][:"0e482e836d"]
+
+        # Check that Advertiser interests were not copied over
+        refute result.body[:interests][:"42728538c3"]
+        refute result.body[:interests][:"843e4b354b"]
+
+        prior_member_result = MailChimp::Api.get_member(email: "alice@verified.org")
+        refute prior_member_result.body[:interests][:"d20f89f89a"]
+
+        # Check that Advertiser interests were not cleared
+        assert prior_member_result.body[:interests][:"42728538c3"]
+        refute prior_member_result.body[:interests][:"843e4b354b"]
+      end
+    ensure
+      Rails.application.secrets[:mailchimp_api_offline] = prev_mailchimp_api_offline
+    end
+  end
+end

--- a/test/tasks/launch_promo_test.rb
+++ b/test/tasks/launch_promo_test.rb
@@ -1,13 +1,6 @@
 require 'test_helper'
 
 class LaunchPromoTest < ActiveJob::TestCase
-
-  before do
-    require 'rake'
-    Rake::Task.define_task :environment
-    Rails.application.load_tasks
-  end
-
   # test "incorrect active_promo_id does not launch the promo" do
   #   # TO DO
 

--- a/test/tasks/mail_chimp_refresh_test.rb
+++ b/test/tasks/mail_chimp_refresh_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class MailChimpRefreshTest < ActiveJob::TestCase
+
+  test "upserts all email verified publishers to MailChimp with one RegisterPublisherWithMailChimpJob per publisher" do
+    assert_enqueued_with job: RegisterPublisherWithMailChimpJob do
+      Rake::Task["mailchimp:refresh"].invoke
+    end
+
+    assert_enqueued_jobs Publisher.email_verified.count
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "minitest/rails/capybara"
 require "webmock/minitest"
 require "chromedriver/helper"
 require 'sidekiq/testing'
+require 'mail_chimp/api'
 
 Sidekiq::Testing.fake!
 
@@ -21,6 +22,15 @@ Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new app,
     browser: :chrome,
     desired_capabilities: capabilities
+end
+
+VCR.configure do |config|
+  config.cassette_library_dir = "./test/cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data("<ENCODED API KEY>") {
+    Base64.encode64(["apikey", Rails.application.secrets[:mailchimp_api_key]].join(':')).chomp
+  }
+  config.ignore_hosts '127.0.0.1', 'localhost'
 end
 
 class Capybara::Rails::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,6 +84,10 @@ module ActionDispatch
   end
 end
 
+# Load rake tasks here so it only happens one time. If tasks are loaded again they will run once for each time loaded.
+require 'rake'
+Publishers::Application.load_tasks
+
 # One time test suite setup.
 DatabaseCleaner.strategy = :transaction
 DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
WIP - This PR was made for discussion. I'd like to get the Rake Task in as well so we can initialize the mailchimp account.

There are a few things I'd like to change, but looking for feedback:

 The main one is the configuration for the mailchimp api. We're using a single list, and Publishers will track interests under it's own category. Currently the ids for the list and category need to be specified. It's easy to get them with an api call, but not from the MailChimp UI. And this is an additional config step.

Failures communicating with the MailChimp api do not result in the service trying again. These are only logged.

Fixes ##738

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))