### PR TITLE
Allow Uphold account to be disconnected / changed

### DIFF
--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -506,18 +506,6 @@ body[data-controller="u2f_registrations"]
           margin-bottom: 40px
       .attribute-value
         margin-bottom: 24px
-
-      #publisher_verification_status
-        font-size: $font-size-base
-        vertical-align: middle
-        padding: 5px 0 5px 35px
-        background-position: center left
-        background-repeat: no-repeat
-        background-size: 25px
-        &.verified
-          background-image: url(asset-path("verified-icon@1x.png"))
-        &.unverified
-          background-image: url(asset-path("unverified-icon.png"))
       #publisher_status
         vertical-align: top
         margin-top: 20px

--- a/app/assets/stylesheets/legacy/application/publishers.sass
+++ b/app/assets/stylesheets/legacy/application/publishers.sass
@@ -1,5 +1,9 @@
 $subnav-active: #8F9397
 
+@keyframes blinker
+  50%
+    opacity: 0
+
 body[data-controller="publishers"],
 body[data-controller="site_channels"],
 body[data-controller="two_factor_authentications"],
@@ -506,28 +510,75 @@ body[data-controller="u2f_registrations"]
           margin-bottom: 40px
       .attribute-value
         margin-bottom: 24px
-      #publisher_status
+      #uphold_status
         vertical-align: top
-        margin-top: 20px
         margin-bottom: 25px
-        &.complete
-          // no background
-        &.uphold_processing,
-        &.uphold_reauthorize,
-        &.uphold_unconnected
+        .deposit-currency
+          margin-top: 10px
+        .unavailable-currencies
           padding: 0 0 5px 52px
           background-position: top left
           background-repeat: no-repeat
           background-size: 42px
           background-image: url(asset-path("icn-warning@1x.png"))
