### PR TITLE
WIP: Feature/settlement info

### DIFF
--- a/app/assets/stylesheets/pages/home.scss
+++ b/app/assets/stylesheets/pages/home.scss
@@ -361,7 +361,7 @@
   #uphold_status {
     #uphold_status_display {
       vertical-align: top;
-      margin-bottom: 25px;
+      margin-bottom: 5px;
     }
     .deposit-currency {
       margin-top: 10px;
@@ -394,6 +394,36 @@
     .status-description {
       margin-top: 40px;
     }
+    #last_settlement {
+      &.settlement-made {
+        display: block;
+      }
+      &.no-settlement-made {
+        display: none;
+      }
+      .last-deposit {
+        font-size: $font-size-base;
+        vertical-align: top;
+        margin-top: 34px;
+        .amounts {
+          .bat-amount {
+            font-size: 30px;
+            color: #fc4145;
+            font-weight: 500;
+          }
+          .bat-code {
+            font-size: 16px;
+            color: #222326;
+            font-weight: 500;
+          }
+          .converted {
+            margin-top: -8px;
+            font-size: 14px;
+            color: $braveGray-4;
+          }
+        }
+      }
+    }
     #uphold_check_balance {
       margin-top: 2rem;
     }
@@ -401,6 +431,7 @@
       .status-summary .action,
       #uphold_dashboard,
       #uphold_connect,
+      #last_settlement,
       .statements-available {
         display: none;
       }
@@ -414,6 +445,7 @@
     }
     &.uphold-processing {
       #uphold_dashboard,
+      #last_settlement,
       .statements-available {
         display: none;
       }
@@ -438,8 +470,9 @@
         margin-top: 30px;
       }
       #uphold_dashboard,
+      #last_settlement,
       .status-summary .action .disconnect-uphold,
-      .statements-available {
+      .statements-available  {
         display: none;
       }
     }

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -33,7 +33,8 @@ class PublishersController < ApplicationController
   before_action :require_publisher_email_verified_through_youtube_auth,
                 only: %i(update_email)
   before_action :require_verified_publisher,
