### PR TITLE
Log brave_publisher_id for PublisherHostInspector failures

### DIFF
--- a/app/services/site_channel_host_inspector.rb
+++ b/app/services/site_channel_host_inspector.rb
@@ -37,7 +37,7 @@ class SiteChannelHostInspector < BaseService
 
     { response: response, web_host: web_host }
   rescue Publishers::Fetch::RedirectError, Publishers::Fetch::ConnectionFailedError => e
-    Rails.logger.warn("PublisherHostInspector #inspect_uri error: #{e}")
+    Rails.logger.warn("PublisherHostInspector #{brave_publisher_id} #inspect_uri error: #{e}")
     { response: e }
   end
 
@@ -80,7 +80,7 @@ class SiteChannelHostInspector < BaseService
   end
 
   def failure_result(inspect_result)
-    Rails.logger.warn("PublisherHostInspector #perform failure: #{inspect_result[:response]}")
+    Rails.logger.warn("PublisherHostInspector #{brave_publisher_id} #perform failure: #{inspect_result[:response]}")
     { response: inspect_result[:response], host_connection_verified: false, https: false }
   end
 


### PR DESCRIPTION
Adds the domain to the logs to aid in troubleshooting host inspection errors.

Doesn't fix an issue, but should help with #253 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
