### PR TITLE
Track successful logins with browser details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem "attr_encrypted", "~> 3.1.0"
 
 gem "bootstrap", "~> 4.1.1"
 
+# browser details
+gem 'browser'
+
 # Authorization
 gem 'cancancan'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
     brakeman (4.3.0)
+    browser (2.5.3)
     builder (3.2.3)
     bundler-audit (0.6.0)
       bundler (~> 1.2)
@@ -429,6 +430,7 @@ DEPENDENCIES
   attr_encrypted (~> 3.1.0)
   bootstrap (~> 4.1.1)
   brakeman
+  browser
   bundler-audit
   byebug
   cancancan

--- a/app/models/login_activity.rb
+++ b/app/models/login_activity.rb
@@ -1,0 +1,9 @@
+class LoginActivity < ApplicationRecord
+  belongs_to :publisher
+
+  default_scope { order(created_at: :asc) }
+
+  def browser
+    Browser.new(user_agent, accept_language: accept_language)
+  end
+end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -14,6 +14,7 @@ class Publisher < ApplicationRecord
   has_many :statements, -> { order('created_at DESC') }, class_name: 'PublisherStatement'
   has_many :u2f_registrations, -> { order("created_at DESC") }
   has_one :totp_registration
+  has_many :login_activities
 
   has_many :channels, validate: true, autosave: true
   has_many :site_channel_details, through: :channels, source: :details, source_type: 'SiteChannelDetails'
@@ -219,6 +220,10 @@ class Publisher < ApplicationRecord
   
   def last_status_update
     status_updates.first
+  end
+
+  def last_login_activity
+    login_activity = login_activities.last
   end
 
   private

--- a/config/initializers/login_activities.rb
+++ b/config/initializers/login_activities.rb
@@ -1,0 +1,10 @@
+# Record the publishers's successful login
+Warden::Manager.after_authentication except: :fetch do |publisher, auth, opts|
+  params = {
+      publisher: publisher,
+      user_agent: auth.request.headers["User-Agent"],
+      accept_language: auth.request.headers["Accept-Language"]
+  }
+
+  LoginActivity.create!(params)
+end

--- a/db/migrate/20180613134700_create_login_activities.rb
+++ b/db/migrate/20180613134700_create_login_activities.rb
@@ -1,0 +1,11 @@
+class CreateLoginActivities < ActiveRecord::Migration[5.0]
+  def change
+    create_table :login_activities, id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+      t.references :publisher, type: :uuid
+      t.text :user_agent
+      t.text :accept_language
+      t.timestamps
+      t.index ["created_at"]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -123,6 +123,16 @@ ActiveRecord::Schema.define(version: 20180614215946) do
     t.index ["id"], name: "index_legacy_youtube_channels_on_id", unique: true, using: :btree
   end
 
+  create_table "login_activities", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid     "publisher_id"
+    t.text     "user_agent"
+    t.text     "accept_language"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["created_at"], name: "index_login_activities_on_created_at", using: :btree
+    t.index ["publisher_id"], name: "index_login_activities_on_publisher_id", using: :btree
+  end
+
   create_table "promo_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid     "channel_id",    null: false
     t.string   "promo_id",      null: false

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -705,4 +705,20 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
     assert publisher.last_status_update.status == "active"
   end
+
+  test "publisher login activity is recorded" do
+    publisher = publishers(:completed)
+    login = publisher.last_login_activity
+    assert_nil login
+
+    sign_in publisher
+    get home_publishers_path, headers: { "HTTP_USER_AGENT" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36",
+                                         "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
+
+    login = publisher.last_login_activity
+    assert login
+    assert_equal login.user_agent, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36"
+    assert_equal login.accept_language, "en-US,en;q=0.9"
+    assert login.browser.chrome?
+  end
 end

--- a/test/fixtures/login_activities.yml
+++ b/test/fixtures/login_activities.yml
@@ -1,0 +1,13 @@
+verified_1:
+  publisher: verified
+  created_at: "<%= 1.day.ago %>"
+  updated_at: "<%= 1.day.ago %>"
+  user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36"
+  accept_language: "en-US,en;q=0.9"
+
+verified_2:
+  publisher: verified
+  created_at: "<%= 1.minute.ago %>"
+  updated_at: "<%= 1.minute.ago %>"
+  user_agent: "Googlebot"
+  accept_language: "en-US,en;q=0.9"

--- a/test/models/login_activity_test.rb
+++ b/test/models/login_activity_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class LoginActivityTest < ActiveSupport::TestCase
+  include Devise::Test::IntegrationHelpers
+  include ActionMailer::TestHelper
+
+  test "gets the latest login activity" do
+    publisher = publishers(:verified)
+    assert publisher.valid?
+
+    assert_equal "Googlebot", publisher.last_login_activity.user_agent
+  end
+end


### PR DESCRIPTION
This only records the logins and user-agent details. A follow on feature could make use of this data in the admin dashboard, or for analytics purposes.

Fixes #946

Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))