-    only: %i(disconnect_uphold
+    only: %i(balance
+             disconnect_uphold
              edit_payment_info
              generate_statement
              home
@@ -384,14 +385,12 @@ class PublishersController < ApplicationController
   end
 
   def balance
-    publisher = current_publisher
-    respond_to do |format|
-      format.json {
-        render(json: {
-            bat_amount: publisher_humanize_balance(current_publisher, "BAT"),
-            converted_balance: publisher_converted_balance(publisher)
-        }, status: 200)
-      }
+    wallet = current_publisher.wallet
+    if wallet
+      json = JsonBuilders::WalletJsonBuilder.new(wallet: wallet).build
+      render(json: json, status: :ok)
+    else
+      render(nothing: true, status: 404)
     end
   end
 

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -20,7 +20,9 @@ module PublishersHelper
   end
 
   def publisher_humanize_balance(publisher, currency)
-    if balance = publisher.wallet && publisher.wallet.contribution_balance
+    if balance = publisher.wallet &&
+        publisher.wallet.contribution_balance.is_a?(Eyeshade::Balance) &&
+        publisher.wallet.contribution_balance
       '%.2f' % balance.convert_to(currency)
     else
       I18n.t("helpers.publisher.balance_error")
@@ -34,7 +36,9 @@ module PublishersHelper
   def publisher_converted_balance(publisher)
     currency = publisher.default_currency
     return if currency == "BAT" || currency.blank?
-    if balance = publisher.wallet && publisher.wallet.contribution_balance
+    if balance = publisher.wallet &&
+        publisher.wallet.contribution_balance.is_a?(Eyeshade::Balance) &&
+        publisher.wallet.contribution_balance
       converted_amount = '%.2f' % balance.convert_to(currency)
       I18n.t("helpers.publisher.balance_pending_approximate", amount: converted_amount, code: currency)
     else
@@ -44,6 +48,49 @@ module PublishersHelper
     require "sentry-raven"
     Raven.capture_exception(e)
     I18n.t("helpers.publisher.balance_error")
+  end
+
+  def publisher_humanize_last_settlement(publisher, currency)
+    if balance = publisher.wallet &&
+        publisher.wallet.last_settlement_balance.is_a?(Eyeshade::Balance) &&
+        publisher.wallet.last_settlement_balance
+      '%.2f' % balance.convert_to(currency)
+    else
+      I18n.t("helpers.publisher.no_deposit")
+    end
+  rescue => e
+    require "sentry-raven"
+    Raven.capture_exception(e)
+    I18n.t("helpers.publisher.balance_error")
+  end
+
+  def publisher_converted_last_settlement(publisher)
+    currency = publisher.default_currency
+    return if currency == "BAT" || currency.blank?
+    if balance = publisher.wallet &&
+        publisher.wallet.last_settlement_balance.is_a?(Eyeshade::Balance) &&
+        publisher.wallet.last_settlement_balance
+      converted_amount = '%.2f' % balance.convert_to(currency)
+      I18n.t("helpers.publisher.balance_pending_approximate", amount: converted_amount, code: currency)
+    end
+  rescue => e
+    require "sentry-raven"
+    Raven.capture_exception(e)
+    I18n.t("helpers.publisher.balance_error")
+  end
+
+  def publisher_humanize_last_settlement_date(publisher)
+    if settlement_date = publisher.wallet &&
+        publisher.wallet.last_settlement_date.is_a?(Date) &&
+        publisher.wallet.last_settlement_date
+      settlement_date.strftime("%B %d, %Y")
+    else
+      I18n.t("helpers.publisher.no_deposit")
+    end
+  rescue => e
+    require "sentry-raven"
+    Raven.capture_exception(e)
+    I18n.t("helpers.publisher.no_deposit")
   end
 
   def publisher_channel_balance(publisher, channel_identifier, currency)
@@ -115,6 +162,14 @@ module PublishersHelper
       'uphold-reauthorization-needed'
     else
       'uphold-unconnected'
+    end
+  end
+
+  def last_settlement_class(publisher)
+    if publisher.wallet.last_settlement_date
+      'settlement-made'
+    else
+      'no-settlement-made'
     end
   end
 

--- a/app/javascript/utils/dates.js
+++ b/app/javascript/utils/dates.js
@@ -1,0 +1,3 @@
+export function formatFullDate(date) {
+  return date.toLocaleDateString("en-US", { month: 'long', day: '2-digit', year: 'numeric' });
+}

--- a/app/javascript/wallet.js
+++ b/app/javascript/wallet.js
@@ -1,0 +1,91 @@
+export class Wallet {
+  constructor(data) {
+    this._raw = data;
+
+    this._providerWallet = data.providerWallet;
+
+    this._status = data.status;
+
+    this._channelBalances = data.channelBalances ? data.channelBalances : {};
+
+    if ((data.lastSettlement) && (data.lastSettlement.balance) && (data.lastSettlement.balance.probi)) {
+      this._lastSettlement = {
+        amount: this._formatAmount(Wallet._probi_to_bat(data.lastSettlement.balance.probi)),
+        date: new Date(data.lastSettlement.date)
+      };
+    }
+    else {
+      this._lastSettlement = {
+        amount: undefined,
+        date: undefined
+      };
+    }
+
+    // Total the channel balances
+    let total = 0.0;
+    for (let key in this._channelBalances) {
+      total = total + this._getChannelBat(key);
+    }
+    this._totalAmount = this._formatAmount(total);
+  }
+
+  get status() {
+    return this._status;
+  }
+
+  get providerWallet() {
+    return this._providerWallet;
+  }
+
+  get lastSettlement() {
+    return this._lastSettlement;
+  }
+
+  get channelBalances() {
+    return this._channelBalances;
+  }
+
+  get totalAmount() {
+    return this._totalAmount;
+  }
+
+  getChannelAmount(channel) {
+    return this._formatAmount(this._getChannelBat(channel));
+  }
+
+  _convertBatToDefaultCurrency(bat) {
+    if ((this.providerWallet === undefined) || (this.providerWallet.rates === undefined)) {
+      return undefined;
+    }
+
+    let default_currency = this._providerWallet.defaultCurrency;
+
+    if (default_currency === "BAT") {
+      return bat;
+    }
+
+    let rate = Number(this.providerWallet.rates[default_currency]);
+    return bat * rate;
+  }
+
+  _formatAmount(bat) {
+    return {
+      bat: Number(bat),
+      converted: this._convertBatToDefaultCurrency(bat),
+      currency: this.providerWallet ? this.providerWallet.defaultCurrency : undefined
+    };
+  }
+
+  static _probi_to_bat(probi) {
+    return Number(probi) / 1E18;
+  }
+
+  _getChannelBat(channel) {
+    let balance = 0;
+    if (this._channelBalances[channel].probi) {
+      balance = Wallet._probi_to_bat(this._channelBalances[channel].probi);
+    }
+
+    return balance;
+  }
+}

--- a/app/models/json_builders/wallet_json_builder.rb
+++ b/app/models/json_builders/wallet_json_builder.rb
@@ -1,0 +1,60 @@
+module JsonBuilders
+  class WalletJsonBuilder
+
+    attr_reader :wallet
+
+    def initialize(wallet:)
+      @wallet = wallet
+    end
+
+    def build
+      Jbuilder.encode do |json|
+
+        if @wallet.last_settlement_date &&
+            @wallet.last_settlement_balance &&
+            @wallet.last_settlement_balance.is_a?(Eyeshade::Balance)
+          json.lastSettlement do
+            json.date @wallet.last_settlement_date
+
+            last_settlement_balance = @wallet.last_settlement_balance
+            json.balance do
+              build_balance(json, last_settlement_balance)
+            end
+          end
+        end
+
+        if @wallet.wallet_details['provider']
+          json.providerWallet do
+            json.provider @wallet.wallet_details['provider']
+            json.authorized @wallet.wallet_details['authorized']
+            json.defaultCurrency @wallet.wallet_details['defaultCurrency']
+            json.rates @wallet.rates
+            json.availableCurrencies @wallet.wallet_details['availableCurrencies']
+            json.possibleCurrencies @wallet.wallet_details['possibleCurrencies']
+            json.scope @wallet.wallet_details['scope']
+          end
+        end
+
+        json.channelBalances do
+          @wallet.channel_balances.each_pair do |identifier, channel_balance|
+            build_channel(json, identifier, channel_balance)
+          end
+        end
+
+        json.status @wallet.status
+      end
+    end
+
+    private
+
+    def build_balance(json, balance)
+      json.probi balance.probi.to_s
+    end
+
+    def build_channel(json, identifier, channel_balance)
+      json.set! identifier do
+        build_balance(json, channel_balance)
+      end
+    end
+  end
+end

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -58,7 +58,7 @@ noscript
                     .promo-panel-number
                       = confirmed_referral_downloads(current_publisher)
                 .promo-flex-row.promo-flex-row-sub
-                    =t("promo.dashboard.check_statement")
+                  =t("promo.dashboard.check_statement")
             - else
               .promo-panel-item.promo-panel-item-alert
                 #promo-panel-alert
@@ -84,22 +84,38 @@ noscript
                 script type="text/html" id="disconnect-uphold-js"
                   = render "publishers/disconnect_uphold_modal"
                 = form_for(current_publisher, url: disconnect_uphold_publishers_path, html: {id: "disconnect_uphold"}) do |f|
+          .dashboard-panel--content#uphold_connect
             .status-description
               = uphold_status_description(current_publisher)
-          .dashboard-panel--content#uphold_connect
             = link_to(uphold_authorization_description(current_publisher),
                       uphold_authorization_endpoint(current_publisher), class: "btn btn-primary", :"data-test" => "reconnect-button")
           .dashboard-panel--content#uphold_dashboard
-            - available_currencies = publisher_available_currencies(current_publisher)
-            - if available_currencies
+            .deposit-currency-label
               = form_for(current_publisher, url: publishers_path, html: { id: "update_default_currency_form" }) do |f|
-                .deposit-currency-label= t ".uphold.deposit_currency_label"
-                .deposit-currency
-                  span= t ".uphold.deposit_currency"
-                  span#default_currency_code= f.select(:default_currency, options_for_select(publisher_available_currencies(current_publisher), current_publisher.default_currency))
-            - else
-              .unavailable-currencies= t ".uphold.no_currencies_available"
-            = link_to(t(".uphold.check_balance"), uphold_dashboard_url, class: "btn btn-primary", id: "uphold_check_balance", :"data-piwik-action" => "CheckUpholdBalanceClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
+                = t ".uphold.deposit_currency_label"
+                span#default_currency_code
+                  - available_currencies = publisher_available_currencies(current_publisher)
+                  - if available_currencies
+                    = f.select(:default_currency, options_for_select(available_currencies, current_publisher.default_currency))
+                  - else
+                    = t ".uphold.no_currencies_available"
+            .last-deposit-date
+              = t ".uphold.last_deposit_date"
+              span.deposit-date#last_deposit_date= publisher_humanize_last_settlement_date(current_publisher)
+          .dashboard-panel--content#last_settlement class=last_settlement_class(current_publisher)
+            .last-deposit
+              = t ".uphold.last_deposit"
+              .amounts
+                .bat
+                  - last_depost_balance = publisher_humanize_last_settlement(current_publisher, "BAT")
+                  span.bat-amount#last_deposit_bat_amount= last_depost_balance
+                  - unless last_depost_balance == I18n.t("helpers.publisher.no_deposit")
+                    span.bat-code= " BAT"
+                .converted#last_deposit_converted_amount
+                  = publisher_converted_last_settlement(current_publisher)
+              = link_to(t(".uphold.check_balance"), uphold_dashboard_url, class: "btn btn-primary",
+                      id: "uphold_check_balance", :"data-piwik-action" => "CheckUpholdBalanceClicked",
+                      :"data-piwik-name" => "Clicked", :"data-piwik-value" => "Dashboard")
       .col
         .dashboard-panel--wrapper
           .dashboard-panel--header#publishers_statements
@@ -170,7 +186,8 @@ noscript
               - else
                 .channel-status.float-right
                   .bat-channel
-                    h4.bat-channel--amount= publisher_channel_balance(current_publisher, channel.details.channel_identifier, "BAT")
+                    h4.bat-channel--amount id=("channel_amount_bat_#{channel.details.channel_identifier}")
+                      = publisher_channel_balance(current_publisher, channel.details.channel_identifier, "BAT")
                     span.bat-channel--currency= " BAT"
                     .bat-channel--period
                       = t(".channel_balance_period")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,8 @@ en:
       verification_awaiting_admin_approval: Awaiting admin approval
     publisher:
       balance_error: Unavailable
-      balance_pending_approximate: Approximately %{amount} %{code}
+      no_deposit: No deposit made yet
+      balance_pending_approximate: ~ %{amount} %{code}
       channel_type:
         youtube: YouTube channel
         website: Website
@@ -312,12 +313,14 @@ en:
       add_channel_cta: Add a website or YouTube channel to see how much your fans on Brave have contributed so far.
       uphold:
         heading: Your Uphold Wallet
-        deposit_currency_label: "Current deposit currency:"
+        deposit_currency_label: "Deposit Currency: "
         deposit_currency: "BAT to "
         check_balance: Check Balance
         no_currencies_available: We're unable to load deposit currencies from Uphold at this time. Please check again later.
         connect: Connect
         disconnect: Disconnect
+        last_deposit: LAST DEPOSIT
+        last_deposit_date: "Last Deposit Date: "
       statements:
         heading: Statements
         statement_name: "%{created_at} statement - %{period}"

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -3,15 +3,22 @@ require "eyeshade/balance"
 module Eyeshade
   class Wallet
     attr_reader :wallet_json, :status, :contribution_balance, :wallet_details,
-                :channel_json, :channel_balances
+                :channel_json, :channel_balances, :rates, :last_settlement_balance, :last_settlement_date
 
     def initialize(wallet_json:, channel_json:)
       @wallet_json = wallet_json
       @channel_json = channel_json
+
       @status = wallet_json["status"].is_a?(Hash) ? wallet_json["status"] : {}
+      @rates = wallet_json["rates"].is_a?(Hash) ? wallet_json["rates"] : {}
+
+      if wallet_json["lastSettlement"].is_a?(Hash)
+        @last_settlement_balance = Eyeshade::Balance.new(balance_json: wallet_json["lastSettlement"].merge({'rates' => rates}))
+        @last_settlement_date = Time.at(wallet_json["lastSettlement"]["timestamp"]/1000).to_datetime
+      end
 
       balance_json = wallet_json["contributions"].is_a?(Hash) ? wallet_json["contributions"] : {}
-      balance_json["rates"] = wallet_json["rates"].is_a?(Hash) ? wallet_json["rates"] : {}
+      balance_json["rates"] = @rates
 
       @contribution_balance = Eyeshade::Balance.new(balance_json: balance_json)
 

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -591,7 +591,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     get balance_publishers_path, headers: { 'HTTP_ACCEPT' => "application/json" }
 
     assert_response 200
-    assert_equal '{"bat_amount":"38077.50","converted_balance":"Approximately 9001.00 USD"}',
+    assert_equal '{"providerWallet":{"provider":"uphold","authorized":true,"defaultCurrency":"USD","rates":{"BTC":5.418424016883016e-05,"ETH":0.000795331082073117,"USD":0.2363863335301452,"EUR":0.20187818378874756,"GBP":0.1799810085548496},"availableCurrencies":["USD","EUR","BTC","ETH","BAT"],"possibleCurrencies":null,"scope":null},"channelBalances":{"uphold_connected.org":{"probi":"38077497398351695427000"},"twitch#channel:ucTw":{"probi":"38077497398351695427000"}},"status":{"provider":"uphold"}}',
                  response.body
   end
 

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -26,7 +26,7 @@ class PublishersHelperTest < ActionView::TestCase
     publisher = publishers(:default)
     publisher.default_currency = "USD"
     publisher.save
-    assert_dom_equal %{Approximately 9001.00 USD}, publisher_converted_balance(publisher)
+    assert_dom_equal %{~ 9001.00 USD}, publisher_converted_balance(publisher)
   end
 
   test "publisher_converted_balance should return `Unavailable` when no wallet is set" do
@@ -66,7 +66,7 @@ class PublishersHelperTest < ActionView::TestCase
       }
     )
     assert_not_nil publisher.wallet
-    assert_dom_equal %{Approximately 9001.00 USD}, publisher_converted_balance(publisher)
+    assert_dom_equal %{~ 9001.00 USD}, publisher_converted_balance(publisher)
 
     publisher = FakePublisher.new(
       wallet_json: nil

--- a/test/javascript/wallet-test.js
+++ b/test/javascript/wallet-test.js
@@ -1,0 +1,51 @@
+import { Wallet } from 'wallet';
+
+const { module, test } = QUnit;
+
+module('Wallet tests', function() {
+  let wallet_data_with_settlement = {"lastSettlement":{"balance":{"probi":53213081343122476086},"date":"2018-06-04T15:55:12.000-04:00"},"providerWallet":{"provider":"uphold","authorized":true,"defaultCurrency":"USD","rates":{"BTC":"0.00003514","ETH":0.0004749371464487743,"LTC":0.0022794117647058827,"USD":0.28188557439999995,"EUR":0.24163829927299837},"availableCurrencies":["USD","BAT","BTC","EUR","XAU"],"possibleCurrencies":["AED","ARS","AUD","BAT","BCH","BRL","BTC","BTG","CAD","CHF","CNY","DASH","DKK","ETH","EUR","GBP","HKD","ILS","INR","JPY","KES","LTC","MXN","NOK","NZD","PHP","PLN","SEK","SGD","USD","XAG","XAU","XPD","XPT","XRP"],"scope":"cards:read user:read transactions:transfer:others"},"channelBalances":{"youtube#channel:UC1CF3Uud5SZJAOtusRcaMZg":{"probi":17737693781040825362},"youtube#channel:UCpspxI6hEuK9AVxNMtZsObA":{"probi":17737693781040825362}}};
+  let wallet_data_without_settlement = {"providerWallet":{"provider":"uphold","authorized":true,"defaultCurrency":"USD","rates":{"BTC":"0.00003514","ETH":0.0004749371464487743,"LTC":0.0022794117647058827,"USD":0.28188557439999995,"EUR":0.24163829927299837},"availableCurrencies":["USD","BAT","BTC","EUR","XAU"],"possibleCurrencies":["AED","ARS","AUD","BAT","BCH","BRL","BTC","BTG","CAD","CHF","CNY","DASH","DKK","ETH","EUR","GBP","HKD","ILS","INR","JPY","KES","LTC","MXN","NOK","NZD","PHP","PLN","SEK","SGD","USD","XAG","XAU","XPD","XPT","XRP"],"scope":"cards:read user:read transactions:transfer:others"},"channelBalances":{"youtube#channel:UC1CF3Uud5SZJAOtusRcaMZg":{"probi":17737693781040825362},"youtube#channel:UCpspxI6hEuK9AVxNMtZsObA":{"probi":17737693781040825362}}};
+  let wallet_data_not_uphold_verified = {};
+
+  test('converts probi to bat', function(assert) {
+    assert.equal(Wallet._probi_to_bat(5E20), 500, "converted probi to bat");
+    assert.equal(Wallet._probi_to_bat("5.01E20"), 501, "converted probi string to bat");
+  });
+
+  test('initializes from json with settlement data', function(assert) {
+    let wallet = new Wallet(wallet_data_with_settlement);
+
+    assert.equal(wallet.providerWallet.defaultCurrency, "USD", "defaultCurrency set");
+    assert.equal(wallet.lastSettlement.amount.bat, 53.213081343122475, "lastSettlementAmount is object with correct bat");
+    assert.equal(wallet.lastSettlement.amount.converted, 53.213081343122475 * 0.28188557439999995, "lastSettlementAmount is object with correct converted amount");
+    assert.equal(wallet.lastSettlement.amount.currency, "USD", "lastSettlementAmount is object with correct currency");
+  });
+
+  test('initializes from json without settlement data', function(assert) {
+    let wallet = new Wallet(wallet_data_without_settlement);
+
+    assert.equal(wallet.lastSettlement.amount, undefined, "lastSettlementAmount is undefined when last settlement isn't available");
+  });
+
+  test('initializes from json without uphold wallet data', function(assert) {
+    let wallet = new Wallet(wallet_data_not_uphold_verified);
+
+    assert.equal(wallet.providerWallet, undefined, "defaultCurrency is undefined when user isn't verified with Uphold");
+  });
+
+  test('adds up total channel amounts and converts to default currency', function(assert) {
+    let wallet = new Wallet(wallet_data_with_settlement);
+
+    assert.equal(wallet.totalAmount.bat, 17.737693781040825362 + 17.737693781040825362, "totalAmount is object with correct bat");
+    assert.equal(wallet.totalAmount.converted, 10, "totalAmount is object with correct converted amount");
+    assert.equal(wallet.totalAmount.currency, "USD", "totalAmount is object with correct currency");
+  });
+
+  test('total channel amount is 0 if there are no channels', function(assert) {
+    let wallet = new Wallet(wallet_data_not_uphold_verified);
+
+    assert.equal(wallet.totalAmount.bat, 0, "totalAmount is object with correct bat");
+    assert.equal(wallet.totalAmount.converted, undefined, "totalAmount is object with undefined converted amount");
+    assert.equal(wallet.totalAmount.currency, undefined, "totalAmount is object with undefined currency");
+  });
+});

--- a/test/javascript/wallet-test.js
+++ b/test/javascript/wallet-test.js
@@ -3,9 +3,9 @@ import { Wallet } from 'wallet';
 const { module, test } = QUnit;
 
 module('Wallet tests', function() {
-  let wallet_data_with_settlement = {"lastSettlement":{"balance":{"probi":53213081343122476086},"date":"2018-06-04T15:55:12.000-04:00"},"providerWallet":{"provider":"uphold","authorized":true,"defaultCurrency":"USD","rates":{"BTC":"0.00003514","ETH":0.0004749371464487743,"LTC":0.0022794117647058827,"USD":0.28188557439999995,"EUR":0.24163829927299837},"availableCurrencies":["USD","BAT","BTC","EUR","XAU"],"possibleCurrencies":["AED","ARS","AUD","BAT","BCH","BRL","BTC","BTG","CAD","CHF","CNY","DASH","DKK","ETH","EUR","GBP","HKD","ILS","INR","JPY","KES","LTC","MXN","NOK","NZD","PHP","PLN","SEK","SGD","USD","XAG","XAU","XPD","XPT","XRP"],"scope":"cards:read user:read transactions:transfer:others"},"channelBalances":{"youtube#channel:UC1CF3Uud5SZJAOtusRcaMZg":{"probi":17737693781040825362},"youtube#channel:UCpspxI6hEuK9AVxNMtZsObA":{"probi":17737693781040825362}}};
-  let wallet_data_without_settlement = {"providerWallet":{"provider":"uphold","authorized":true,"defaultCurrency":"USD","rates":{"BTC":"0.00003514","ETH":0.0004749371464487743,"LTC":0.0022794117647058827,"USD":0.28188557439999995,"EUR":0.24163829927299837},"availableCurrencies":["USD","BAT","BTC","EUR","XAU"],"possibleCurrencies":["AED","ARS","AUD","BAT","BCH","BRL","BTC","BTG","CAD","CHF","CNY","DASH","DKK","ETH","EUR","GBP","HKD","ILS","INR","JPY","KES","LTC","MXN","NOK","NZD","PHP","PLN","SEK","SGD","USD","XAG","XAU","XPD","XPT","XRP"],"scope":"cards:read user:read transactions:transfer:others"},"channelBalances":{"youtube#channel:UC1CF3Uud5SZJAOtusRcaMZg":{"probi":17737693781040825362},"youtube#channel:UCpspxI6hEuK9AVxNMtZsObA":{"probi":17737693781040825362}}};
-  let wallet_data_not_uphold_verified = {};
+  let walletDataWithSettlement = {"lastSettlement":{"balance":{"probi":53213081343122476086},"date":"2018-06-04T15:55:12.000-04:00"},"providerWallet":{"provider":"uphold","authorized":true,"defaultCurrency":"USD","rates":{"BTC":"0.00003514","ETH":0.0004749371464487743,"LTC":0.0022794117647058827,"USD":0.28188557439999995,"EUR":0.24163829927299837},"availableCurrencies":["USD","BAT","BTC","EUR","XAU"],"possibleCurrencies":["AED","ARS","AUD","BAT","BCH","BRL","BTC","BTG","CAD","CHF","CNY","DASH","DKK","ETH","EUR","GBP","HKD","ILS","INR","JPY","KES","LTC","MXN","NOK","NZD","PHP","PLN","SEK","SGD","USD","XAG","XAU","XPD","XPT","XRP"],"scope":"cards:read user:read transactions:transfer:others"},"channelBalances":{"youtube#channel:UC1CF3Uud5SZJAOtusRcaMZg":{"probi":17737693781040825362},"youtube#channel:UCpspxI6hEuK9AVxNMtZsObA":{"probi":17737693781040825362}}};
+  let walletDataWithoutSettlement = {"providerWallet":{"provider":"uphold","authorized":true,"defaultCurrency":"USD","rates":{"BTC":"0.00003514","ETH":0.0004749371464487743,"LTC":0.0022794117647058827,"USD":0.28188557439999995,"EUR":0.24163829927299837},"availableCurrencies":["USD","BAT","BTC","EUR","XAU"],"possibleCurrencies":["AED","ARS","AUD","BAT","BCH","BRL","BTC","BTG","CAD","CHF","CNY","DASH","DKK","ETH","EUR","GBP","HKD","ILS","INR","JPY","KES","LTC","MXN","NOK","NZD","PHP","PLN","SEK","SGD","USD","XAG","XAU","XPD","XPT","XRP"],"scope":"cards:read user:read transactions:transfer:others"},"channelBalances":{"youtube#channel:UC1CF3Uud5SZJAOtusRcaMZg":{"probi":17737693781040825362},"youtube#channel:UCpspxI6hEuK9AVxNMtZsObA":{"probi":17737693781040825362}}};
+  let walletDataNotUpholdVerified = {};
 
   test('converts probi to bat', function(assert) {
     assert.equal(Wallet._probi_to_bat(5E20), 500, "converted probi to bat");
@@ -13,7 +13,7 @@ module('Wallet tests', function() {
   });
 
   test('initializes from json with settlement data', function(assert) {
-    let wallet = new Wallet(wallet_data_with_settlement);
+    let wallet = new Wallet(walletDataWithSettlement);
 
     assert.equal(wallet.providerWallet.defaultCurrency, "USD", "defaultCurrency set");
     assert.equal(wallet.lastSettlement.amount.bat, 53.213081343122475, "lastSettlementAmount is object with correct bat");
@@ -22,19 +22,19 @@ module('Wallet tests', function() {
   });
 
   test('initializes from json without settlement data', function(assert) {
-    let wallet = new Wallet(wallet_data_without_settlement);
+    let wallet = new Wallet(walletDataWithoutSettlement);
 
     assert.equal(wallet.lastSettlement.amount, undefined, "lastSettlementAmount is undefined when last settlement isn't available");
   });
 
   test('initializes from json without uphold wallet data', function(assert) {
-    let wallet = new Wallet(wallet_data_not_uphold_verified);
+    let wallet = new Wallet(walletDataNotUpholdVerified);
 
     assert.equal(wallet.providerWallet, undefined, "defaultCurrency is undefined when user isn't verified with Uphold");
   });
 
   test('adds up total channel amounts and converts to default currency', function(assert) {
-    let wallet = new Wallet(wallet_data_with_settlement);
+    let wallet = new Wallet(walletDataWithSettlement);
 
     assert.equal(wallet.totalAmount.bat, 17.737693781040825362 + 17.737693781040825362, "totalAmount is object with correct bat");
     assert.equal(wallet.totalAmount.converted, 10, "totalAmount is object with correct converted amount");
@@ -42,7 +42,7 @@ module('Wallet tests', function() {
   });
 
   test('total channel amount is 0 if there are no channels', function(assert) {
-    let wallet = new Wallet(wallet_data_not_uphold_verified);
+    let wallet = new Wallet(walletDataNotUpholdVerified);
 
     assert.equal(wallet.totalAmount.bat, 0, "totalAmount is object with correct bat");
     assert.equal(wallet.totalAmount.converted, undefined, "totalAmount is object with undefined converted amount");


### PR DESCRIPTION
This creates a new javascript wallet class to handle the wallet logic on the client. This wallet is now returned by the `balance` class and handles contribution calculations and the last settlement date. This goes a good ways towards allowing for the asynchronous fetching of the wallet data (#838), but because some of the wallet info is still needed by the server it will not result in the desired speedup.

It also updates the Your Uphold Wallet section to match #835, which is an updated version of the UI from #768. However @dgeb is adding the dialog that will replace the Default Currency drop down as a separate PR. Merging this should be coordinated with this PR.

Further work is expected to reorganize the server side wallet, once eyeshade is updated to handle balance requests for multiple channels at once.

Fixes #768 

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))