### PR TITLE
Disable channel removal

### DIFF
--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -199,13 +199,13 @@ script id="choose-channel-type" type="text/html"
           .channel-details
             .added-date
               = t ".channel.added", date: channel.created_at.to_date.iso8601
-            .separator
-              = '|'
-            a.remove-channel href="#" data-channel-id=(channel.id)
-              = t ".channel.remove_verified"
-            script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
-              = render "publishers/remove_channel_modal", channel: channel
-            = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
+            / .separator
+            /   = '|'
+            / a.remove-channel href="#" data-channel-id=(channel.id)
+            /   = t ".channel.remove_verified"
+            / script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
+            /   = render "publishers/remove_channel_modal", channel: channel
+            / = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
         .clearfix
 .row.tos-row
   - if current_publisher.promo_enabled_2018q1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     member do
       get :verification_status
       get :cancel_add
-      delete :destroy
+      # delete :destroy
     end
   end
 

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -65,33 +65,35 @@ class PublishersHomeTest < Capybara::Rails::TestCase
     refute_content page, 'Pending: Email address has been updated'
   end
 
-  test "unverified channel can be removed after confirmation" do
-    publisher = publishers(:small_media_group)
-    channel = channels(:small_media_group_to_verify)
+  # TODO Uncomment when channel removal is enabled
+  # test "unverified channel can be removed after confirmation" do
+  #   publisher = publishers(:small_media_group)
+  #   channel = channels(:small_media_group_to_verify)
 
-    sign_in publisher
-    visit home_publishers_path
+  #   sign_in publisher
+  #   visit home_publishers_path
 
-    assert_content page, channel.publication_title
-    find("#channel_row_#{channel.id}").click_link('Remove Channel')
-    assert_content page, "Are you sure you want to remove this channel?"
-    find('[data-test-modal-container]').click_link("Remove Channel")
-    refute_content page, channel.publication_title
-  end
+  #   assert_content page, channel.publication_title
+  #   find("#channel_row_#{channel.id}").click_link('Remove Channel')
+  #   assert_content page, "Are you sure you want to remove this channel?"
+  #   find('[data-test-modal-container]').click_link("Remove Channel")
+  #   refute_content page, channel.publication_title
+  # end
 
-  test "verified channel can be removed after confirmation" do
-    publisher = publishers(:small_media_group)
-    channel = channels(:small_media_group_to_delete)
+  # TODO Uncomment when channel removal is enabled
+  # test "verified channel can be removed after confirmation" do
+  #   publisher = publishers(:small_media_group)
+  #   channel = channels(:small_media_group_to_delete)
 
-    sign_in publisher
-    visit home_publishers_path
+  #   sign_in publisher
+  #   visit home_publishers_path
 
-    assert_content page, channel.publication_title
-    find("#channel_row_#{channel.id}").click_link('Remove Channel')
-    assert_content page, "Are you sure you want to remove this channel?"
-    find('[data-test-modal-container]').click_link("Remove Channel")
-    refute_content page, channel.publication_title
-  end
+  #   assert_content page, channel.publication_title
+  #   find("#channel_row_#{channel.id}").click_link('Remove Channel')
+  #   assert_content page, "Are you sure you want to remove this channel?"
+  #   find('[data-test-modal-container]').click_link("Remove Channel")
+  #   refute_content page, channel.publication_title
+  # end
 
   test "website channel type can be chosen" do
     publisher = publishers(:completed)


### PR DESCRIPTION
Resolves #797 

* Remove the ability to disable channels from UI

* Remove the delete route

* Temporarily comment out tests

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
