### PR TITLE
Update promo stats sync logic

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -321,9 +321,8 @@ class PublishersController < ApplicationController
   # Domain verified. See balance and submit payment info.
   def home
     if current_publisher.promo_stats_status == :update
-      PublisherPromoStatsFetcher.new(publisher: current_publisher).perform
+      SyncPublisherPromoStatsJob.perform_later(publisher: current_publisher)
     end
-
     # ensure the wallet has been fetched, which will check if Uphold needs to be re-authorized
     # ToDo: rework this process?
     current_publisher.wallet

--- a/app/jobs/sync_publisher_promo_stats_job.rb
+++ b/app/jobs/sync_publisher_promo_stats_job.rb
@@ -3,12 +3,17 @@ class SyncPublisherPromoStatsJob < ApplicationJob
   include PromosHelper
   queue_as :transactional
 
-  def perform(promo_id: active_promo_id)
-    # Might be able to select fewer with a more specific query
-    publishers = Publisher.where(promo_enabled_2018q1: true)
+  # Syncs promo stats for all publishers by default
+  # If a publisher is provided, sync stats for only that publisher
 
-    publishers.find_each do |publisher|
+  def perform(promo_id: active_promo_id, publisher: nil)
+    if publisher
       PublisherPromoStatsFetcher.new(publisher: publisher, promo_id: promo_id).perform
+    else
+      publishers = Publisher.where(promo_enabled_2018q1: true)
+      publishers.find_each do |publisher|
+        PublisherPromoStatsFetcher.new(publisher: publisher, promo_id: promo_id).perform
+      end
     end
   end
 end

--- a/app/services/publisher_promo_stats_fetcher.rb
+++ b/app/services/publisher_promo_stats_fetcher.rb
@@ -18,11 +18,6 @@ class PublisherPromoStatsFetcher < BaseApiClient
     stats = JSON.parse(response.body)
     @publisher.promo_stats_2018q1 = stats
     @publisher.save!
-  rescue => e
-    require "sentry-raven"
-    Rails.logger.error("PublisherPromoStatsFetcher #perform error: #{e}, publisher: #{@publisher}")
-    Raven.capture_exception("PublisherPromoStatsFetcher #perform error: #{e}, publisher: #{@publisher}")
-    nil
   end
 
   def perform_offline

--- a/test/jobs/sync_publisher_promo_stats_job_test.rb
+++ b/test/jobs/sync_publisher_promo_stats_job_test.rb
@@ -2,18 +2,40 @@ require 'test_helper'
 
 class SyncPublisherPromoStatsJobTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
-  test "updates stats" do
-    publisher = publishers(:completed)
-    sign_in publisher
+  include ActiveJob::TestHelper
+  
+  test "updates stats for all publishers" do
+    publisher_one = publishers(:completed)
+    publisher_two = publishers(:global_media_group)
 
-    assert_equal publisher.promo_stats_2018q1, {} # sanity check
-
-    # enable promo and register channel
-    post promo_registrations_path
+    enable_promo_for_publisher(publisher_one)
+    enable_promo_for_publisher(publisher_two)
 
     SyncPublisherPromoStatsJob.perform_now
+
+    publisher_one.reload
+    publisher_two.reload
+
+    assert_not_equal publisher_one.promo_stats_2018q1, {}
+    assert_not_equal publisher_two.promo_stats_2018q1, {}
+  end
+
+  test "test updates stats for a single publisher" do
+    publisher = publishers(:completed)
+    enable_promo_for_publisher(publisher)
+
+    SyncPublisherPromoStatsJob.new(publisher: publisher).perform_now
     publisher.reload
 
     assert_not_equal publisher.promo_stats_2018q1, {}
+  end
+
+  private
+
+  # Requires a verified publisher
+  def enable_promo_for_publisher(publisher)
+    sign_in publisher
+    assert_equal publisher.promo_stats_2018q1, {} # sanity check
+    post promo_registrations_path
   end
 end


### PR DESCRIPTION
Resolves #821 

* Use SyncPublisherPromoStatsJob in `PublishersController#home` to make stats refresh async

* Adjust SyncPublisherPromoStatsJob to be able to be used for a single publisher

* Adjust SyncPublisherPromoStatsJobTest

* Remove `publisher` from sentry call in PublisherPromoStatsFetcher

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
