### PR TITLE
Handles unescaped hyphens in regex

### DIFF
--- a/app/models/json_builders/identity_json_builder.rb
+++ b/app/models/json_builders/identity_json_builder.rb
@@ -6,7 +6,7 @@ class JsonBuilders::IdentityJsonBuilder
   attr_reader :channel_detail, :publisher_name, :errors
 
   # Copy of bat-ledger/node_modules/bat-publisher/index.js `providerRE`
-  URL_REGULAR_EXPRESSION = /^([A-Za-z0-9][A-Za-z0-9-]{0,62})#([A-Za-z0-9][A-Za-z0-9-]{0,62}):(([A-Za-z0-9-._~]|%[0-9A-F]{2})+)$/
+  URL_REGULAR_EXPRESSION = /^([A-Za-z0-9][A-Za-z0-9]{0,62})#([A-Za-z0-9][A-Za-z0-9]{0,62}):(([A-Za-z0-9\-._~]|%[0-9A-F]{2})+)$/
 
 
   def initialize(publisher_name:)


### PR DESCRIPTION
Removes hyphens in first two sections, which are under Publishers control and not used
Escapes the last hyphen as a valid character for twitch or youtube ids

Fixes #919 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
