### PR TITLE
Better handle scenarios in which a publisher statement is empty

### DIFF
--- a/app/jobs/sync_publisher_statement_job.rb
+++ b/app/jobs/sync_publisher_statement_job.rb
@@ -16,6 +16,7 @@ class SyncPublisherStatementJob < ApplicationJob
 
     publisher_statement = PublisherStatement.find(publisher_statement_id)
 
+    # Sends notification email to publisher on successful sync of statement
     PublisherStatementSyncer.new(publisher_statement: publisher_statement).perform
 
     publisher_statement.reload

--- a/app/services/publisher_statement_syncer.rb
+++ b/app/services/publisher_statement_syncer.rb
@@ -9,12 +9,11 @@ class PublisherStatementSyncer
     return if publisher_statement.contents.present?
 
     contents = PublisherStatementGetter.new(publisher_statement: publisher_statement).perform
-    if contents
+    if contents.present?
       publisher_statement.contents = contents
       publisher_statement.save!
 
-      # TODO uncomment when statement notification emails are sending
-      # PublisherMailer.statement_ready(publisher_statement).deliver_later
+      PublisherMailer.statement_ready(publisher_statement).deliver_later
     end
   end
 end


### PR DESCRIPTION
If a publisher’s statement is returned as an empty string, then we don’t want to notify the publisher that it is ready.

We need to check that `contents.present?` instead of just the truthiness of `contents`. In this way, the same logic is applied in both PublisherStatementSyncer and SyncPublisherStatementJob for evaluating the presence of a statement’s contents.

This fixes an error that resulted because eyeshade was returning statement URLs that required a redirect to fetch.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