-      .deposit-currency
-        margin-top: 10px
-      .unavailable-currencies
-        padding: 0 0 5px 52px
-        background-position: top left
-        background-repeat: no-repeat
-        background-size: 42px
-        background-image: url(asset-path("icn-warning@1x.png"))
+        .status-summary
+          margin-top: -10px
+          margin-bottom: 20px
+          font-size: 14px
+          .text
+            display: inline-block
+            &:before
+              content: "\25CF\00a0"
+          .action
+            display: inline-block
+            margin-left: 15px
+            .disconnect-uphold
+              color: $mediumGray
+        .status-description
+          margin-top: 40px
+        &.uphold-timeout
+          .status-summary .action,
+          #uphold_dashboard,
+          #uphold_connect
+            display: none
+        &.uphold-complete,
+        &.uphold-processing
+          .status-summary .action .connect-uphold,
+          #uphold_connect
+            display: none
+        &.uphold-processing
+          #uphold_dashboard
+            display: none
+        &.uphold-reauthorization-needed,
+        &.uphold-unconnected
+          .status-description
+            margin-bottom: 40px
+            padding: 0 0 5px 52px
+            min-height: 42px
+            background-position: top left
+            background-repeat: no-repeat
+            background-size: 42px
+            background-image: url(asset-path("icn-warning@1x.png"))
+          #uphold_connect
+            margin-top: 30px
+          #uphold_dashboard,
+          .status-summary .action .disconnect-uphold
+            display: none
+        // Status summary label
+        &.uphold-complete,
+        &.uphold-processing
+          .status-summary .text
+            color: darken(#2aeaa1, 10%)
+        &.uphold-reauthorization-needed,
+        &.uphold-timeout
+          .status-summary .text
+            color: $braveRed
+        &.uphold-unconnected
+          .status-summary .text
+            color: $mediumGray
+        &.uphold-processing
+          .status-summary .text
+            animation: blinker 1s linear infinite
       #update_publisher_visible_form
         margin-top: 40px
         margin-left: -30px

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -358,15 +358,13 @@ class PublishersController < ApplicationController
     end
   end
 
-  def status
+  def uphold_status
     publisher = current_publisher
     respond_to do |format|
       format.json {
         render(json: {
-          status: publisher_status(publisher).to_s,
-          status_description: publisher_status_description(publisher),
-          timeout_message: publisher_status_timeout(publisher),
           uphold_status: publisher.uphold_status.to_s,
+          uphold_status_summary: uphold_status_summary(publisher),
           uphold_status_description: uphold_status_description(publisher),
           uphold_status_class: uphold_status_class(publisher)
         }, status: 200)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -32,7 +32,8 @@ class PublishersController < ApplicationController
   before_action :require_publisher_email_verified_through_youtube_auth,
                 only: %i(update_email)
   before_action :require_verified_publisher,
-    only: %i(edit_payment_info
+    only: %i(disconnect_uphold
+             edit_payment_info
              generate_statement
              home
              statement
@@ -283,6 +284,14 @@ class PublishersController < ApplicationController
     end
 
     redirect_to(publisher_next_step_path(@publisher))
+  end
+
+  def disconnect_uphold
+    publisher = current_publisher
+    publisher.disconnect_uphold
+    DisconnectUpholdJob.perform_later(publisher_id: publisher.id)
+
+    head :no_content
   end
 
   def change_email

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -119,31 +119,6 @@ module PublishersHelper
     available_currencies
   end
 
-  def publisher_verification_status(publisher)
-    publisher.verified? ? :verified : :unverified
-  end
-
-  def publisher_verification_status_description(publisher)
-    case publisher_verification_status(publisher)
-      when :verified
-        I18n.t("publishers.shared.verified")
-      when :unverified
-        I18n.t("helpers.publisher.not_verified")
-    end
-  end
-
-  def publisher_verification_file_content(publisher)
-    PublisherVerificationFileGenerator.new(publisher: publisher).generate_file_content
-  end
-
-  def publisher_verification_file_directory(publisher)
-    "<span class=\"strong-line\">https:</span>//#{publisher.brave_publisher_id}/.well-known/"
-  end
-
-  def publisher_verification_file_url(publisher)
-    PublisherVerificationFileGenerator.new(publisher: publisher).generate_url
-  end
-
   # Overall publisher status combining verification and uphold wallet connection
   def publisher_status(publisher)
     if publisher.verified?

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -5,31 +5,6 @@ module PublishersHelper
     publisher.uphold_status == :verified
   end
 
-  def uphold_status_description(publisher)
-    case publisher.uphold_status
-    when :verified
-      I18n.t("helpers.publisher.uphold_status.verified")
-    when :access_parameters_acquired
-      I18n.t("helpers.publisher.uphold_status.access_parameters_acquired")
-    when :code_acquired
-      I18n.t("helpers.publisher.uphold_status.code_acquired")
-    when :unconnected
-      I18n.t("helpers.publisher.uphold_status.unconnected")
-    end
-  end
-
-  def uphold_last_deposit_date(publisher)
-    "September 31st, 2022 (ToDo)"
-  end
-
-  def show_uphold_connect?(publisher)
-    publisher.uphold_status == :unconnected || publisher.uphold_status == :code_acquired || publisher.uphold_status == :access_parameters_acquired
-  end
-
-  def show_uphold_dashboard?(publisher)
-    publisher.uphold_verified?
-  end
-
   def uphold_status_class(publisher)
     "uphold-status-#{publisher.uphold_status.to_s.gsub('_', '-')}"
   end
@@ -96,10 +71,11 @@ module PublishersHelper
   end
 
   def uphold_authorization_description(publisher)
-    if publisher_status(publisher) == :uphold_reauthorize || publisher_status(publisher) == :uphold_processing
-      I18n.t("helpers.publisher.reconnect_to_uphold")
+    case publisher.uphold_status
+    when :unconnected
+      I18n.t("helpers.publisher.uphold_authorization_description.connect_to_uphold")
     else
-      I18n.t("helpers.publisher.create_uphold_wallet")
+      I18n.t("helpers.publisher.uphold_authorization_description.reconnect_to_uphold")
     end
   end
 
@@ -119,46 +95,42 @@ module PublishersHelper
     available_currencies
   end
 
-  # Overall publisher status combining verification and uphold wallet connection
-  def publisher_status(publisher)
-    if publisher.verified?
-      if publisher.uphold_verified?
-        :complete
-      elsif publisher.uphold_status == :code_acquired || publisher.uphold_status == :access_parameters_acquired
-        :uphold_processing
-      else
-        if publisher.wallet.try(:status).try(:[], 'action') == 're-authorize'
-          :uphold_reauthorize
-        else
-          :uphold_unconnected
-        end
-      end
+  def uphold_status_class(publisher)
+    case publisher.uphold_status
+    when :verified
+      'uphold-complete'
+    when :code_acquired, :access_parameters_acquired
+      'uphold-processing'
+    when :reauthorization_needed
+      'uphold-reauthorization-needed'
     else
-      :unverified
+      'uphold-unconnected'
     end
   end
 
-  def publisher_status_timeout(publisher)
-    case publisher_status(publisher)
-    when :uphold_processing
-      I18n.t("helpers.publisher.uphold_status.processing_timeout")
+  def uphold_status_summary(publisher)
+    case publisher.uphold_status
+    when :verified
+      I18n.t("helpers.publisher.uphold_status_summary.connected")
+    when :code_acquired, :access_parameters_acquired
+      I18n.t("helpers.publisher.uphold_status_summary.connecting")
+    when :reauthorization_needed
+      I18n.t("helpers.publisher.uphold_status_summary.connection_problems")
     else
-      nil
+      I18n.t("helpers.publisher.uphold_status_summary.unconnected")
     end
   end
 
-  def publisher_status_description(publisher)
-    case publisher_status(publisher)
-    when :complete
-      I18n.t("helpers.publisher.uphold_status.balance_sending")
-    when :uphold_processing
-      I18n.t("helpers.publisher.uphold_status.processing")
-    when :uphold_reauthorize
-      I18n.t("helpers.publisher.uphold_status.reconnect_to_uphold")
-    when :uphold_unconnected
-      I18n.t("helpers.publisher.uphold_status.connect_to_uphold")
-    when :unverified
-      I18n.t("helpers.publisher.uphold_status.unverified")
+  def uphold_status_description(publisher)
+    case publisher.uphold_status
+    when :verified
+      I18n.t("helpers.publisher.uphold_status_description.verified")
+    when :code_acquired, :access_parameters_acquired
+      I18n.t("helpers.publisher.uphold_status_description.connecting")
+    when :reauthorization_needed
+      I18n.t("helpers.publisher.uphold_status_description.reauthorization_needed")
+    when :unconnected
+      I18n.t("helpers.publisher.uphold_status_description.unconnected")
     end
   end
 

--- a/app/jobs/disconnect_uphold_job.rb
+++ b/app/jobs/disconnect_uphold_job.rb
@@ -1,0 +1,9 @@
+class DisconnectUpholdJob < ApplicationJob
+  queue_as :default
+
+  def perform(publisher_id:)
+    publisher = Publisher.find(publisher_id)
+
+    PublisherWalletDisconnector.new(publisher: publisher).perform
+  end
+end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -163,6 +163,8 @@ class Publisher < ApplicationRecord
       :access_parameters_acquired
     elsif self.uphold_code.present?
       :code_acquired
+    elsif self.wallet.try(:status).try(:[], 'action') == 're-authorize'
+      :reauthorization_needed
     else
       :unconnected
     end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -139,6 +139,13 @@ class Publisher < ApplicationRecord
     save!
   end
 
+  def disconnect_uphold
+    self.uphold_code = nil
+    self.uphold_access_parameters = nil
+    self.uphold_verified = false
+    save!
+  end
+
   def uphold_complete?
     # check the wallet to see if the connection to uphold has been been denied
     action = wallet.try(:status).try(:[], 'action')
@@ -159,6 +166,10 @@ class Publisher < ApplicationRecord
     else
       :unconnected
     end
+  end
+
+  def uphold_processing?
+    self.uphold_access_parameters.present? || self.uphold_code.present?
   end
 
   def set_uphold_updated_at

--- a/app/services/publisher_wallet_disconnector.rb
+++ b/app/services/publisher_wallet_disconnector.rb
@@ -1,0 +1,51 @@
+# Ask Eyeshade to disconnect an Uphold account to a Publisher.
+class PublisherWalletDisconnector < BaseApiClient
+  attr_reader :publisher
+
+  def initialize(publisher:)
+    @publisher = publisher
+  end
+
+  def perform
+    return perform_offline if Rails.application.secrets[:api_eyeshade_offline]
+
+    if publisher.uphold_verified
+      raise "Publisher #{publisher.id} has re-verified their Uphold connection, so it should not be disconnected."
+    end
+
+    # This raises when response is not 2xx.
+    response = connection.put do |request|
+      request.headers["Authorization"] = api_authorization_header
+      request.headers["Content-Type"] = "application/json"
+
+      request.body =
+          <<~BODY
+          {
+            "provider": "uphold", 
+            "parameters": {}
+          }
+      BODY
+      request.url("/v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet")
+    end
+    response
+
+  rescue Faraday::Error => e
+    Rails.logger.warn("PublisherWalletDisconnector #perform error: #{e}")
+    nil
+  end
+
+  def perform_offline
+    Rails.logger.info("PublisherWalletDisconnector eyeshade offline")
+    true
+  end
+
+  private
+
+  def api_base_uri
+    Rails.application.secrets[:api_eyeshade_base_uri]
+  end
+
+  def api_authorization_header
+    "Bearer #{Rails.application.secrets[:api_eyeshade_key]}"
+  end
+end

--- a/app/views/publishers/_disconnect_uphold_modal.html.slim
+++ b/app/views/publishers/_disconnect_uphold_modal.html.slim
@@ -1,0 +1,10 @@
+.col.col-center.col-xs-12.col-sm-10.col-md-10.col-lg-10
+  h4= t ".headline"
+  p
+    = t ".intro"
+  p
+    = t ".confirmation"
+  .row
+    .col.md-confirm-buttons.pull-right
+      = link_to t(".deny"), "#", class: "js-deny btn btn-secondary"
+      = link_to t(".confirm"), "#", class: "js-confirm btn btn-secondary"

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -63,26 +63,37 @@ script id="choose-channel-type" type="text/html"
     .sub-panel.dashboard-panel.uphold-panel
       .panel-header.panel-header-h3#dashboard_uphold_header
         = t ".uphold.heading"
-      .attribute-value.status
-        #publisher_status class=publisher_status(current_publisher)
-          = publisher_status_description(current_publisher)
-        - if show_uphold_connect?(current_publisher)
-          div#uphold_connect
-            .panel-section= link_to(uphold_authorization_description(current_publisher),
-                    uphold_authorization_endpoint(current_publisher), class: "btn btn-primary", :"data-test" => "reconnect-button")
-        - if current_publisher.uphold_status == :access_parameters_acquired || current_publisher.uphold_status == :verified
-          .panel-section#uphold_dashboard class=(uphold_status_class(current_publisher) + (show_uphold_dashboard?(current_publisher) ? '' : ' hidden'))
-            .panel-section
-              - available_currencies = publisher_available_currencies(current_publisher)
-              - if available_currencies
-                = form_for(current_publisher, url: publishers_path, html: { id: "update_default_currency_form" }) do |f|
-                  .deposit-currency-label= t ".uphold.deposit_currency_label"
-                  .deposit-currency
-                    span= t ".uphold.deposit_currency"
-                    span#default_currency_code= f.select(:default_currency, options_for_select(available_currencies, current_publisher.default_currency))
-              - else
-                .unavailable-currencies= t ".uphold.no_currencies_available"
-            = link_to(t(".uphold.check_balance"), uphold_dashboard_url, class: "btn btn-primary", :"data-piwik-action" => "CheckUpholdBalanceClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
+      #uphold_status class=uphold_status_class(current_publisher)
+        .attribute-value
+          .status-summary
+            .text= uphold_status_summary(current_publisher)
+            .action
+              span= "("
+              = link_to(t(".uphold.connect"), uphold_authorization_endpoint(current_publisher), class: "connect-uphold")
+              a.disconnect-uphold href="#"
+                = t ".uphold.disconnect"
+              span= ")"
+              script type="text/html" id="disconnect-uphold-js"
+                = render "publishers/disconnect_uphold_modal"
+              = form_for(current_publisher, url: disconnect_uphold_publishers_path, html: {id: "disconnect_uphold"}) do |f|
+          .status-description
+            = uphold_status_description(current_publisher)
+        #uphold_connect
+          .panel-section
+            = link_to(uphold_authorization_description(current_publisher),
+                      uphold_authorization_endpoint(current_publisher), class: "btn btn-primary", :"data-test" => "reconnect-button")
+        #uphold_dashboard class=uphold_status_class(current_publisher)
+          .panel-section
+            - available_currencies = publisher_available_currencies(current_publisher)
+            - if available_currencies
+              = form_for(current_publisher, url: publishers_path, html: { id: "update_default_currency_form" }) do |f|
+                .deposit-currency-label= t ".uphold.deposit_currency_label"
+                .deposit-currency
+                  span= t ".uphold.deposit_currency"
+                  span#default_currency_code= f.select(:default_currency, options_for_select(publisher_available_currencies(current_publisher), current_publisher.default_currency))
+            - else
+              .unavailable-currencies= t ".uphold.no_currencies_available"
+          = link_to(t(".uphold.check_balance"), uphold_dashboard_url, class: "btn btn-primary", :"data-piwik-action" => "CheckUpholdBalanceClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
   .col.col-details.col-md-6.col-xs-10.col-xs-center.col-sm-center
     .sub-panel.dashboard-panel
       .statements#statement_section class=(current_publisher.uphold_verified ? '' : 'hidden')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,8 +107,6 @@ en:
         website: the website
         twitch: Twitch
         unknown: the website
-      create_uphold_wallet: Create Uphold Wallet
-      reconnect_to_uphold: Reconnect to Uphold
       statement_periods:
         past_7_days: Past 7 days
         past_30_days: Past 30 days
@@ -117,10 +115,11 @@ en:
         this_year: This year
         last_year: Last year
         all: All
+      uphold_authorization_description:
+        connect_to_uphold: Connect to Uphold
+        reconnect_to_uphold: Reconnect to Uphold
       uphold_status:
-        access_parameters_acquired: Connecting your Uphold account.
         balance_sending: Contribution balance is transferred to your Uphold wallet monthly.
-        code_acquired: A problem was experienced connecting your Uphold account.
         connect_to_uphold: You need to create a wallet with Uphold to receive contributions from Brave Payments.
         processing: |
           Your Uphold wallet is being connected to your account.
@@ -129,8 +128,15 @@ en:
         reconnect_to_uphold: |
           Uh oh! Connecting to Uphold has been denied.
           In order to deposit your contributions accrued we need you to reconnect to your Uphold wallet.
-        unconnected: Not connected to Uphold.
-        unverified: Your account has not been verified
+      uphold_status_summary:
+        connected: Connected
+        connecting: Connecting
+        unconnected: Not connected
+        connection_problems: Connection problems
+      uphold_status_description:
+        connecting: Brave Payments is connecting to your Uphold account.
+        reauthorization_needed: We are having trouble communicating with Uphold.
+        unconnected: You need to connect to your Uphold account to receive contributions from Brave Payments.
         verified: Your Uphold wallet is ready to receive Brave Payments.
   layouts:
     mailer:
@@ -302,6 +308,8 @@ en:
         deposit_currency: "BAT to "
         check_balance: Check Balance
         no_currencies_available: We're unable to load deposit currencies from Uphold at this time. Please check again later.
+        connect: Connect
+        disconnect: Disconnect
       statements:
         heading: Statements
         generate: Generate
@@ -344,6 +352,12 @@ en:
       confirmation: Are you sure you want to remove this channel?
       deny: Do Not Remove
       confirm: Remove Channel
+    disconnect_uphold_modal:
+      headline: Disconnect Uphold Account?
+      intro: You won't be able to receive the monthly contributions from your fans until your wallet at Uphold is connected to us.
+      confirmation: Are you sure you want to disconnect your account with Uphold?
+      deny: Cancel
+      confirm: Disconnect
     uphold_verified:
       uphold_error: There was a problem connecting with Uphold. Please try again.
   promo:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,7 +108,6 @@ en:
         twitch: Twitch
         unknown: the website
       create_uphold_wallet: Create Uphold Wallet
-      not_verified: Unverified
       reconnect_to_uphold: Reconnect to Uphold
       statement_periods:
         past_7_days: Past 7 days

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,11 +13,11 @@ Rails.application.routes.draw do
       get :expired_auth_token
       get :log_out
       get :email_verified
-      get :status
       get :balance
       get :uphold_verified
       get :statement
       get :statement_ready
+      get :uphold_status
       patch :verify
       patch :update
       patch :generate_statement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       patch :update
       patch :generate_statement
       patch :complete_signup
+      patch :disconnect_uphold
       get :choose_new_channel_type
       resources :two_factor_authentications, only: %i(index)
       resources :two_factor_registrations, only: %i(index) do

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -339,7 +339,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
                    .gsub('<STATE>', publisher.uphold_state_token)
 
     assert_select("a[href='#{endpoint}']") do |elements|
-      assert_equal(1, elements.length, 'A link with the correct href to Uphold.com is present')
+      assert_equal(2, elements.length, 'Two links with the correct href to Uphold.com are present (one link in the status area + one big button)')
     end
   end
 
@@ -474,13 +474,13 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_equal publisher.reload.uphold_status, :code_acquired
 
     # verify message tells publisher they need to reconnect
-    assert_select("div#publisher_status.uphold_processing") do |element|
-      assert_equal element.text, I18n.t("helpers.publisher.uphold_status.processing")
+    assert_select("div#uphold_status.uphold-processing .status-description") do |element|
+      assert_equal I18n.t("helpers.publisher.uphold_status_description.connecting"), element.text
     end
 
     # verify button says 'reconnect to uphold' not 'create uphold wallet'
     assert_select("[data-test=reconnect-button]") do |element|
-      assert_equal element.text, I18n.t("helpers.publisher.reconnect_to_uphold")
+      assert_equal I18n.t("helpers.publisher.uphold_authorization_description.reconnect_to_uphold"), element.text
     end
     Rails.application.secrets[:active_promo_id] = active_promo_id_original
   end

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -514,19 +514,17 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
                  response.body
   end
 
-  test "a publisher's status can be polled via ajax" do
+  test "a publisher's uphold status can be polled via ajax" do
     publisher = publishers(:completed)
     sign_in publisher
 
-    get status_publishers_path, headers: { 'HTTP_ACCEPT' => "application/json" }
+    get uphold_status_publishers_path, headers: { 'HTTP_ACCEPT' => "application/json" }
 
     assert_response 200
-    assert_equal '{"status":"uphold_unconnected",' +
-                  '"status_description":"You need to create a wallet with Uphold to receive contributions from Brave Payments.",' +
-                  '"timeout_message":null,' +
-                  '"uphold_status":"unconnected",' +
-                  '"uphold_status_description":"Not connected to Uphold.",' +
-                  '"uphold_status_class":"uphold-status-unconnected"}',
+    assert_equal '{"uphold_status":"unconnected",' +
+                  '"uphold_status_summary":"Not connected",' +
+                  '"uphold_status_description":"You need to connect to your Uphold account to receive contributions from Brave Payments.",' +
+                  '"uphold_status_class":"uphold-unconnected"}',
                  response.body
   end
 

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -530,6 +530,20 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
                  response.body
   end
 
+  test "a publisher can be disconnected from uphold" do
+    publisher = publishers(:verified)
+    publisher.verify_uphold
+    assert publisher.uphold_verified?
+    sign_in publisher
+
+    patch disconnect_uphold_publishers_path, headers: { 'HTTP_ACCEPT' => "application/json" }
+
+    assert_response 204
+
+    publisher.reload
+    refute publisher.uphold_verified?
+  end
+
   test "home redirects to 2FA prompt on first visit" do
     publisher = publishers(:unprompted)
 

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -135,15 +135,18 @@ class PublishersHelperTest < ActionView::TestCase
     publisher = PublisherWithUpholdStatus.new
 
     publisher.uphold_status = :verified
-    assert_equal "uphold-status-verified", uphold_status_class(publisher)
+    assert_equal "uphold-complete", uphold_status_class(publisher)
 
     publisher.uphold_status = :access_parameters_acquired
-    assert_equal "uphold-status-access-parameters-acquired", uphold_status_class(publisher)
+    assert_equal "uphold-processing", uphold_status_class(publisher)
 
     publisher.uphold_status = :code_acquired
-    assert_equal "uphold-status-code-acquired", uphold_status_class(publisher)
+    assert_equal "uphold-processing", uphold_status_class(publisher)
+
+    publisher.uphold_status = :reauthorization_needed
+    assert_equal "uphold-reauthorization-needed", uphold_status_class(publisher)
 
     publisher.uphold_status = :unconnected
-    assert_equal "uphold-status-unconnected", uphold_status_class(publisher)
+    assert_equal "uphold-unconnected", uphold_status_class(publisher)
   end
 end

--- a/test/jobs/disconnect_uphold_job_test.rb
+++ b/test/jobs/disconnect_uphold_job_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+require "webmock/minitest"
+
+class DisconnectUpholdJobTest < ActiveJob::TestCase
+  test "requests that eyeshade disconnect a publisher's wallet" do
+    prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+
+      publisher = publishers(:verified)
+      publisher.uphold_verified = false
+      publisher.save!
+
+      stub_request(:put, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+        with(headers: {'Accept'=>'*/*',
+                       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                       'Authorization'=>"Bearer #{Rails.application.secrets[:api_eyeshade_key]}",
+                       'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'},
+             body:
+               <<~BODY
+                {
+                  "provider": "uphold", 
+                  "parameters": {}
+                }
+        BODY
+        ).
+        to_return(status: 200, headers: {})
+
+      DisconnectUpholdJob.perform_now(publisher_id: publisher.id)
+
+      publisher.reload
+      refute publisher.uphold_verified?
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
+    end
+  end
+end

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -76,6 +76,7 @@ class PublisherTest < ActiveSupport::TestCase
     assert_nil publisher.uphold_state_token
     assert_nil publisher.uphold_access_parameters
     assert publisher.valid?
+    assert publisher.uphold_processing?
     assert_equal :code_acquired, publisher.uphold_status
   end
 
@@ -84,9 +85,22 @@ class PublisherTest < ActiveSupport::TestCase
     publisher.uphold_code = "foo"
     publisher.uphold_access_parameters = "bar"
     publisher.uphold_verified = false
+    assert publisher.uphold_processing?
     publisher.verify_uphold
 
     assert publisher.uphold_verified?
+    assert publisher.valid?
+    refute publisher.uphold_processing?
+  end
+
+  test "disconnect_uphold clears uphold settings" do
+    publisher = publishers(:verified)
+    publisher.verify_uphold
+    assert publisher.uphold_verified?
+
+    publisher.disconnect_uphold
+    refute publisher.uphold_verified?
+    refute publisher.uphold_processing?
     assert publisher.valid?
   end
 

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -167,6 +167,7 @@ class PublisherTest < ActiveSupport::TestCase
 
       publisher.wallet
       refute publisher.uphold_verified
+      assert_equal :reauthorization_needed, publisher.uphold_status
 
     ensure
       Rails.application.secrets[:api_eyeshade_offline] = prev_offline

--- a/test/services/publisher_wallet_disconnector_test.rb
+++ b/test/services/publisher_wallet_disconnector_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PublisherWalletDisconnectorTest < ActiveJob::TestCase
+  test "when offline returns true" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = true
+
+      publisher = publishers(:verified)
+      result = PublisherWalletDisconnector.new(publisher: publisher).perform
+
+      assert_equal true, result
+
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+    end
+  end
+
+  test "when online returns response when the wallet can be set" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+
+      publisher = publishers(:verified)
+      publisher.uphold_verified = false
+
+      stub_request(:put, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+          with(headers: {'Accept'=>'*/*',
+                         'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                         'Authorization'=>"Bearer #{Rails.application.secrets[:api_eyeshade_key]}",
+                         'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'},
+               body:
+                   <<~BODY
+                {
+                  "provider": "uphold", 
+                  "parameters": {}
+                }
+          BODY
+          ).
+          to_return(status: 200, headers: {})
+
+      result = PublisherWalletDisconnector.new(publisher: publisher).perform
+      assert_equal 200, result.status
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+    end
+  end
+
+  test "raises if uphold has been reverified" do
+    prev_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+
+      publisher = publishers(:verified)
+      publisher.uphold_verified = true
+
+      assert_raises("Publisher #{publisher.id} has re-verified their Uphold connection, so it should not be disconnected.") do
+        PublisherWalletDisconnector.new(publisher: publisher).perform
+      end
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_offline
+    end
+  end
+end


### PR DESCRIPTION
This introduces a new UX and new capabilities to the Uphold panel on the dashboard.

A status message and status change link now always appear at the top of the panel.

When connected, the user now has the option to disconnect:

![screen shot 2018-04-17 at 9 41 58 am](https://user-images.githubusercontent.com/29122/38879451-5fca3a02-4231-11e8-8d6e-56c9992228f9.png)

This link will raise the following confirmation prompt:

![screen shot 2018-04-17 at 9 42 10 am](https://user-images.githubusercontent.com/29122/38879455-61d20ee2-4231-11e8-948f-f344b0ce9f66.png)

If the user chooses to disconnect, Uphold will show as "Not Connected", and eyeshade will be notified:

![screen shot 2018-04-17 at 9 42 24 am](https://user-images.githubusercontent.com/29122/38879460-6384def4-4231-11e8-8e73-a48f2fb4ccda.png)

If the user then reconnects to Uphold, the "Connecting" status will pulse until a connection has been confirmed:

![screen shot 2018-04-17 at 9 43 02 am](https://user-images.githubusercontent.com/29122/38879462-650b00f0-4231-11e8-88ac-8e39152224b2.png)

If communication problems occur and the browser is unable to get an updated status, the following timeout message will eventually appear: 

![screen shot 2018-04-17 at 9 40 07 am](https://user-images.githubusercontent.com/29122/38879446-5d905f78-4231-11e8-836a-6b7d1f0fd122.png)


Closes #133 

/cc @nvonpentz @jenn-rhim 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
