### PR TITLE
Add rate limiting and reCAPTCHA to resend_auth_email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,13 @@ gem "premailer-rails", "~> 1.9.4", require: false
 # Puma as app server
 gem "puma", "3.10"
 
+# Make cracking a little bit harder
+gem "rack-attack", "~> 5.0"
+
 gem "rails", "~> 5.0.0", ">= 5.0.0.1"
+
+# I love captchas
+gem "recaptcha", "~> 3.3", require: "recaptcha/rails"
 
 # Cache with Redis
 gem "redis-rails", "~> 5"
@@ -143,14 +149,6 @@ group :development, :test do
   gem "minitest-rails-capybara"
   gem "capybara-selenium"
   gem "chromedriver-helper"
-end
-
-group :production, :staging do
-  # Make cracking a little bit harder
-  gem "rack-attack", "~> 5.0"
-
-  # I love captchas
-  gem "recaptcha", "~> 3.3", require: "recaptcha/rails"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Setup a google API project:
   * Update your env to include `TWITCH_CLIENT_SECRET="your-app-secret"`
 * Save the app
 
+### reCAPTCHA Setup
+
+In order to test the rate limiting and captcha components you will need to setup an account with Google's 
+[reCAPTCHA](https://www.google.com/recaptcha/intro/android.html). Instructions can be found at the 
+[reCAPTCHA gem repo](https://github.com/ambethia/recaptcha#rails-installation). Add the api keys to your Env variables.
+
 ### Local Eyeshade Setup
 
 1. Follow the [setup instructions](https://github.com/brave-intl/bat-ledger) for bat-ledger

--- a/app/views/publishers/emailed_auth_token.html.slim
+++ b/app/views/publishers/emailed_auth_token.html.slim
@@ -5,11 +5,12 @@
       h3.single-panel--headline= t ".heading"
 
       .col-small-centered
-        - if @should_throttle
-          .form-group
-            = recaptcha_tags
-        = t ".body_html", email: @publisher_email, try_again_link: link_to(t(".try_again"), "#", onclick: "document.getElementById('resend_email_form').submit();")
-        = form_tag resend_auth_email_publishers_path(publisher_id: @publisher.id), method: "post", class: "hidden", id: "resend_email_form" do 
+        p= t ".sent_access_link_html", email: @publisher_email
+        hr
+        = form_tag resend_auth_email_publishers_path(publisher_id: @publisher.id), method: "post", class: "hidden", id: "resend_email_form" do
           - if params[:captcha]
             = hidden_field_tag :captcha
-
+          - if @should_throttle
+            .col-small-centered
+              = recaptcha_tags
+        p= t ".resend_email_html", try_again_link: link_to(t(".try_again"), "#", onclick: "document.getElementById('resend_email_form').submit();")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,9 @@ Rails.application.configure do
   # since you don"t have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  # Rate limiting
+  config.middleware.use(Rack::Attack)
+
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,101 +1,106 @@
-if Rails.env.production? || Rails.env.staging?
-  class Rack::Attack
+class Rack::Attack
 
-    # Safelists
-    if Rails.application.secrets[:api_ip_whitelist]
-      API_IP_WHITELIST = Rails.application.secrets[:api_ip_whitelist].split(",").freeze
-    else
-      API_IP_WHITELIST = [].freeze
+  # Safelists
+  if Rails.application.secrets[:api_ip_whitelist]
+    API_IP_WHITELIST = Rails.application.secrets[:api_ip_whitelist].split(",").freeze
+  else
+    API_IP_WHITELIST = [].freeze
+  end
+
+  safelist('allow/API_IP_WHITELIST') do |req|
+    # Requests are allowed if the return value is truthy
+    API_IP_WHITELIST.include?(req.ip)
+  end
+
+  ### Configure Cache ###
+
+  # If you don't want to use Rails.cache (Rack::Attack's default), then
+  # configure it here.
+  #
+  # Note: The store is only used for throttling (not blacklisting and
+  # whitelisting). It must implement .increment and .write like
+  # ActiveSupport::Cache::Store
+
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  ### Throttle Spammy Clients ###
+
+  # If any single client IP is making tons of requests, then they're
+  # probably malicious or a poorly-configured scraper. Either way, they
+  # don't deserve to hog all of the app server's CPU. Cut them off!
+  #
+  # Note: If you're serving assets through rack, those requests may be
+  # counted by rack-attack and this throttle may be activated too
+  # quickly. If so, enable the condition to exclude them from tracking.
+
+  # Throttle all requests by IP (60rpm)
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
+  throttle("req/ip", limit: 300, period: 5.minutes) do |req|
+    req.ip if !req.path.start_with?("/assets")
+  end
+
+  ### Prevent Brute-Force Login Attacks ###
+
+  # The most common brute-force login attack is a brute-force password
+  # attack where an attacker simply tries a large number of emails and
+  # passwords to see if any credentials match.
+  #
+  # Another common method of attack is to use a swarm of computers with
+  # different IPs to try brute-forcing a password for a specific account.
+
+  # Throttle POST requests to /login by IP address
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
+  throttle("logins/ip", limit: 5, period: 120.seconds) do |req|
+    if req.path.start_with?("/publishers/") && req.params["token"]
+      req.ip
     end
+  end
 
-    safelist('allow/API_IP_WHITELIST') do |req|
-      # Requests are allowed if the return value is truthy
-      API_IP_WHITELIST.include?(req.ip)
+  throttle("created-auth-tokens/ip", limit: 5, period: 20.seconds) do |req|
+    if req.path == "/publishers/log_in" && req.post?
+      req.ip
     end
+  end
 
-    ### Configure Cache ###
-
-    # If you don't want to use Rails.cache (Rack::Attack's default), then
-    # configure it here.
-    #
-    # Note: The store is only used for throttling (not blacklisting and
-    # whitelisting). It must implement .increment and .write like
-    # ActiveSupport::Cache::Store
-
-    # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
-
-    ### Throttle Spammy Clients ###
-
-    # If any single client IP is making tons of requests, then they're
-    # probably malicious or a poorly-configured scraper. Either way, they
-    # don't deserve to hog all of the app server's CPU. Cut them off!
-    #
-    # Note: If you're serving assets through rack, those requests may be
-    # counted by rack-attack and this throttle may be activated too
-    # quickly. If so, enable the condition to exclude them from tracking.
-
-    # Throttle all requests by IP (60rpm)
-    #
-    # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
-    throttle("req/ip", limit: 300, period: 5.minutes) do |req|
-      req.ip if !req.path.start_with?("/assets")
+  # Throttle resend auth emails for a publisher
+  throttle("resend_auth_email/publisher_id", limit: 5, period: 5.minutes) do |req|
+    if req.path == "/publishers/resend_auth_email" && req.post?
+      req['publisher_id']
     end
+  end
 
-    ### Prevent Brute-Force Login Attacks ###
+  # Throttle POST requests to /login by email param
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"
+  #
+  # Note: This creates a problem where a malicious user could intentionally
+  # throttle logins for another user and force their login requests to be
+  # denied, but that"s not very common and shouldn"t happen to you. (Knock
+  # on wood!)
+  # throttle("logins/email", :limit => 5, :period => 20.seconds) do |req|
+  #   if req.path.start_with?("/publishers/") && req.params["token"]
+      # return the email if present, nil otherwise
+  #     req.params["email"].presence
+  #   end
+  # end
 
-    # The most common brute-force login attack is a brute-force password
-    # attack where an attacker simply tries a large number of emails and
-    # passwords to see if any credentials match.
-    #
-    # Another common method of attack is to use a swarm of computers with
-    # different IPs to try brute-forcing a password for a specific account.
-
-    # Throttle POST requests to /login by IP address
-    #
-    # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
-    throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
-      if req.path.start_with?("/publishers/") && req.params["token"]
-        req.ip
-      end
+  # In PublishersController we'll check the annotated request object
+  # to apply additional Recaptcha.
+  throttle("registrations/ip", limit: 60, period: 1.hour) do |req|
+    if req.path == "/publishers" && req.post?
+      req.ip
     end
-
-    throttle("created-auth-tokens/ip", limit: 5, period: 20.seconds) do |req|
-      if req.path == "/publishers/log_in" && req.post?
-        req.ip
-      end
-    end
-
-    # Throttle POST requests to /login by email param
-    #
-    # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{req.email}"
-    #
-    # Note: This creates a problem where a malicious user could intentionally
-    # throttle logins for another user and force their login requests to be
-    # denied, but that"s not very common and shouldn"t happen to you. (Knock
-    # on wood!)
-    # throttle("logins/email", :limit => 5, :period => 20.seconds) do |req|
-    #   if req.path.start_with?("/publishers/") && req.params["token"]
-        # return the email if present, nil otherwise
-    #     req.params["email"].presence
-    #   end
-    # end
-
-    # In PublishersController we'll check the annotated request object
-    # to apply additional Recaptcha.
-    throttle("registrations/ip", limit: 60, period: 1.hour) do |req|
-      if req.path == "/publishers" && req.post?
-        req.ip
-      end
-    end
+  end
 
 
-    ### Custom Throttle Response ###
-    self.throttled_response = lambda do |env|
-      [
-        420, # status
-        {"Content-Type" => "text/plain; charset=UTF-8"}, # headers
-        ["🎷"] # body
-      ]
-    end
+  ### Custom Throttle Response ###
+  self.throttled_response = lambda do |env|
+    [
+      420, # status
+      {"Content-Type" => "text/plain; charset=UTF-8"}, # headers
+      ["🎷"] # body
+    ]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,10 +276,8 @@ en:
       heading: Login email sent!
       body: Please check your email for the login link.
       heading: An email is on its way!
-      body_html: |
-        <p>We just sent an access link to <strong class="email-address">%{email}</strong>.  Click on the link to log in to your account</p>
-        <hr>
-        <p>Don't see the email? Be sure to check your spam folder. Please wait for a few minutes and %{try_again_link}.</p>
+      sent_access_link_html: We just sent an access link to <strong class="email-address">%{email}</strong>.  Click on the link to log in to your account
+      resend_email_html: Don't see the email? Be sure to check your spam folder. Please wait for a few minutes and %{try_again_link}.
       try_again: try again
     devise:
       login_session_expired: Your session has expired. Please log in again.

--- a/docs/publishers-secrets.example.sh
+++ b/docs/publishers-secrets.example.sh
@@ -15,6 +15,7 @@ export API_EYESHADE_OFFLINE=1
 export INTERNAL_EMAIL="admin@publishers.local" # Admin notifications get sent here.
 #export LOG_API_REQUESTS=1 # Enable to log publishers' external API access.
 #export MAILER_SENDER="" # The From: header in emails sent to users.
+export REDIS_URL="redis://127.0.0.1:6379/0"
 export RECAPTCHA_PUBLIC_KEY="" # For recaptcha for rate limiting.
 export RECAPTCHA_PRIVATE_KEY=""
 #export SENTRY_DSN="" # Exception handling


### PR DESCRIPTION
Fixes issue where sometimes the reCAPTCHA is not shown and user instead sees 🎷
Supports rate limiting and reCAPTCHA in development and staging environments

Fixes #755, #791

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))