### PR TITLE
Give PublisherMailer#verified_invalid_wallet an extra param

### DIFF
--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -194,7 +194,7 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
-  def verified_invalid_wallet(publisher)
+  def verified_invalid_wallet(publisher, params)
     @publisher = publisher
     if !@publisher.uphold_verified
       begin
@@ -211,7 +211,7 @@ class PublisherMailer < ApplicationMailer
     end
   end
 
-  def verified_invalid_wallet_internal(publisher)
+  def verified_invalid_wallet_internal(publisher, params)
     @publisher = publisher
     return if !@publisher.uphold_verified
     mail(

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -111,7 +111,7 @@ class PublisherMailerTest < ActionMailer::TestCase
 
   test "verified_invalid_wallet" do
     publisher = publishers(:uphold_connected)
-    email = PublisherMailer.verified_invalid_wallet(publisher)
+    email = PublisherMailer.verified_invalid_wallet(publisher, nil)
 
     assert_emails 1 do
       email.deliver_now
@@ -122,7 +122,7 @@ class PublisherMailerTest < ActionMailer::TestCase
 
     # Ensure emails are not delivered if they have never created a wallet
     publisher = publishers(:default)
-    email = PublisherMailer.verified_invalid_wallet(publisher)
+    email = PublisherMailer.verified_invalid_wallet(publisher, nil)
 
     assert_emails 0 do
       email.deliver_now
@@ -131,7 +131,7 @@ class PublisherMailerTest < ActionMailer::TestCase
 
   test "verified_invalid_wallet_internal" do
     publisher = publishers(:uphold_connected)
-    email = PublisherMailer.verified_invalid_wallet_internal(publisher)
+    email = PublisherMailer.verified_invalid_wallet_internal(publisher, nil)
 
     assert_emails 1 do
       email.deliver_now


### PR DESCRIPTION
This adds to https://github.com/brave-intl/publishers/pull/806.  `PublisherMailer#verified_invalid_wallet` did not include the extra param which the `PublisherNotifier` sends. 

The tests missed this because we only check if the email is enqueued, not delivered:

https://github.com/brave-intl/publishers/blob/40f492594f02bac69762acdc20670512b136efdc/test/controllers/api/channels_controller_test.rb#L86-L88

We aren't able to update the test to see if the email is delivered because the mailing is asynchronous (`deliver_later`), and we cannot guarantee the mail will already delivered at the time the assertion executes:

https://github.com/brave-intl/publishers/blob/40f492594f02bac69762acdc20670512b136efdc/app/services/publisher_notifier.rb#L21-L24

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
