### PR TITLE
Display error message when currencies are unavailable

### DIFF
--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -534,6 +534,12 @@ body[data-controller="u2f_registrations"]
           background-image: url(asset-path("icn-warning@1x.png"))
       .deposit-currency
         margin-top: 10px
+      .unavailable-currencies
+        padding: 0 0 5px 52px
+        background-position: top left
+        background-repeat: no-repeat
+        background-size: 42px
+        background-image: url(asset-path("icn-warning@1x.png"))
       #update_publisher_visible_form
         margin-top: 40px
         margin-left: -30px

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -113,7 +113,7 @@ module PublishersHelper
 
   def publisher_available_currencies(publisher)
     available_currencies = publisher.wallet.try(:wallet_details).try(:[], 'availableCurrencies')
-    if publisher.default_currency.blank?
+    if available_currencies && publisher.default_currency.blank?
       available_currencies.unshift(['-- Select currency --', nil])
     end
     available_currencies

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -73,11 +73,15 @@ script id="choose-channel-type" type="text/html"
         - if current_publisher.uphold_status == :access_parameters_acquired || current_publisher.uphold_status == :verified
           .panel-section#uphold_dashboard class=(uphold_status_class(current_publisher) + (show_uphold_dashboard?(current_publisher) ? '' : ' hidden'))
             .panel-section
-              = form_for(current_publisher, url: publishers_path, html: { id: "update_default_currency_form" }) do |f|
-                .deposit-currency-label= t ".uphold.deposit_currency_label"
-                .deposit-currency
-                  span= t ".uphold.deposit_currency"
-                  span#default_currency_code= f.select(:default_currency, options_for_select(publisher_available_currencies(current_publisher), current_publisher.default_currency))
+              - available_currencies = publisher_available_currencies(current_publisher)
+              - if available_currencies
+                = form_for(current_publisher, url: publishers_path, html: { id: "update_default_currency_form" }) do |f|
+                  .deposit-currency-label= t ".uphold.deposit_currency_label"
+                  .deposit-currency
+                    span= t ".uphold.deposit_currency"
+                    span#default_currency_code= f.select(:default_currency, options_for_select(available_currencies, current_publisher.default_currency))
+              - else
+                .unavailable-currencies= t ".uphold.no_currencies_available"
             = link_to(t(".uphold.check_balance"), uphold_dashboard_url, class: "btn btn-primary", :"data-piwik-action" => "CheckUpholdBalanceClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
   .col.col-details.col-md-6.col-xs-10.col-xs-center.col-sm-center
     .sub-panel.dashboard-panel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,7 @@ en:
         deposit_currency_label: "Current deposit currency:"
         deposit_currency: "BAT to "
         check_balance: Check Balance
+        no_currencies_available: We're unable to load deposit currencies from Uphold at this time. Please check again later.
       statements:
         heading: Statements
         generate: Generate


### PR DESCRIPTION
When no currencies are available, display a helpful message instead of failing.

![screen shot 2018-04-11 at 10 24 45 am](https://user-images.githubusercontent.com/29122/38623279-412fceda-3d73-11e8-8eb8-2c7b59fd0531.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
