### PR TITLE
1. Always show exclusion even if the domain is not a publisher

### DIFF
--- a/app/models/json_builders/identity_json_builder.rb
+++ b/app/models/json_builders/identity_json_builder.rb
@@ -100,21 +100,19 @@ class JsonBuilders::IdentityJsonBuilder
   def build_properties(json)
     require 'publishers/excluded_channels'
 
-    if @channel_detail.present? && @channel_detail.channel.verified?
-      show_timestamp = true
-      json.verified true
-    end
-
-    if Publishers::ExcludedChannels.excluded?(@channel_detail)
-      show_timestamp = true
+    if @channel_detail.present? && @channel_detail.channel.present?
 =begin
       (Albert Wang): To satisfy backwards compatibility in Ledger's v3.identity
       which erroneously uses Bson.timestamp().
 =end
-      json.exclude true
-    end
-    if show_timestamp
       json.timestamp (@channel_detail.channel.updated_at.to_i << 32)
+      if @channel_detail.channel.verified?
+        json.verified true
+      end
+    end
+
+    if Publishers::ExcludedChannels.excluded?(@channel_detail)
+      json.exclude true
     end
   end
 end

--- a/test/controllers/api/public/channels_controller_test.rb
+++ b/test/controllers/api/public/channels_controller_test.rb
@@ -20,7 +20,7 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_equal ""         , response_body["RLD"]
     assert_equal ""         , response_body["QLD"]
     assert_equal channel.details.brave_publisher_id, response_body["URL"]
-    assert_nil   response_body['properties']
+    assert       response_body['properties']['timestamp'] != nil
   end
 
   test 'a site that is marked for exclude' do
@@ -46,6 +46,19 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_equal ""                                 , response_body["RLD"]
     assert_equal ""                                 , response_body["QLD"]
     assert_equal true                               , response_body['properties']['verified']
+  end
+
+  test 'a site that was never registered with Publishers' do
+    random_url = "shouldfail.github.io"
+    get "/api/public/channels/identity?publisher=#{random_url}",
+        headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    response_body = JSON.parse(response.body)
+
+    assert_equal random_url                         , response_body["SLD"]
+    assert_equal random_url                         , response_body["publisher"]
+    assert_equal ""                                 , response_body["RLD"]
+    assert_equal ""                                 , response_body["QLD"]
+    assert_equal nil                                , response_body['properties']
   end
 
   test 'a youtube channel' do
@@ -82,7 +95,7 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "youtube#channel:#{channel.details.youtube_channel_id}", response_body["SLD"]
     assert_equal channel.details.youtube_channel_id , response_body["RLD"]
     assert_equal ""                                 , response_body["QLD"]
-    assert_nil   response_body['properties']
+    assert       response_body['properties']['timestamp'] != nil
   end
 
   test 'a twitch channel' do
@@ -117,7 +130,7 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "twitch#author:#{channel.details.twitch_channel_id}", response_body["SLD"]
     assert_equal channel.details.twitch_channel_id , response_body["RLD"]
     assert_equal ""                                 , response_body["QLD"]
-    assert_nil   response_body['properties']
+    assert       response_body['properties']['timestamp'] != nil
   end
 
   test 'last updated channel' do


### PR DESCRIPTION
2. Properly display SLD, RLD, and QLD by checking against PublicSuffix

Closes #978

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
