### PR TITLE
Fix minor issues with new statements page

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -227,7 +227,7 @@ module PublishersHelper
   end
 
   def statement_period_date(date)
-    date.strftime('%B %e')
+    date.strftime('%b %e')
   end
 
   def link_to_most_recent_statement

--- a/app/javascript/publishers/statements.js
+++ b/app/javascript/publishers/statements.js
@@ -69,7 +69,10 @@ document.addEventListener('DOMContentLoaded', function() {
         })
         .then(function() {
           dynamicEllipsis.stop(statementDownloadDiv);
-          statementDownloadDiv.innerHTML = '<span>Ready</span><a class="download" href="/publishers/statement?id=' + statementId + '">Download</a>';
+          statementDownloadDiv.innerHTML = '<span>Ready</span>' +
+            '<a class="download" data-piwik-action="DownloadPublisherStatement" ' +
+               'data-piwik-name="Clicked" data-piwik-value="Dashboard" ' +
+               'href="/publishers/statement?id=' + statementId + '">Download</a>';
           spinner.hide();
           generating = false;
         })

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -5,7 +5,11 @@ noscript
   = render partial: 'channel_taken', locals: { channel_id: flash[:taken_channel_id] }
 
 - content_for(:navbar_content_right) do
-  .title= t ".title"
+  = link_to( \
+    t("shared.dashboard"), \
+    home_publishers_path, \
+    class: 'title' \
+  )
   = render partial: "choose_channel_button"
 
 .dashboard

--- a/app/views/publishers/statements.html.slim
+++ b/app/views/publishers/statements.html.slim
@@ -34,6 +34,6 @@ noscript
               .status
                 - if s.encrypted_contents?
                   span= 'Ready'
-                  = link_to(t("shared.download"), statement_publishers_url(id: s.id), class: 'download')
+                  = link_to(t("shared.download"), statement_publishers_url(id: s.id), class: 'download', "data-piwik-action": "DownloadPublisherStatement", "data-piwik-name": "Clicked", "data-piwik-value": "Dashboard")
                 - else
                   = t ".statements.delayed"

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -579,7 +579,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_response 200
     assert_match(
       '{"id":"' + publisher_statement.id + '",' +
-        '"date":"' + publisher_statement.created_at.strftime('%B %e') + '",' +
+        '"date":"' + publisher_statement.created_at.strftime('%b %e') + '",' +
         '"period":"All dates"}',
       response.body)
   end


### PR DESCRIPTION
* Ensure that the short date (`Jun` instead of `June`) will always be used for statements
* Track statement downloads with piwik
* Converts the "Dashboard" title on the home page to a link for consistency with the statements page

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
