### PR TITLE
Add should_send_notifications envar 

### DIFF
--- a/app/services/publisher_notifier.rb
+++ b/app/services/publisher_notifier.rb
@@ -17,6 +17,7 @@ class PublisherNotifier < BaseService
   end
 
   def perform
+    return unless should_send_notifications?
     PublisherMailer.public_send(mailer_method, @publisher, notification_params).deliver_later
     if PublisherMailer.should_send_internal_emails? && PublisherMailer.respond_to?(mailer_method_internal)
       PublisherMailer.public_send(mailer_method_internal, @publisher, notification_params).deliver_later
@@ -34,5 +35,9 @@ class PublisherNotifier < BaseService
 
   def mailer_method_internal
     "#{mailer_method}_internal".to_sym
+  end
+
+  def should_send_notifications?
+    Rails.application.secrets[:should_send_notifications]
   end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -67,6 +67,7 @@ default: &default
   active_promo_id: <%= ENV["ACTIVE_PROMO_ID"] %>
   base_referral_url: <%= ENV["BASE_REFERRAL_URL"] %>
   max_site_age: <%= ENV["MAX_SITE_AGE"] %> # Maximimum age in weeks of sites enqueued for verification
+  should_send_notifications: <%= ENV["SHOULD_SEND_NOTIFICATIONS"] # Enables eyeshade notifications
 
 development:
   <<: *default
@@ -86,6 +87,7 @@ development:
   bat_reddit_url: "https://www.reddit.com/r/BATProject/"
   bat_rocketchat_url: "https://basicattentiontoken.rocket.chat/"
   max_site_age: 6
+  should_send_notifications: true
 
 test:
   <<: *default


### PR DESCRIPTION
This will enable/disable eyeshade's use of the PublisherNotifier.

Resolves #775 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
