### PR TITLE
Provide default UPHOLD_AUTHORIZATION_ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ These steps presume you are using OSX and [Homebrew](https://brew.sh/).
       `bundle config build.nokogiri --use-system-libraries` then again
       `bundle install`.
   * Node deps: `yarn --frozen-lockfile`
-8. Get an `env.sh` file from another developer which contains development-mode
-   bash env exports. `source` that file.
-9. Create and initialize the database
+8. (Optional) Get an `env.sh` file from another developer which contains development-mode
+   bash env exports and `source` that file. You can start developing without this, but some functionality may be limited.
+9. Create and initialize the database:
   - `rails db:create RAILS_ENV=development`
   - `rails db:migrate RAILS_ENV=development`
+10. Setup SSL as described below.
 
 ### HTTPS Setup
 
@@ -99,8 +100,8 @@ Setup a google API project:
 
 ### reCAPTCHA Setup
 
-In order to test the rate limiting and captcha components you will need to setup an account with Google's 
-[reCAPTCHA](https://www.google.com/recaptcha/intro/android.html). Instructions can be found at the 
+In order to test the rate limiting and captcha components you will need to setup an account with Google's
+[reCAPTCHA](https://www.google.com/recaptcha/intro/android.html). Instructions can be found at the
 [reCAPTCHA gem repo](https://github.com/ambethia/recaptcha#rails-installation). Add the api keys to your Env variables.
 
 ### Local Eyeshade Setup

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -81,6 +81,12 @@ development:
   from_email: Brave Payments Publishers Dev<brave-publishers@localhost.local>
   attr_encrypted_key: 499a4c51df667b4edfab40c1f8b813b7ed6ce02096d59f23b5dcb095369375f6
   secret_key_base: dd7b12788a804315fd75f1ff97fae33310b451c39d83d1d015543d25d0ba034c02fd312e83735f0d0aeaaf70131f26e614629e3c40531b949445b4dfacd3bad3
+  uphold_authorization_endpoint: "https://uphold.example.com/authorize/<UPHOLD_CLIENT_ID>?scope=<UPHOLD_SCOPE>&intention=signup&state=<STATE>"
+  uphold_client_id: test_client_id
+  uphold_client_secret: test_client_secret
+  uphold_scope: a:read,b:read,c:deposit
+  uphold_api_uri: "https://uphold-api.example.com"
+  uphold_dashboard_url: "https://sandbox.uphold.com/dashboard"
   # Social media links
   bat_medium_url: "https://medium.com/@attentiontoken"
   bat_twitter_url: "https://twitter.com/@attentiontoken"


### PR DESCRIPTION
Fix #608

This lets you run tests and the app without special environment variables.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
