### PR TITLE
Remove duplicate gems from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,16 +134,6 @@ group :development do
   gem "i18n-tasks", "~> 0.9.12"
 end
 
-group :development, :test do
-  # Call "byebug" anywhere in the code to stop execution and get a debugger console
-  gem "byebug", platform: :mri
-end
-
-group :development, :staging do
-  # Offline domain normalization
-  gem "domain_name", require: false
-end
-
 group :test do
   # Clean state in-between tests which modify the DB
   gem "database_cleaner"


### PR DESCRIPTION
Duplicated gem entries in the Gemfile were removed. I suspect these came back during a rebase.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))