### PR TITLE
Register email addresses with SendGrid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+# Rate limit ActiveJob
+gem 'activejob-traffic_control'
+
 # Serialize models for JSON APIs
 gem "active_model_serializers", "~> 0.10.0"
 
@@ -70,6 +73,9 @@ gem "rqrcode", "~> 0.10"
 # SCSS for stylesheets
 gem "sass-rails", "~> 5.0"
 
+# Sendgrid mail service
+gem 'sendgrid-ruby'
+
 # Exception logging
 gem "sentry-raven", "~> 2.1", require: false
 
@@ -131,6 +137,9 @@ group :test do
 
   # Locking to 5.10.3 to workaround issue in 5.11.1 (https://github.com/seattlerb/minitest/issues/730)
   gem 'minitest', '5.10.3'
+
+  # API recording and playback
+  gem "vcr"
 
   gem "webmock", "~> 3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,10 @@ GEM
     activejob (5.0.7)
       activesupport (= 5.0.7)
       globalid (>= 0.3.6)
+    activejob-traffic_control (0.1.3)
+      activejob (>= 4.2)
+      activesupport (>= 4.2)
+      suo
     activemodel (5.0.7)
       activesupport (= 5.0.7)
     activerecord (5.0.7)
@@ -99,6 +103,7 @@ GEM
     crass (1.0.4)
     css_parser (1.6.0)
       addressable
+    dalli (2.7.8)
     database_cleaner (1.6.2)
     devise (4.2.1)
       bcrypt (~> 3.0)
@@ -182,9 +187,11 @@ GEM
       minitest-rails (~> 3.0)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
+    msgpack (1.2.4)
     multi_json (1.13.0)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustermann (1.0.2)
     newrelic_rpm (3.18.1.330)
     nio4r (2.3.0)
     nokogiri (1.8.2)
@@ -314,6 +321,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    ruby_http_client (3.3.0)
     rubyzip (1.2.1)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
