### PR TITLE
Revert "Merge pull request #855 from yachtcaptain23/feature/verificat…

### DIFF
--- a/app/controllers/api/channels_controller.rb
+++ b/app/controllers/api/channels_controller.rb
@@ -7,7 +7,6 @@ class Api::ChannelsController < Api::BaseController
 
   before_action :ensure_json_content_type,
                 only: %i(create)
-  before_action :get_current_channel, only: :verification_status
 
   include PublishersHelper
 
@@ -81,25 +80,6 @@ class Api::ChannelsController < Api::BaseController
     render(json: channel.details, status: :ok)
   end
 
-  def verification_status
-    if @current_channel.verified?
-      render(
-        json: {
-          status: "success",
-          verificationId: @current_channel.id
-        },
-        status: :ok
-      ) and return
-    else
-      render(
-        json: {
-          status: "failure"
-        },
-        status: :ok
-      ) and return
-    end
-  end
-
   private
 
   def require_owner
@@ -131,9 +111,5 @@ class Api::ChannelsController < Api::BaseController
   def site_channel_details_params
     details_params = params[:channel].permit(:brave_publisher_id)
     details_params
-  end
-
-  def get_current_channel
-    @current_channel = Channel.find(params[:channel_id])
   end
 end

--- a/app/helpers/channels_helper.rb
+++ b/app/helpers/channels_helper.rb
@@ -65,9 +65,9 @@ module ChannelsHelper
 
   def channel_verification_details(channel)
     if channel.verification_failed?
-      channel.verification_details || I18n.t("helpers.channels.generic_verification_failure")
+      channel.verification_details || t("helpers.channels.generic_verification_failure")
     elsif channel.verification_started?
-      I18n.t("helpers.channels.verification_in_progress")
+      t("helpers.channels.verification_in_progress")
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,9 +79,6 @@ Rails.application.routes.draw do
       end
     end
     resources :tokens, only: %i(index)
-    resources :channels, constraints: { channel_id: %r{[^\/]+} } do
-      get :verification_status
-    end
   end
 
   resources :errors, only: [], path: "/" do

--- a/test/controllers/api/channels_controller_test.rb
+++ b/test/controllers/api/channels_controller_test.rb
@@ -3,7 +3,6 @@ require "shared/mailer_test_helper"
 
 class Api::ChannelsControllerTest < ActionDispatch::IntegrationTest
   include ActionMailer::TestHelper
-  include Devise::Test::IntegrationHelpers
 
   test "can get owner's youtube channel by identifier" do
     channel = channels(:global_yt2)
@@ -135,37 +134,4 @@ class Api::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert channel.created_via_api?
   end
 
-  test "a channel's verification status can be polled via api" do
-    publisher = publishers(:default)
-    channel = channels(:new_site)
-    sign_in publisher
-
-    channel.verification_started!
-
-    get api_channel_verification_status_path(channel)
-
-    assert_response 200
-    assert_match(
-      '{"status":"started",' +
-       '"details":"Verification in progress"}',
-          response.body)
-
-    channel.verification_failed!('something happened')
-
-    get "/api/channels/#{channel.id}/verification_status"
-    assert_response 200
-    assert_match(
-      '{"status":"failed",' +
-        '"details":"something happened"}',
-      response.body)
-
-    channel.verification_succeeded!
-
-    get "/api/channels/#{channel.id}/verification_status"
-    assert_response 200
-    assert_match(
-      '{"status":"verified",' +
-        '"details":null}',
-      response.body)
-  end
 end


### PR DESCRIPTION
…ion_status_channel_and_verified_time"

This reverts commit 8c1090c848386d74ae820986535b610dcfbeffa0, reversing
changes made to 657dbc487c69cacbaf8d24a5c6f7b51603c60538.

Revert "Merge pull request #853 from yachtcaptain23/feature/verification_status_channel_and_verified_time"

This reverts commit 5efbecbdd5877a30a15e922063ea9727137a9da9, reversing
changes made to 340457eafb96f4c6d8cde57508743d3bb397e31c.

Closes #856

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
