### PR TITLE
Release 2018-04-10

### DIFF
--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -521,7 +521,7 @@ body[data-controller="u2f_registrations"]
       #publisher_status
         vertical-align: top
         margin-top: 20px
-        margin-bottom: 45px
+        margin-bottom: 25px
         &.complete
           // no background
         &.uphold_processing,
@@ -532,6 +532,8 @@ body[data-controller="u2f_registrations"]
           background-repeat: no-repeat
           background-size: 42px
           background-image: url(asset-path("icn-warning@1x.png"))
+      .deposit-currency
+        margin-top: 10px
       #update_publisher_visible_form
         margin-top: 40px
         margin-left: -30px

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -180,6 +180,10 @@ class PublishersController < ApplicationController
       PublisherMailer.confirm_email_change_internal(publisher).deliver_later if PublisherMailer.should_send_internal_emails?
     end
 
+    if success && update_params[:default_currency]
+      UploadDefaultCurrencyJob.perform_later(publisher_id: publisher.id)
+    end
+
     respond_to do |format|
       format.json {
         if success

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -47,8 +47,8 @@ module PublishersHelper
   end
 
   def publisher_converted_balance(publisher)
-    currency = publisher_default_currency(publisher)
-    return if currency == "BAT"
+    currency = publisher.default_currency
+    return if currency == "BAT" || currency.blank?
     if balance = publisher.wallet && publisher.wallet.contribution_balance
       converted_amount = '%.2f' % balance.convert_to(currency)
       I18n.t("helpers.publisher.balance_pending_approximate", amount: converted_amount, code: currency)
@@ -111,13 +111,12 @@ module PublishersHelper
     Rails.application.secrets[:terms_of_service_url]
   end
 
-  def publisher_default_currency(publisher)
-    publisher.default_currency.present? ? publisher.default_currency : 'BAT'
-  end
-
   def publisher_available_currencies(publisher)
     available_currencies = publisher.wallet.try(:wallet_details).try(:[], 'availableCurrencies')
-    available_currencies.blank? ? ['BAT'] : available_currencies
+    if publisher.default_currency.blank?
+      available_currencies.unshift(['-- Select currency --', nil])
+    end
+    available_currencies
   end
 
   def publisher_verification_status(publisher)

--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -3,6 +3,7 @@ import {
   pollUntilSuccess,
   submitForm
 } from '../utils/request';
+import fetch from '../utils/fetchPolyfill';
 import dynamicEllipsis from '../utils/dynamicEllipsis';
 import flash from '../utils/flash';
 
@@ -69,7 +70,7 @@ function checkUpholdStatus() {
     method: 'GET'
   };
 
-  return window.fetch('./status', options)
+  return fetch('./status', options)
     .then(function(response) {
       checkUpholdStatusCount += 1;
       if (response.status === 200 || response.status === 304) {
@@ -106,7 +107,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   if (document.querySelectorAll('div#uphold_dashboard.uphold-status-access-parameters-acquired').length > 0) {
-    window.dynamicEllipsis.start('publisher_status');
+    dynamicEllipsis.start('publisher_status');
     checkUpholdStatusInterval = window.setInterval(checkUpholdStatus, 2000);
   }
 

--- a/app/jobs/upload_default_currency_job.rb
+++ b/app/jobs/upload_default_currency_job.rb
@@ -1,0 +1,9 @@
+class UploadDefaultCurrencyJob < ApplicationJob
+  queue_as :default
+
+  def perform(publisher_id:)
+    publisher = Publisher.find(publisher_id)
+
+    PublisherDefaultCurrencySetter.new(publisher: publisher).perform
+  end
+end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -88,7 +88,7 @@ class Publisher < ApplicationRecord
 
       # Initialize the default_currency from the wallet, if it exists
       if self.default_currency.nil?
-        default_currency_code = @_wallet.try(:wallet_details).try(:[], 'preferredCurrency')
+        default_currency_code = @_wallet.try(:wallet_details).try(:[], 'defaultCurrency')
         if default_currency_code
           self.default_currency = default_currency_code
           save_needed = true

--- a/app/services/publisher_default_currency_setter.rb
+++ b/app/services/publisher_default_currency_setter.rb
@@ -1,0 +1,49 @@
+class PublisherDefaultCurrencySetter < BaseApiClient
+  attr_reader :publisher
+
+  def initialize(publisher:)
+    @publisher = publisher
+  end
+
+  def perform
+    return perform_offline if Rails.application.secrets[:api_eyeshade_offline]
+
+    if publisher.default_currency.blank?
+      raise "Publisher #{publisher.id} is missing a default_currency."
+    end
+
+    # This raises when response is not 2xx.
+    response = connection.patch do |request|
+      request.headers["Authorization"] = api_authorization_header
+      request.headers["Content-Type"] = "application/json"
+
+      request.body =
+          <<~BODY
+          {
+            "defaultCurrency": "#{publisher.default_currency}" 
+          }
+      BODY
+      request.url("/v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet")
+    end
+    response
+
+  rescue Faraday::Error => e
+    Rails.logger.warn("PublisherDefaultCurrencySetter #perform error: #{e}")
+    nil
+  end
+
+  def perform_offline
+    Rails.logger.info("PublisherDefaultCurrencySetter eyeshade offline; only locally updating default_currency.")
+    true
+  end
+
+  private
+
+  def api_base_uri
+    Rails.application.secrets[:api_eyeshade_base_uri]
+  end
+
+  def api_authorization_header
+    "Bearer #{Rails.application.secrets[:api_eyeshade_key]}"
+  end
+end

--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -84,7 +84,7 @@ class PublisherWalletGetter < BaseApiClient
         "wallet" => {
             "provider" => "uphold",
             "authorized" => true,
-            "preferredCurrency" => 'USD',
+            "defaultCurrency" => 'USD',
             "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       },

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -74,8 +74,10 @@ script id="choose-channel-type" type="text/html"
           .panel-section#uphold_dashboard class=(uphold_status_class(current_publisher) + (show_uphold_dashboard?(current_publisher) ? '' : ' hidden'))
             .panel-section
               = form_for(current_publisher, url: publishers_path, html: { id: "update_default_currency_form" }) do |f|
-                span= t ".uphold.deposit_currency"
-                span#default_currency_code= f.select(:default_currency, options_for_select(publisher_available_currencies(current_publisher), publisher_default_currency(current_publisher)))
+                .deposit-currency-label= t ".uphold.deposit_currency_label"
+                .deposit-currency
+                  span= t ".uphold.deposit_currency"
+                  span#default_currency_code= f.select(:default_currency, options_for_select(publisher_available_currencies(current_publisher), current_publisher.default_currency))
             = link_to(t(".uphold.check_balance"), uphold_dashboard_url, class: "btn btn-primary", :"data-piwik-action" => "CheckUpholdBalanceClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
   .col.col-details.col-md-6.col-xs-10.col-xs-center.col-sm-center
     .sub-panel.dashboard-panel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,7 +299,8 @@ en:
       add_channel_cta: Add a website or YouTube channel to see how much your fans on Brave have contributed so far.
       uphold:
         heading: Your Uphold Wallet
-        deposit_currency: "Current deposit currency: BAT to "
+        deposit_currency_label: "Current deposit currency:"
+        deposit_currency: "BAT to "
         check_balance: Check Balance
       statements:
         heading: Statements

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -60,7 +60,7 @@ class PublishersHelperTest < ActionView::TestCase
         "wallet" => {
           "provider" => "uphold",
           "authorized" => true,
-          "preferredCurrency" => 'USD',
+          "defaultCurrency" => 'USD',
           "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       }
@@ -111,7 +111,7 @@ class PublishersHelperTest < ActionView::TestCase
         "wallet" => {
           "provider" => "uphold",
           "authorized" => true,
-          "preferredCurrency" => 'USD',
+          "defaultCurrency" => 'USD',
           "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       }

--- a/test/jobs/upload_default_currency_job_test.rb
+++ b/test/jobs/upload_default_currency_job_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+require "webmock/minitest"
+
+class UploadDefaultCurrencyJobTest < ActiveJob::TestCase
+  test "sends default currency to eyeshade" do
+    prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+
+      publisher = publishers(:verified)
+      publisher.default_currency = 'USD'
+      publisher.save!
+
+      stub_request(:patch, /v1\/owners\/#{publisher.owner_identifier}\/wallet/).
+        with(headers: {'Accept'=>'*/*',
+                       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                       'Authorization'=>"Bearer #{Rails.application.secrets[:api_eyeshade_key]}",
+                       'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'},
+             body:
+               <<~BODY
+                 {
+                   "defaultCurrency": "USD" 
+                 }
+               BODY
+        )
+
+      UploadDefaultCurrencyJob.perform_now(publisher_id: publisher.id)
+
+      publisher.reload
+      assert_equal 'USD', publisher.default_currency
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
+    end
+  end
+end

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -135,7 +135,7 @@ class PublisherTest < ActiveSupport::TestCase
     begin
       Rails.application.secrets[:api_eyeshade_offline] = false
       
-      body = "{ \"status\":{ \"provider\":\"uphold\", \"action\":\"re-authorize\" }, \"contributions\":{ \"amount\":\"9001.00\", \"currency\":\"USD\", \"altcurrency\":\"BAT\", \"probi\":\"38077497398351695427000\" }, \"rates\":{ \"BTC\":0.00005418424016883016, \"ETH\":0.000795331082073117, \"USD\":0.2363863335301452, \"EUR\":0.20187818378874756, \"GBP\":0.1799810085548496 }, \"wallet\":{ \"provider\":\"uphold\", \"authorized\":true, \"preferredCurrency\":\"USD\", \"availableCurrencies\":[ \"USD\", \"EUR\", \"BTC\", \"ETH\", \"BAT\" ] } }"
+      body = "{ \"status\":{ \"provider\":\"uphold\", \"action\":\"re-authorize\" }, \"contributions\":{ \"amount\":\"9001.00\", \"currency\":\"USD\", \"altcurrency\":\"BAT\", \"probi\":\"38077497398351695427000\" }, \"rates\":{ \"BTC\":0.00005418424016883016, \"ETH\":0.000795331082073117, \"USD\":0.2363863335301452, \"EUR\":0.20187818378874756, \"GBP\":0.1799810085548496 }, \"wallet\":{ \"provider\":\"uphold\", \"authorized\":true, \"defaultCurrency\":\"USD\", \"availableCurrencies\":[ \"USD\", \"EUR\", \"BTC\", \"ETH\", \"BAT\" ] } }"
 
       publisher = publishers(:uphold_connected)
       assert publisher.uphold_verified

--- a/test/services/publisher_default_currency_setter_test.rb
+++ b/test/services/publisher_default_currency_setter_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PublisherDefaultCurrencySetterTest < ActiveJob::TestCase
+  test "when offline returns true" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = true
+
+      publisher = publishers(:verified)
+      result = PublisherDefaultCurrencySetter.new(publisher: publisher).perform
+
+      assert_equal true, result
+
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+    end
+  end
+
+  test "when online returns the response when the default currency can be set" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+
+      publisher = publishers(:verified)
+      publisher.default_currency = 'USD'
+
+      stub_request(:patch, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+          with(headers: {'Accept'=>'*/*',
+                         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                         'Authorization'=>"Bearer #{Rails.application.secrets[:api_eyeshade_key]}",
+                         'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'},
+               body:
+                 <<~BODY
+                 {
+                   "defaultCurrency": "USD" 
+                 }
+                 BODY
+          ).
+          to_return(status: 204, headers: {})
+
+      result = PublisherDefaultCurrencySetter.new(publisher: publisher).perform
+      assert_equal 204, result.status
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+    end
+  end
+end

--- a/test/unit/wallet_test.rb
+++ b/test/unit/wallet_test.rb
@@ -25,7 +25,7 @@ class WalletTest < ActiveSupport::TestCase
         "wallet" => {
             "provider" => "uphold",
             "authorized" => true,
-            "preferredCurrency" => 'USD',
+            "defaultCurrency" => 'USD',
             "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       },
@@ -57,7 +57,7 @@ class WalletTest < ActiveSupport::TestCase
   end
 
   test "supports wallet details preferred currency" do
-    assert_equal('USD', test_wallet.wallet_details['preferredCurrency'])
+    assert_equal('USD', test_wallet.wallet_details['defaultCurrency'])
   end
 
   test "supports wallet details available currencies" do


### PR DESCRIPTION
* Fix use of dynamicEllipsis

Should use import rather than no-longer-existent global.

* Ensure that fetch polyfill is used

Instead of relying on global, ensure that `fetch` polyfill is used.

* Introduce PublisherDefaultCurrencySetter service

Updates a publisher’s default currency setting through a PATCH request to eyeshade.

* Introduce UploadDefaultCurrencyJob

Background job for uploading the default currency to eyeshade.

* Push default_currency updates to eyeshade

When the default_currency is successfully updated, an UploadDefaultCurrencyJob will be triggered that will upload the change to eyeshade.

The UX has been tweaked slightly so that, for users with no default currency, a select option `— Select currency —` will appear as selected by default. This allows any other selection to trigger a change (since there’s no default chosen as was previously the case).

* Eyeshade now sends defaultCurrency instead of preferredCurrency

* Stop assuming BAT is an available currency

BAT is not actually a universally available option. Some publishers should only be able to choose fiat currencies, for example. The bottom line is that only currencies coming from uphold (via eyeshade) should ever be displayed.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
