### PR TITLE
Dev: Easier to use local Eyeshade

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -74,7 +74,6 @@ development:
   api_promo_base_uri: "" # http://127.0.0.1:8194
   active_promo_id: "free-bats-2018q1"
   base_referral_url: "brave.com"
-  api_eyeshade_offline: true
   host_inspector_offline: true
   internal_email: brave-publishers@localhost.local
   support_email: brave-publishers@localhost.local


### PR DESCRIPTION
To use Eyeshade in dev currently requires editing out the secrets.yml `dev.api_eyeshade_offline` which is not obvious. This fixes it so if you specify env API_EYESHADE_BASE_URI it will work as expected, and otherwise fallback to offline mode.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
