### PR TITLE
Obfuscate publisher information in slack and papertrail logs

### DIFF
--- a/app/controllers/totp_registrations_controller.rb
+++ b/app/controllers/totp_registrations_controller.rb
@@ -21,7 +21,7 @@ class TotpRegistrationsController < ApplicationController
 
       handle_redirect_after_2fa_registration
     else
-      Rails.logger.info "ROTP::TOTP! Failed to verify unsaved #{totp_registration} for publisher #{current_publisher} with password '#{params[:totp_password]}'"
+      Rails.logger.info "ROTP::TOTP! Failed to verify unsaved #{totp_registration} for publisher #{current_publisher.owner_identifier} with password '#{params[:totp_password]}'"
       flash[:alert] = t("shared.invalid_totp")
       redirect_to new_totp_registration_path
     end

--- a/app/jobs/clean_stale_uphold_data_job.rb
+++ b/app/jobs/clean_stale_uphold_data_job.rb
@@ -11,8 +11,8 @@ class CleanStaleUpholdDataJob < ApplicationJob
       publisher.uphold_code = nil
       publisher.save!
       n += 1
-      Rails.logger.info("Cleaned stalled uphold code for #{publisher.id}.")
-      Raven.capture_message("Cleaned stalled uphold code for #{publisher.id}.")
+      Rails.logger.info("Cleaned stalled uphold code for #{publisher.owner_identifier}.")
+      Raven.capture_message("Cleaned stalled uphold code for #{publisher.owner_identifier}.")
     end
     Rails.logger.info("CleanStaleUpholdDataJob cleared #{n} stalled uphold codes.")
 
@@ -24,8 +24,8 @@ class CleanStaleUpholdDataJob < ApplicationJob
       publisher.uphold_access_parameters = nil
       publisher.save!
       n += 1
-      Rails.logger.info("Cleaned stalled uphold access parameters for #{publisher.id}.")
-      Raven.capture_message("Cleaned stalled uphold access parameters for #{publisher.id}.")
+      Rails.logger.info("Cleaned stalled uphold access parameters for #{publisher.owner_identifier}.")
+      Raven.capture_message("Cleaned stalled uphold access parameters for #{publisher.owner_identifier}.")
     end
     Rails.logger.info("CleanStaleUpholdDataJob cleared #{n} stalled uphold access parameters.")
   end

--- a/app/services/promo_registrar.rb
+++ b/app/services/promo_registrar.rb
@@ -34,7 +34,7 @@ class PromoRegistrar < BaseApiClient
   rescue Faraday::Error => e
     if e.response[:status] == 409
       Rails.logger.warn("PromoRegistrar #register_channel returned 409, channel already registered.  Using PromoRegistrationGetter to get the referral_code.")
-      Rails.logger.info("Attempted to register channel #{channel.id}, but it already registered.  Saving referral code #{referral_code}.")
+      Rails.logger.info("Attempted to register channel #{channel.details.channel_identifier}, but it already registered.  Saving referral code #{referral_code}.")
       referral_code = PromoRegistrationGetter.new(publisher: @publisher, channel: channel).perform
       referral_code
     else

--- a/app/services/publisher_promo_token_generator.rb
+++ b/app/services/publisher_promo_token_generator.rb
@@ -24,7 +24,7 @@ class PublisherPromoTokenGenerator < BaseService
     already_has_promo_token = publisher.promo_token_2018q1.present?
 
     if already_has_promo_token && !@force
-      Rails.logger.info("Publisher #{@publisher} already has a promo token, use force=true to overwrite.")
+      Rails.logger.info("Publisher #{@publisher.owner_identifier} already has a promo token, use force=true to overwrite.")
       nil
     else
       publisher.promo_token_2018q1 = SecureRandom.hex(32)

--- a/app/services/site_channel_verifier.rb
+++ b/app/services/site_channel_verifier.rb
@@ -50,7 +50,7 @@ class SiteChannelVerifier < BaseService
       else
         verified_channel.verification_awaiting_admin_approval!
         InternalMailer.channel_verification_approval_required(channel: verified_channel).deliver_later
-        SlackMessenger.new(message: "*Admin Action Required:* *#{verified_channel.publication_title}* on the restriction list verified by #{verified_channel.publisher.name} (#{verified_channel.publisher.email}); id=#{verified_channel.id}").perform
+        SlackMessenger.new(message: "*Admin Action Required:* *#{verified_channel.publication_title}* on the restriction list verified by #{verified_channel.publisher.owner_identifier}; id=#{verified_channel.details.channel_identifier}").perform
         return
       end
     end
@@ -65,7 +65,7 @@ class SiteChannelVerifier < BaseService
 
   def verified_channel_post_verify
     MailerServices::VerificationDoneEmailer.new(verified_channel: verified_channel).perform
-    SlackMessenger.new(message: "*#{verified_channel.publication_title}* verified by #{verified_channel.publisher.name} (#{verified_channel.publisher.email}); id=#{verified_channel.id}").perform
+    SlackMessenger.new(message: "*#{verified_channel.publication_title}* verified by owner #{verified_channel.publisher.owner_identifier}; id=#{verified_channel.details.channel_identifier}").perform
 
     # Let eyeshade know about the new Publisher
     begin


### PR DESCRIPTION
Resolves #932 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.
- [x] Integrated piwik/matomo (for code that adds new buttons).
- [x] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
