### PR TITLE
Update attr_encrypted gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'activerecord-session_store'
 gem "api-pagination"
 
 # Encrypt DB data at rest
-gem "attr_encrypted", "~> 3.0.0"
+gem "attr_encrypted", "~> 3.1.0"
 
 gem "bootstrap", "~> 4.0.0.beta3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       io-like (~> 0.3.0)
     arel (7.1.4)
     ast (2.3.0)
-    attr_encrypted (3.0.3)
+    attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
     autoprefixer-rails (7.2.5)
       execjs
@@ -426,7 +426,7 @@ DEPENDENCIES
   activejob-traffic_control
   activerecord-session_store
   api-pagination
-  attr_encrypted (~> 3.0.0)
+  attr_encrypted (~> 3.1.0)
   bootstrap (~> 4.0.0.beta3)
   brakeman
   bundler-audit


### PR DESCRIPTION
Updates the `attr_encrypted` gem to 3.1.0.

Captures an exception to sentry if we encounter a nil token.

Fixes #907 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
