### PR TITLE
Auto calculated Next Deposit Date

### DIFF
--- a/app/assets/stylesheets/pages/home.scss
+++ b/app/assets/stylesheets/pages/home.scss
@@ -351,6 +351,7 @@
     font-weight: 300;
     letter-spacing: 0.5px;
     white-space: nowrap;
+    padding-left: 75px;
 
     #balance_pending_message {
       opacity: .6;

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -31,6 +31,13 @@ module PublishersHelper
     I18n.t("helpers.publisher.balance_error")
   end
 
+  def next_deposit_date(today = DateTime.now)
+    if today.day > 8
+      today = today + 1.month
+    end
+    today.strftime("%B 8th")
+  end
+
   def publisher_converted_balance(publisher)
     currency = publisher.default_currency
     return if currency == "BAT" || currency.blank?

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -17,10 +17,9 @@ noscript
   #uphold_status class=uphold_status_class(current_publisher)
     .row
       .col
-        h4.balance-header
-          span = t ".balance_pending"
-          span#balance_pending_message = t ".balance_pending_message"
         .balance
+          h4.balance-header
+            span = t ".balance_pending"
           .float-left
             = image_tag("bat-logo@2x.png", class: "", width: 60, height: 57)
           .float-left.amounts
@@ -29,6 +28,9 @@ noscript
               span.bat-code= " BAT"
             .converted#converted_amount
               = publisher_converted_balance(current_publisher)
+            .next_deposit_date
+              span = t ".next_deposit_date"
+              span= next_deposit_date
       - if promo_running?
         .col
           .promo-panel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,7 +308,7 @@ en:
       noscript: Please enable JavaScript in your browser if you wish to interact with the dashboard.
       title: Dashboard
       balance_pending: CURRENT CONTRIBUTION BALANCE
-      balance_pending_message: (Next payment occurs June 6, 2018)
+      next_deposit_date: "Next Deposit Date: "
 
       add_channel_cta: Add a website or YouTube channel to see how much your fans on Brave have contributed so far.
       uphold:

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -149,4 +149,10 @@ class PublishersHelperTest < ActionView::TestCase
     publisher.uphold_status = :unconnected
     assert_equal "uphold-unconnected", uphold_status_class(publisher)
   end
+
+  test "next settlement date is current month if <= 8th, otherwise next month" do
+    assert_equal "June 8th", next_deposit_date(DateTime.parse("June 7, 2018"))
+    assert_equal "June 8th", next_deposit_date(DateTime.parse("June 8, 2018"))
+    assert_equal "July 8th", next_deposit_date(DateTime.parse("June 9, 2018"))
+  end
 end


### PR DESCRIPTION
![screen shot 2018-06-12 at 2 01 56 pm](https://user-images.githubusercontent.com/29154/41308181-37e2a990-6e49-11e8-9759-d9b80adf3b7d.png)

Note, I display the date as "July 8th" instead of "July 8". I can change this back if that's not desired.

Fixes #947, #938

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))