### PR TITLE
Allow unverified channels to be removed

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -7,6 +7,8 @@ class ChannelsController < ApplicationController
   attr_reader :current_channel
 
   def destroy
+    return if current_channel.verified
+
     channel_identifier = current_channel.details.channel_identifier
     update_promo_server = current_channel.promo_registration.present?
 

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -199,13 +199,14 @@ script id="choose-channel-type" type="text/html"
           .channel-details
             .added-date
               = t ".channel.added", date: channel.created_at.to_date.iso8601
-            / .separator
-            /   = '|'
-            / a.remove-channel href="#" data-channel-id=(channel.id)
-            /   = t ".channel.remove_verified"
-            / script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
-            /   = render "publishers/remove_channel_modal", channel: channel
-            / = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
+            - unless channel.verified
+              .separator
+                = '|'
+              a.remove-channel href="#" data-channel-id=(channel.id)
+                = t ".channel.remove_verified"
+              script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
+                = render "publishers/remove_channel_modal", channel: channel
+              = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
         .clearfix
 .row.tos-row
   - if current_publisher.promo_enabled_2018q1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     member do
       get :verification_status
       get :cancel_add
-      # delete :destroy
+      delete :destroy
     end
   end
 

--- a/test/controllers/channels_controller_test.rb
+++ b/test/controllers/channels_controller_test.rb
@@ -8,16 +8,29 @@ class ChannelsControllerTest < ActionDispatch::IntegrationTest
   include MailerTestHelper
   include PublishersHelper
 
-  test "delete removes a channel and associated details" do
-    publisher = publishers(:small_media_group)
-    channel = channels(:small_media_group_to_delete)
+  # TODO Uncomment when verified channels can be removed
+  # test "delete removes a verified channel and associated details" do
+  #   publisher = publishers(:small_media_group)
+  #   channel = channels(:small_media_group_to_delete)
+  #   sign_in publisher
+  #   assert_difference("publisher.channels.count", -1) do
+  #     assert_difference("SiteChannelDetails.count", -1) do
+  #       assert_enqueued_jobs 1 do
+  #         delete channel_path(channel), headers: { 'HTTP_ACCEPT' => "application/json" }
+  #         assert_response 204
+  #       end
+  #     end
+  #   end
+  # end
+
+  test "delete removes an unverified channel and associated details" do
+    publisher = publishers(:default)
+    channel = channels(:default)
     sign_in publisher
     assert_difference("publisher.channels.count", -1) do
       assert_difference("SiteChannelDetails.count", -1) do
-        assert_enqueued_jobs 1 do
-          delete channel_path(channel), headers: { 'HTTP_ACCEPT' => "application/json" }
-          assert_response 204
-        end
+        delete channel_path(channel), headers: { 'HTTP_ACCEPT' => "application/json" }
+        assert_response 204
       end
     end
   end


### PR DESCRIPTION
Resolves #800 

* Allow the DELETE route

* Only allow unverified channels in ChannelsController#destroy

* Only allow unverified channels to have option to remove a channel in the UI

* Comment out test expecting the DeletePublisherChannelJob to run when a channel is deleted (only happens for verified channels)

* Add new test expecting unverified channels to be removed successfully

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
