### PR TITLE
Fix flappy test

### DIFF
--- a/test/controllers/admin/publishers_controller_test.rb
+++ b/test/controllers/admin/publishers_controller_test.rb
@@ -36,17 +36,11 @@ class Admin::PublishersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "raises error unless admin is on admin whitelist" do
-    class ActionDispatch::Request #rails 2: ActionController::Request
-      def remote_ip
-        '1.2.3.4' # not on whitelist
-      end
-    end
-
     admin = publishers(:admin)
     sign_in admin
 
     assert_raises(Ability::AdminNotOnIPWhitelistError) do
-      get admin_publishers_path
+      get admin_publishers_path, headers: { 'REMOTE_ADDR' => '1.2.3.4' } # not on whitelist
     end
   end
 end


### PR DESCRIPTION
Stop overriding the `remote_ip` method and set the ip in the header.

Fixes #968

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))