### PR TITLE
 Resolve Uphold disconnection / reauthorization issues

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -146,16 +146,6 @@ class Publisher < ApplicationRecord
     save!
   end
 
-  def uphold_complete?
-    # check the wallet to see if the connection to uphold has been been denied
-    action = wallet.try(:status).try(:[], 'action')
-    if action == 're-authorize' || action == 'authorize'
-      false
-    else
-      self.uphold_verified || self.uphold_access_parameters.present?
-    end
-  end
-
   def uphold_status
     if self.uphold_verified
       :verified

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -79,13 +79,6 @@ class Publisher < ApplicationRecord
 
     # if the wallet call fails the wallet will be nil
     if @_wallet
-      # Reset the uphold_verified if eyeshade thinks we need to re-authorize (or authorize for the first time)
-      save_needed = false
-      if self.uphold_verified && ['re-authorize', 'authorize'].include?(@_wallet.status['action'])
-        self.uphold_verified = false
-        save_needed = true
-      end
-
       # Initialize the default_currency from the wallet, if it exists
       if self.default_currency.nil?
         default_currency_code = @_wallet.try(:wallet_details).try(:[], 'defaultCurrency')
@@ -146,15 +139,18 @@ class Publisher < ApplicationRecord
     save!
   end
 
+  def uphold_reauthorization_needed?
+    self.uphold_verified? &&
+      ['re-authorize', 'authorize'].include?(self.wallet.try(:status).try(:[], 'action'))
+  end
+
   def uphold_status
-    if self.uphold_verified
-      :verified
+    if self.uphold_verified?
+      self.uphold_reauthorization_needed? ? :reauthorization_needed : :verified
     elsif self.uphold_access_parameters.present?
       :access_parameters_acquired
     elsif self.uphold_code.present?
       :code_acquired
-    elsif self.wallet.try(:status).try(:[], 'action') == 're-authorize'
-      :reauthorization_needed
     else
       :unconnected
     end

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -144,7 +144,7 @@ class PublisherTest < ActiveSupport::TestCase
     refute_nil publisher.default_currency
   end
 
-  test "when wallet is gotten uphold_verified will be reset if the wallet status directs it" do
+  test "when wallet is retrieved uphold_status will reflect if reauthorization is needed" do
     prev_offline = Rails.application.secrets[:api_eyeshade_offline]
     begin
       Rails.application.secrets[:api_eyeshade_offline] = false
@@ -166,7 +166,8 @@ class PublisherTest < ActiveSupport::TestCase
       end
 
       publisher.wallet
-      refute publisher.uphold_verified
+      assert publisher.uphold_verified?
+      assert publisher.uphold_reauthorization_needed?
       assert_equal :reauthorization_needed, publisher.uphold_status
 
     ensure


### PR DESCRIPTION
When eyeshade responds that Uphold authorization / reauthorization is needed, the `uphold_verified` status should not be revoked immediately, because this status can be resolved either by a user or by Uphold without involving Brave. Instead `:reauthorization_needed` should be viewed as a a substate of `:verified`.

This approach also fixes the case in which a user has explicitly disconnected their Uphold account. They will always be shown a status of “Not connected” and never be shown “Connection problems”.

This PR also removes the now unused `Publisher#uphold_complete?` method.

Fixes #841

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