@@ -332,6 +340,9 @@ GEM
     selenium-webdriver (3.8.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    sendgrid-ruby (5.2.0)
+      ruby_http_client (~> 3.2)
+      sinatra (>= 1.4.7, < 3)
     sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (4.2.10)
@@ -344,6 +355,11 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
+    sinatra (2.0.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.1)
+      tilt (~> 2.0)
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -358,6 +374,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    suo (0.3.2)
+      dalli
+      msgpack
+      redis
     temple (0.8.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -372,6 +392,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
+    vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -403,6 +424,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
+  activejob-traffic_control
   api-pagination
   attr_encrypted (~> 3.0.0)
   bootstrap (~> 4.0.0.beta3)
@@ -445,12 +467,14 @@ DEPENDENCIES
   rqrcode (~> 0.10)
   rubocop
   sass-rails (~> 5.0)
+  sendgrid-ruby
   sentry-raven (~> 2.1)
   sidekiq (~> 4.2)
   sidekiq-scheduler (~> 2.0)
   slim-rails (~> 3.1)
   tzinfo-data
   u2f (~> 1.0)
+  vcr
   web-console
   webmock (~> 3.0)
   webpacker (~> 3.0)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -133,6 +133,8 @@ class PublishersController < ApplicationController
       update_params[:agreed_to_tos] = Time.now
     end
 
+    update_sendgrid(publisher: @publisher)
+
     if @publisher.update(update_params)
       # let eyeshade know about the new Publisher
       begin
@@ -412,8 +414,15 @@ class PublishersController < ApplicationController
       session[:publisher_created_through_youtube_auth] = publisher_created_through_youtube_auth
     end
 
+    if confirm_email.present?
+      prior_email = publisher.email
+    end
+
     if PublisherTokenAuthenticator.new(publisher: publisher, token: token, confirm_email: confirm_email).perform
       if confirm_email.present? && publisher.email == confirm_email && !publisher_created_through_youtube_auth
+        # Register the new email address with sendgrid, and clear the publisher interests on the old member
+        update_sendgrid(publisher: publisher, prior_email: prior_email)
+
         flash[:alert] = t(".email_confirmed", email: publisher.email)
       end
 
@@ -494,5 +503,9 @@ class PublishersController < ApplicationController
     return if current_publisher.two_factor_prompted_at.present? || two_factor_enabled?(current_publisher)
     current_publisher.update! two_factor_prompted_at: Time.now
     redirect_to prompt_two_factor_registrations_path
+  end
+
+  def update_sendgrid(publisher:, prior_email: nil)
+    RegisterPublisherWithSendGridJob.perform_later(publisher.id, prior_email)
   end
 end

--- a/app/jobs/register_publisher_with_send_grid_job.rb
+++ b/app/jobs/register_publisher_with_send_grid_job.rb
@@ -1,0 +1,20 @@
+class RegisterPublisherWithSendGridJob < ApplicationJob
+  queue_as :default
+
+  # SendGrid allows 3 POSTs per 2 seconds, but we'll stick with 1 per second for safety
+  throttle threshold: 1, period: 1.second
+
+  # Using positional arguments for issue with activejob-traffic_control
+  def perform(publisher_id, prior_email = nil)
+    publisher = Publisher.find(publisher_id)
+    SendGridRegistrar.new(publisher: publisher, prior_email: prior_email).perform
+  rescue => e
+    require "sentry-raven"
+    Raven.capture_exception(e)
+
+    # Retry later if the SendGrid rate limit was exceeded
+    if e.is_a?(SendGrid::RateLimitExceeded)
+      retry_job wait: 1.minute
+    end
+  end
+end

--- a/app/services/send_grid_registrar.rb
+++ b/app/services/send_grid_registrar.rb
@@ -1,0 +1,37 @@
+require 'sendgrid-ruby'
+require 'send_grid/api_helper'
+
+# Registers each email address with SendGrid
+class SendGridRegistrar < BaseService
+
+  def initialize(publisher:, prior_email: nil)
+    @publisher = publisher
+    @prior_email = prior_email
+  end
+  
+  def perform
+    return if Rails.application.secrets[:sendgrid_api_offline]
+
+    register_publisher(publisher: @publisher, prior_email: @prior_email)
+  end
+
+  private
+
+  def register_publisher(publisher:, prior_email: nil)
+    if prior_email.present?
+      begin
+        result = SendGrid::ApiHelper.remove_contact_by_email_from_list(
+            list_id:  Rails.application.secrets[:sendgrid_publishers_list_id],
+            email: prior_email)
+      rescue SendGrid::NotFoundError => e
+      #   Ignore since the contact may not have been in the system before
+      end
+    end
+
+    id = SendGrid::ApiHelper.upsert_contact(publisher: publisher)
+
+    SendGrid::ApiHelper.add_contact_to_list(
+        list_id:  Rails.application.secrets[:sendgrid_publishers_list_id],
+        contact_id: id)
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,14 +6,29 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: 0.0.0.0
+  port: 25432
+  username: postgres
+  password:
 
 development:
   <<: *default
+#  database: staging_copy
+#  database: staging2_copy
   database: brave_publishers_dev
+#  database: brave_publishers_dev_staging
+
+#Staging 2
+#  host: ec2-54-163-233-103.compute-1.amazonaws.com
+#  database: dc0gs7b1o0nd7q
+#  password: fb7ebaca30dda58947cf90e2f41efd196bdedd18978438a21c886246bf9fe0d4
+#  username: rofkmqlvyecjis
+#  port: 5432
 
 test:
   <<: *default
   database: brave_publishers_test
+#  database: brave_publishers_test_staging
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/initializers/active_job_trafic_control.rb
+++ b/config/initializers/active_job_trafic_control.rb
@@ -1,0 +1,1 @@
+ActiveJob::TrafficControl.client = ConnectionPool.new(size: 5, timeout: 5) { Redis.new }

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -68,6 +68,10 @@ default: &default
   base_referral_url: <%= ENV["BASE_REFERRAL_URL"] %>
   max_site_age: <%= ENV["MAX_SITE_AGE"] %> # Maximimum age in weeks of sites enqueued for verification
   should_send_notifications: <%= ENV["SHOULD_SEND_NOTIFICATIONS"] %> # Enables eyeshade notifications
+  # Sendgrid
+  sendgrid_api_key: <%= ENV["SENDGRID_API_KEY"] %>
+  sendgrid_api_offline: <%= ENV["SENDGRID_API_KEY"].blank? %>
+  sendgrid_publishers_list_id: <%= ENV["SENDGRID_PUBLISHERS_LIST_ID"] %>
 
 development:
   <<: *default
@@ -114,6 +118,11 @@ test:
   bat_rocketchat_url: "https://basicattentiontoken.rocket.chat/"
   max_site_age: 6
   should_send_notifications: true
+  # Sendgrid
+  # a real api_key is needed for recording new VCR based tests
+  sendgrid_api_offline: true
+  sendgrid_api_key: <%= ENV["SENDGRID_API_KEY"] || "fakeapikey" %>
+  sendgrid_publishers_list_id: 3648346
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/lib/send_grid/api_helper.rb
+++ b/lib/send_grid/api_helper.rb
@@ -1,0 +1,116 @@
+require 'digest'
+require "base64"
+
+module SendGrid
+  class Error < StandardError; end
+  class NotFoundError < StandardError; end
+  class Unauthorized < StandardError; end
+  class RateLimitExceeded < StandardError; end
+  class PageLimitExceeded < StandardError; end
+
+  class ApiHelper
+    class << self
+      def find_contact_by_email(email:)
+        params = { "email": email }
+        result = sg.client.contactdb.recipients.search.get(query_params: params)
+        check_result(result: result, sucess: '200')
+
+        json_result = JSON.parse(result.body)
+
+        if json_result['recipient_count'] == 0
+          raise NotFoundError.new
+        end
+
+        json_result['recipients'][0]
+      end
+
+      def get_contact_by_email(email:)
+        result = sg.client.contactdb.recipients._(id_from_email(email)).get
+        check_result(result: result, sucess: '200')
+        JSON.parse(result.body)
+      end
+
+      def upsert_contacts(publishers:)
+        raise PageLimitExceeded.new if publishers.length > 1000
+
+        body = publishers.collect do |publisher|
+          contact_params(publisher: publisher)
+        end
+
+        result = sg.client.contactdb.recipients.patch(request_body: body)
+        check_result(result: result, sucess: '201')
+
+        result_json = JSON.parse(result.body)
+        if result_json['error_count'] > 0
+          raise SendGrid::Error.new(result_json['errors'])
+        end
+
+        result_json['persisted_recipients']
+      end
+
+      # Updates or create the SendGrid contact for the publisher
+      def upsert_contact(publisher:)
+        result = upsert_contacts(publishers: [publisher])
+        result[0]
+      end
+
+      def add_contact_to_list(list_id:, contact_id:)
+        result = sg.client.contactdb.lists._(list_id).recipients._(contact_id).post()
+        check_result(result: result, sucess: '201')
+      end
+
+      def add_contacts_to_list(list_id:, contact_ids:)
+        result = sg.client.contactdb.lists._(list_id).recipients.post(request_body: contact_ids)
+        check_result(result: result, sucess: '201')
+      end
+
+      def remove_contact_from_list(list_id:, contact_id:)
+        params = {"recipient_id": contact_id, "list_id": list_id}
+        result = sg.client.contactdb.lists._(list_id).recipients._(contact_id).delete(query_params: params)
+        check_result(result: result, sucess: '204')
+      end
+
+      def add_contact_by_email_to_list(list_id:, email:)
+        add_contact_to_list(list_id: list_id, contact_id: id_from_email(email))
+      end
+
+      def remove_contact_by_email_from_list(list_id:, email:)
+        remove_contact_from_list(list_id: list_id, contact_id: id_from_email(email))
+      end
+
+      def contact_params(publisher:)
+        params = { 'email': publisher.email}
+        params['name'] = publisher.name unless publisher.name.blank?
+        params['phone'] = publisher.phone_normalized unless publisher.phone_normalized.blank?
+        params
+      end
+
+      private
+
+      def id_from_email(email)
+        Base64.strict_encode64(email.downcase)
+      end
+
+      def check_result(result:, sucess:)
+        case result.status_code
+        when sucess
+          true
+        when '400'
+          raise Error.new(result.body)
+        when '401'
+          raise SendGrid::Unauthorized.new
+        when '404'
+          raise NotFoundError.new(result.body)
+        when '429'
+          raise SendGrid::RateLimitExceeded.new
+        else
+          raise "Unknown Error"
+        end
+      end
+
+      def sg
+        SendGrid::API.new(api_key: Rails.application.secrets[:sendgrid_api_key])
+      end
+    end
+  end
+end

--- a/lib/tasks/sendgrid/refresh.rake
+++ b/lib/tasks/sendgrid/refresh.rake
@@ -1,0 +1,29 @@
+require "send_grid/api_helper"
+
+namespace :sendgrid do
+  desc "Update SendGrid with current contacts from Publishers, creating new contacts if needed"
+  task :refresh, [:page_size] => [:environment] do |t, args|
+
+    limit = args[:page_size] ? args[:page_size].to_i : 1000
+    page = 0
+
+    total_count = Publisher.email_verified.count
+
+    while page * limit < total_count
+      publishers = Publisher.email_verified.offset(page * limit).limit(limit)
+      page = page + 1
+
+      ids = SendGrid::ApiHelper.upsert_contacts(publishers: publishers)
+
+      SendGrid::ApiHelper.add_contacts_to_list(
+          list_id: Rails.application.secrets[:sendgrid_publishers_list_id],
+          contact_ids: ids)
+
+      print '.'
+      # Basic rate limiting (3 requests in 2s)
+      sleep(0.75)
+    end
+
+    puts "\nDone. Refreshed #{total_count} publishers to SendGrid."
+  end
+end

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,28 @@
+Allow other Publisher to verify already verified channel.
+    if channel is verified it must go into a pending state.
+        this needs eyeshade changes to conditionally verify channel
+        we then need a way to tell eyeshade the the verification should be rejected (if contested) or finalized
+        then remove the channel that isn't staying
+
+
+Channel Model
+* new fields
+  * verification_pending (for subsequent channels)
+  * contested_by_channel_id (for initial channels)
+  * contest_token (for initial channels)
+  * contest_time_out
+* relax uniqueness constraint
+
+helper
+  * send emails when verified
+    * owner of originally verified channel must get email with contest token
+    * owner of new channel must get status email
+
+* Dashboard View
+  * Channel must show status
+    * new channel should show it's pending
+    * original channel must show it's pending and allow approval
+      * should we show contact info for new owner
+      * how to handle multiple contesting channels
+        * A channel can only be contested by one other channel
+        * If a third channel verifies it will replace the second channel, which will revert to unverified 

--- a/test/cassettes/test_can_add_a_contact__by_email__to_a_list.yml
+++ b/test/cassettes/test_can_add_a_contact__by_email__to_a_list.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sendgrid.com/v3/contactdb/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:14:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '368'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '998'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266885'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"id":"YWxpY2VAY29tcGxldGVkLm9yZw==","email":"alice@completed.org","created_at":1525207625,"updated_at":1525207625,"last_emailed":null,"last_clicked":null,"last_opened":null,"first_name":null,"last_name":null,"custom_fields":[{"id":2337510,"name":"phone","type":"text","value":"+14159001421"},{"id":2337512,"name":"name","type":"text","value":"Alice
+        the Completed"}]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:14:45 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:14:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266886'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:14:45 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_can_add_multiple_contacts_to_a_list.yml
+++ b/test/cassettes/test_can_add_multiple_contacts_to_a_list.yml
@@ -1,0 +1,142 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@default.org","name":"Alice the Pyramid","phone":"+14159001420"},{"email":"alice@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"alice@completed.org","name":"Alice
+        the Completed","phone":"+14159001421"},{"email":"alice@unprompted.org","name":"Alice
+        the Unprompted","phone":"+14159001421"},{"email":"alice@stale.org","name":"Alice
+        the Stale","phone":"+14159001422"},{"email":"alice@fake.org","name":"Fake
+        Alice","phone":"+14155551212"},{"email":"bob@fake.org","name":"Fake Bob","phone":"+14155551234"},{"email":"alice@upholdconnected.org","name":"Alice
+        the uphold_connected","phone":"+14159001421"},{"email":"alice@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"},{"email":"alice2@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"},{"email":"alice2@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"aliceTwitch@spud.com","name":"Alice
+        the Twitcher","phone":"+14159001420"},{"email":"aliceTwitch@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"fred@vglobal.org","name":"Global
+        Media Group","phone":"+14159001421"},{"email":"fred@small.org","name":"Small
+        Media Group","phone":"+14159001421"},{"email":"barney@medium.org","name":"Small
+        Media Group","phone":"+14159008921"},{"email":"joes-great-channel@pages.plusgoogle.com","name":"Joe
+        Schmoe","phone":"+16035551212"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 12:14:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '630'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525263276'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":15,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[2,10],"persisted_recipients":["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn","YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t","YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc=","YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 12:14:36 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn","YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t","YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc=","YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 12:14:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525263277'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 12:14:36 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_can_find_a_contact_by_email.yml
+++ b/test/cassettes/test_can_find_a_contact_by_email.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sendgrid.com/v3/contactdb/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:13:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '368'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266791'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"id":"YWxpY2VAY29tcGxldGVkLm9yZw==","email":"alice@completed.org","created_at":1525207625,"updated_at":1525207625,"last_emailed":null,"last_clicked":null,"last_opened":null,"first_name":null,"last_name":null,"custom_fields":[{"id":2337510,"name":"phone","type":"text","value":"+14159001421"},{"id":2337512,"name":"name","type":"text","value":"Alice
+        the Completed"}]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:13:10 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_can_remove_a_contact__by_email__from_a_list.yml
+++ b/test/cassettes/test_can_remove_a_contact__by_email__from_a_list.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==?list_id=3648346&recipient_id=YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 204
+      message: NO CONTENT
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:14:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266885'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:14:44 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_raises_an_exception_if_it_can_not_find_a_contact_by_email.yml
+++ b/test/cassettes/test_raises_an_exception_if_it_can_not_find_a_contact_by_email.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sendgrid.com/v3/contactdb/recipients/ZnJhbmtAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:14:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '48'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266887'
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"Recipient not found."}]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:14:46 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_raises_trying_to_add_a_contact__by_email__to_a_missing_list.yml
+++ b/test/cassettes/test_raises_trying_to_add_a_contact__by_email__to_a_missing_list.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sendgrid.com/v3/contactdb/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:14:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '368'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266886'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"id":"YWxpY2VAY29tcGxldGVkLm9yZw==","email":"alice@completed.org","created_at":1525207625,"updated_at":1525207625,"last_emailed":null,"last_clicked":null,"last_opened":null,"first_name":null,"last_name":null,"custom_fields":[{"id":2337510,"name":"phone","type":"text","value":"+14159001421"},{"id":2337512,"name":"name","type":"text","value":"Alice
+        the Completed"}]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:14:45 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/1234/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:14:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '998'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266886'
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"List ID does not exist"}]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:14:45 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_raises_trying_to_remove_a_contact__by_email__to_a_missing_list.yml
+++ b/test/cassettes/test_raises_trying_to_remove_a_contact__by_email__to_a_missing_list.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.sendgrid.com/v3/contactdb/lists/1234/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==?list_id=1234&recipient_id=YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:14:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '50'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266887'
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"List ID does not exist"}]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:14:46 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_registers_a_changed_email_and_replaces_emails_in_Publisher_List.yml
+++ b/test/cassettes/test_registers_a_changed_email_and_replaces_emails_in_Publisher_List.yml
@@ -1,0 +1,248 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.sendgrid.com/v3/contactdb/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:16:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '368'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266989'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"id":"YWxpY2VAY29tcGxldGVkLm9yZw==","email":"alice@completed.org","created_at":1525207625,"updated_at":1525207625,"last_emailed":null,"last_clicked":null,"last_opened":null,"first_name":null,"last_name":null,"custom_fields":[{"id":2337510,"name":"phone","type":"text","value":"+14159001421"},{"id":2337512,"name":"name","type":"text","value":"Alice
+        the Completed"}]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:16:28 GMT
+- request:
+    method: delete
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==?list_id=3648346&recipient_id=YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+  response:
+    status:
+      code: 204
+      message: NO CONTENT
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:16:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266989'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:16:29 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"test@test.com","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:16:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525266990'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["dGVzdEB0ZXN0LmNvbQ=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:16:29 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/dGVzdEB0ZXN0LmNvbQ==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:16:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525266990'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:16:29 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_registers_a_new_publisher_with_SendGrid_and_adds_them_to_the_Publisher_List.yml
+++ b/test/cassettes/test_registers_a_new_publisher_with_SendGrid_and_adds_them_to_the_Publisher_List.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 12:23:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525263830'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 12:23:48 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 12:23:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525263829'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 12:23:48 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_upsert_raises_an_exception_if_an_error_is_returned.yml
+++ b/test/cassettes/test_upsert_raises_an_exception_if_an_error_is_returned.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 30 Apr 2018 19:20:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '242'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525116056'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":1,"error_indices":[0],"unmodified_indices":[],"persisted_recipients":[],"errors":[{"message":"The
+        following parameters are not custom fields or reserved fields: [address]","error_indices":[0]}]}
+
+'
+    http_version:
+  recorded_at: Mon, 30 Apr 2018 19:20:55 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_upserts_all_email_verified_publishers_to_SendGrid_with_paginated_requests.yml
+++ b/test/cassettes/test_upserts_all_email_verified_publishers_to_SendGrid_with_paginated_requests.yml
@@ -1,0 +1,1530 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@default.org","name":"Alice the Pyramid","phone":"+14159001420"},{"email":"alice@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"alice@completed.org","name":"Alice
+        the Completed","phone":"+14159001421"},{"email":"alice@unprompted.org","name":"Alice
+        the Unprompted","phone":"+14159001421"},{"email":"alice@stale.org","name":"Alice
+        the Stale","phone":"+14159001422"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:29:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267798'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:29:56 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:29:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267798'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:29:57 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@fake.org","name":"Fake Alice","phone":"+14155551212"},{"email":"bob@fake.org","name":"Fake
+        Bob","phone":"+14155551234"},{"email":"alice@upholdconnected.org","name":"Alice
+        the uphold_connected","phone":"+14159001421"},{"email":"alice@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"},{"email":"alice2@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:29:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '266'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267800'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:29:58 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:29:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267799'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:29:58 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice2@verified.org","name":"Alice the Verified","phone":"+14159001421"},{"email":"aliceTwitch@spud.com","name":"Alice
+        the Twitcher","phone":"+14159001420"},{"email":"aliceTwitch@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"fred@vglobal.org","name":"Global
+        Media Group","phone":"+14159001421"},{"email":"fred@small.org","name":"Small
+        Media Group","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:29:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '286'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '1'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267800'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:29:59 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc="]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:29:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267800'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:29:59 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"barney@medium.org","name":"Small Media Group","phone":"+14159008921"},{"email":"joes-great-channel@pages.plusgoogle.com","name":"Joe
+        Schmoe","phone":"+16035551212"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267802'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1],"persisted_recipients":["YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:00 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267801'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:01 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@default.org","name":"Alice the Pyramid","phone":"+14159001420"},{"email":"alice@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"alice@completed.org","name":"Alice
+        the Completed","phone":"+14159001421"},{"email":"alice@unprompted.org","name":"Alice
+        the Unprompted","phone":"+14159001421"},{"email":"alice@stale.org","name":"Alice
+        the Stale","phone":"+14159001422"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '1'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267802'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:02 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267803'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:02 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@fake.org","name":"Fake Alice","phone":"+14155551212"},{"email":"bob@fake.org","name":"Fake
+        Bob","phone":"+14155551234"},{"email":"alice@upholdconnected.org","name":"Alice
+        the uphold_connected","phone":"+14159001421"},{"email":"alice@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"},{"email":"alice2@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '266'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267804'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:03 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267804'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:03 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice2@verified.org","name":"Alice the Verified","phone":"+14159001421"},{"email":"aliceTwitch@spud.com","name":"Alice
+        the Twitcher","phone":"+14159001420"},{"email":"aliceTwitch@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"fred@vglobal.org","name":"Global
+        Media Group","phone":"+14159001421"},{"email":"fred@small.org","name":"Small
+        Media Group","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '286'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267806'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:04 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc="]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267805'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:04 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"barney@medium.org","name":"Small Media Group","phone":"+14159008921"},{"email":"joes-great-channel@pages.plusgoogle.com","name":"Joe
+        Schmoe","phone":"+16035551212"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '1'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267806'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1],"persisted_recipients":["YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:05 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267807'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:06 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@default.org","name":"Alice the Pyramid","phone":"+14159001420"},{"email":"alice@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"alice@completed.org","name":"Alice
+        the Completed","phone":"+14159001421"},{"email":"alice@unprompted.org","name":"Alice
+        the Unprompted","phone":"+14159001421"},{"email":"alice@stale.org","name":"Alice
+        the Stale","phone":"+14159001422"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267808'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:07 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2VAZGVmYXVsdC5vcmc=","YWxpY2VAdmVyaWZpZWQub3Jn","YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2VAdW5wcm9tcHRlZC5vcmc=","YWxpY2VAc3RhbGUub3Jn"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267808'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:07 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@fake.org","name":"Fake Alice","phone":"+14155551212"},{"email":"bob@fake.org","name":"Fake
+        Bob","phone":"+14155551234"},{"email":"alice@upholdconnected.org","name":"Alice
+        the uphold_connected","phone":"+14159001421"},{"email":"alice@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"},{"email":"alice2@spud.com","name":"Alice
+        the Youtuber","phone":"+14159001420"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '266'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267810'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:08 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2VAZmFrZS5vcmc=","Ym9iQGZha2Uub3Jn","YWxpY2VAdXBob2xkY29ubmVjdGVkLm9yZw==","YWxpY2VAc3B1ZC5jb20=","YWxpY2UyQHNwdWQuY29t"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267809'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:08 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice2@verified.org","name":"Alice the Verified","phone":"+14159001421"},{"email":"aliceTwitch@spud.com","name":"Alice
+        the Twitcher","phone":"+14159001420"},{"email":"aliceTwitch@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"},{"email":"fred@vglobal.org","name":"Global
+        Media Group","phone":"+14159001421"},{"email":"fred@small.org","name":"Small
+        Media Group","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '286'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '1'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267810'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1,2,3,4],"persisted_recipients":["YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:09 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YWxpY2UyQHZlcmlmaWVkLm9yZw==","YWxpY2V0d2l0Y2hAc3B1ZC5jb20=","YWxpY2V0d2l0Y2hAdmVyaWZpZWQub3Jn","ZnJlZEB2Z2xvYmFsLm9yZw==","ZnJlZEBzbWFsbC5vcmc="]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267810'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:09 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"barney@medium.org","name":"Small Media Group","phone":"+14159008921"},{"email":"joes-great-channel@pages.plusgoogle.com","name":"Joe
+        Schmoe","phone":"+16035551212"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '215'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525267812'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0,1],"persisted_recipients":["YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:10 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients
+    body:
+      encoding: UTF-8
+      string: '["YmFybmV5QG1lZGl1bS5vcmc=","am9lcy1ncmVhdC1jaGFubmVsQHBhZ2VzLnBsdXNnb29nbGUuY29t"]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 13:30:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Reset:
+      - '1525267812'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 May 2018 13:30:11 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_upserts_multiple_one__contacts_and_returns_their_sendgrid_ids.yml
+++ b/test/cassettes/test_upserts_multiple_one__contacts_and_returns_their_sendgrid_ids.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 12:11:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525263110'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 12:11:48 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_upserts_multiple_two__contacts_and_returns_their_sendgrid_ids.yml
+++ b/test/cassettes/test_upserts_multiple_two__contacts_and_returns_their_sendgrid_ids.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"},{"email":"alice2@verified.org","name":"Alice
+        the Verified","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 12:11:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '193'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525263116'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":1,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw==","YWxpY2UyQHZlcmlmaWVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 12:11:55 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_upserts_one_contact_and_returns_their_sendgrid_id.yml
+++ b/test/cassettes/test_upserts_one_contact_and_returns_their_sendgrid_id.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 02 May 2018 12:12:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525263144'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Wed, 02 May 2018 12:12:23 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/test_verify_RegisterPublisherWithSendGridJob_throttles_successfully_when_flooded_with_requests.yml
+++ b/test/cassettes/test_verify_RegisterPublisherWithSendGridJob_throttles_successfully_when_flooded_with_requests.yml
@@ -1,0 +1,747 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525361912'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:30 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525361911'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:30 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '1'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525361912'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:31 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525361912'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:31 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525361914'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:32 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525361914'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:33 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525361916'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:34 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525361915'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:34 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '1'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525361916'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:35 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525361916'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:35 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"alice@completed.org","name":"Alice the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '162'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Limit:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1525361918'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: '{"new_count":0,"updated_count":0,"error_count":0,"error_indices":[],"unmodified_indices":[0],"persisted_recipients":["YWxpY2VAY29tcGxldGVkLm9yZw=="],"errors":[]}
+
+'
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:36 GMT
+- request:
+    method: post
+    uri: https://api.sendgrid.com/v3/contactdb/lists/3648346/recipients/YWxpY2VAY29tcGxldGVkLm9yZw==
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - ''
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 03 May 2018 15:38:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1525361918'
+      Powered-By:
+      - Mako
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 03 May 2018 15:38:37 GMT
+recorded_with: VCR 4.0.0

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -313,6 +313,87 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_nil(publisher.pending_email)
   end
 
+  test "publisher completing signup will trigger RegisterPublisherWithSendGridJob" do
+    perform_enqueued_jobs do
+      post(publishers_path, params: SIGNUP_PARAMS)
+    end
+
+    publisher = Publisher.order(created_at: :asc).last
+    url = publisher_url(publisher, token: publisher.authentication_token)
+    get(url)
+    follow_redirect!
+    assert_performed_with(job: RegisterPublisherWithSendGridJob) do
+      patch(complete_signup_publishers_path, params: COMPLETE_SIGNUP_PARAMS)
+    end
+  end
+
+  test "publisher updating contact email address will trigger RegisterPublisherWithSendGridJob" do
+    perform_enqueued_jobs do
+      post(publishers_path, params: SIGNUP_PARAMS)
+    end
+
+    publisher = Publisher.order(created_at: :asc).last
+    url = publisher_url(publisher, token: publisher.authentication_token)
+    get(url)
+    follow_redirect!
+    assert_performed_with(job: RegisterPublisherWithSendGridJob) do
+      patch(complete_signup_publishers_path, params: COMPLETE_SIGNUP_PARAMS)
+    end
+
+    # update the publisher email
+    perform_enqueued_jobs do
+      patch(publishers_path,
+            params: { publisher: {pending_email: 'alice-pending@example.com' } },
+            headers: { 'HTTP_ACCEPT' => "application/json" })
+    end
+
+    publisher.reload
+
+    # verify pending email has been updated
+    assert_equal 'alice-pending@example.com', publisher.pending_email
+
+    # verify original email still is used
+    assert_equal 'alice@example.com', publisher.email
+
+
+    # verify 3 emails have been sent after update
+    assert ActionMailer::Base.deliveries.count == 5
+
+    # verify notification email sent to original address
+    email = ActionMailer::Base.deliveries.find do |message|
+      message.to == publisher.email
+      message.subject == I18n.t('publisher_mailer.notify_email_change.subject', publication_title: publisher.name)
+    end
+    assert_not_nil(email)
+
+    # verify brave gets an internal email copy of confirmation email
+    email = ActionMailer::Base.deliveries.find do |message|
+      message.to.first == Rails.application.secrets[:internal_email]
+      message.subject == "<Internal> #{I18n.t('publisher_mailer.confirm_email_change.subject', publication_title: publisher.name)}"
+    end
+    assert_not_nil(email)
+
+    # verify confirmation email sent to pending address
+    email = ActionMailer::Base.deliveries.find do |message|
+      message.to == publisher.pending_email
+      message.subject == I18n.t('publisher_mailer.confirm_email_change.subject', publication_title: publisher.name)
+    end
+    assert_not_nil(email)
+
+
+    url = publisher_url(publisher, confirm_email: publisher.pending_email, token: publisher.authentication_token)
+    assert_enqueued_with(job: RegisterPublisherWithSendGridJob) do
+      get(url)
+    end
+    publisher.reload
+
+    # verify email changes after confirmation
+    assert_equal('alice-pending@example.com', publisher.email)
+
+    # verify pending email is removed after confirmation
+    assert_nil(publisher.pending_email)
+  end
+
   test "after verification, a publisher's `uphold_state_token` is set and will be used for Uphold authorization" do
     publisher = publishers(:completed)
     sign_in publisher

--- a/test/jobs/register_publisher_with_send_grid_job_test.rb
+++ b/test/jobs/register_publisher_with_send_grid_job_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class RegisterPublisherWithSendGridJobTest < ActiveJob::TestCase
+  before do
+    VCR.insert_cassette name
+  end
+
+  after do
+    VCR.eject_cassette
+  end
+
+  test "verify RegisterPublisherWithSendGridJob throttles successfully when flooded with requests" do
+    Rails.application.secrets[:sendgrid_api_offline] = false
+
+    begin
+      publisher = publishers(:completed)
+
+      start_time = Time.now.to_f
+
+      perform_enqueued_jobs do
+        assert RegisterPublisherWithSendGridJob.perform_later(publisher.id)
+        assert RegisterPublisherWithSendGridJob.perform_later(publisher.id)
+        assert RegisterPublisherWithSendGridJob.perform_later(publisher.id)
+        assert RegisterPublisherWithSendGridJob.perform_later(publisher.id)
+        assert RegisterPublisherWithSendGridJob.perform_later(publisher.id)
+        assert RegisterPublisherWithSendGridJob.perform_later(publisher.id)
+      end
+
+      end_time = Time.now.to_f
+      assert end_time >= start_time + 5
+    ensure
+      Rails.application.secrets[:sendgrid_api_offline] = true
+    end
+  end
+end

--- a/test/services/send_grid_registrar_test.rb
+++ b/test/services/send_grid_registrar_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+# require "webmock/minitest"
+# require 'vcr'
+require "send_grid/api_helper"
+
+class SendGridRegistrarTest < ActiveJob::TestCase
+  before do
+    VCR.insert_cassette name
+  end
+
+  after do
+    VCR.eject_cassette
+  end
+
+  test "registers a new publisher with SendGrid and adds them to the Publisher List" do
+    prev_sendgrid_api_offline = Rails.application.secrets[:sendgrid_api_offline]
+    Rails.application.secrets[:sendgrid_api_offline] = false
+
+    begin
+      publisher = publishers(:completed)
+
+      assert SendGridRegistrar.new(publisher: publisher).perform
+    ensure
+      Rails.application.secrets[:sendgrid_api_offline] = prev_sendgrid_api_offline
+    end
+  end
+
+  test "registers a changed email and replaces emails in Publisher List" do
+    prev_sendgrid_api_offline = Rails.application.secrets[:sendgrid_api_offline]
+    Rails.application.secrets[:sendgrid_api_offline] = false
+
+    begin
+      publisher = publishers(:completed)
+      prior_email = publisher.email
+
+      publisher.email = "test@test.com"
+
+      assert SendGridRegistrar.new(publisher: publisher, prior_email: prior_email).perform
+    ensure
+      Rails.application.secrets[:sendgrid_api_offline] = prev_sendgrid_api_offline
+    end
+  end
+end

--- a/test/tasks/send_grid_refresh_test.rb
+++ b/test/tasks/send_grid_refresh_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class SendGridRefreshTest < ActiveJob::TestCase
+  before do
+    VCR.insert_cassette name
+  end
+
+  after do
+    VCR.eject_cassette
+  end
+
+  test "upserts all email verified publishers to SendGrid with paginated requests" do
+    assert_output(/....\nDone. Refreshed #{Publisher.email_verified.count} publishers to SendGrid./) do
+      Rake::Task["sendgrid:refresh"].invoke(5)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,15 @@ Capybara.register_driver :chrome do |app|
     desired_capabilities: capabilities
 end
 
+VCR.configure do |config|
+  config.cassette_library_dir = "./test/cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data("<ENCODED API KEY>") { Rails.application.secrets[:sendgrid_api_key] }
+  config.ignore_hosts '127.0.0.1', 'localhost'
+  config.allow_http_connections_when_no_cassette = true
+  config.default_cassette_options = { match_requests_on: [:method, :uri, :body] }
+end
+
 class Capybara::Rails::TestCase
   def setup
     Capybara.current_driver = :chrome
@@ -73,6 +82,10 @@ module ActionDispatch
     end
   end
 end
+
+# Load rake tasks here so it only happens one time. If tasks are loaded again they will run once for each time loaded.
+require 'rake'
+Publishers::Application.load_tasks
 
 # One time test suite setup.
 DatabaseCleaner.strategy = :transaction

--- a/test/unit/send_grid_helper_test.rb
+++ b/test/unit/send_grid_helper_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+require "send_grid/api_helper"
+require 'vcr'
+
+class SendGridHelperTest < ActiveSupport::TestCase
+  before do
+    VCR.insert_cassette name
+  end
+
+  after do
+    VCR.eject_cassette
+  end
+
+  test "can find a contact by email" do
+    contact = SendGrid::ApiHelper.get_contact_by_email(email: 'alice@completed.org')
+
+    assert_equal 'alice@completed.org', contact['email']
+  end
+
+  test "raises an exception if it can not find a contact by email" do
+    assert_raises SendGrid::NotFoundError do
+      contact = SendGrid::ApiHelper.get_contact_by_email(email: 'frank@completed.org')
+    end
+  end
+
+  test "upserts multiple(one) contacts and returns their sendgrid ids" do
+    publisher = publishers(:completed)
+    ids = SendGrid::ApiHelper.upsert_contacts(publishers: [publisher])
+
+    assert_equal ['YWxpY2VAY29tcGxldGVkLm9yZw=='], ids
+  end
+
+  test "upserts multiple(two) contacts and returns their sendgrid ids" do
+    publisher1 = publishers(:completed)
+    publisher2 = publishers(:google_verified)
+
+    ids = SendGrid::ApiHelper.upsert_contacts(publishers: [publisher1, publisher2])
+
+    assert_equal ['YWxpY2VAY29tcGxldGVkLm9yZw==', 'YWxpY2UyQHZlcmlmaWVkLm9yZw=='], ids
+  end
+
+  test "upserts one contact and returns their sendgrid id" do
+    publisher = publishers(:completed)
+
+    id = SendGrid::ApiHelper.upsert_contact(publisher: publisher)
+
+    assert_equal 'YWxpY2VAY29tcGxldGVkLm9yZw==', id
+  end
+
+  # Note: Cassette modified to produce error
+  test "upsert raises an exception if an error is returned" do
+    publisher = publishers(:completed)
+
+    exp = assert_raises SendGrid::Error do
+      SendGrid::ApiHelper.upsert_contact(publisher: publisher)
+    end
+
+    assert_equal '[{"message"=>"The following parameters are not custom fields or reserved fields: [address]", "error_indices"=>[0]}]', exp.message
+  end
+
+  test "can add a contact, by email, to a list" do
+    assert SendGrid::ApiHelper.add_contact_by_email_to_list(email: 'alice@completed.org', list_id: '3648346')
+  end
+
+  test "raises trying to add a contact, by email, to a missing list" do
+    exp = assert_raises SendGrid::NotFoundError do
+      SendGrid::ApiHelper.add_contact_by_email_to_list(email: 'alice@completed.org', list_id: '1234')
+    end
+    assert_equal "{\"errors\":[{\"message\":\"List ID does not exist\"}]}\n", exp.message
+  end
+
+  test "can remove a contact, by email, from a list" do
+    assert SendGrid::ApiHelper.remove_contact_by_email_from_list(email: 'alice@completed.org', list_id: '3648346')
+  end
+
+  test "raises trying to remove a contact, by email, to a missing list" do
+    exp = assert_raises SendGrid::NotFoundError do
+      SendGrid::ApiHelper.remove_contact_by_email_from_list(email: 'alice@completed.org', list_id: '1234')
+    end
+    assert_equal "{\"errors\":[{\"message\":\"List ID does not exist\"}]}\n", exp.message
+  end
+
+  test "can add multiple contacts to a list" do
+    publishers = Publisher.email_verified
+    ids = SendGrid::ApiHelper.upsert_contacts(publishers: publishers)
+
+    assert SendGrid::ApiHelper.add_contacts_to_list(list_id: '3648346', contact_ids: ids)
+  end
+end


### PR DESCRIPTION
Uploads publishers as contacts to SendGrid as they are created and edited. Also adds them to a specified list. When emails are changed the old email is removed from the list and the new one added.

Includes a rake task to upload all email verified publishers to SendGrid. This rake task is safe to run more than once.

Fixes #804, #805

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
