### PR TITLE
(1) Handle domains marked for exclusion

### DIFF
--- a/app/models/json_builders/identity_json_builder.rb
+++ b/app/models/json_builders/identity_json_builder.rb
@@ -57,7 +57,7 @@ class JsonBuilders::IdentityJsonBuilder
     Jbuilder.encode do |json|
       json.publisher      @publisher_name
       json.publisherType  'provider'
-      json.providerName   @parsed_publisher_name[1]
+      json.providerName   Channel::YOUTUBE
       json.providerSuffix @parsed_publisher_name[2]
       json.providerValue  @parsed_publisher_name[3]
       json.URL            "https://youtube.com/#{@parsed_publisher_name[2]}/#{@parsed_publisher_name[3]}"
@@ -87,9 +87,9 @@ class JsonBuilders::IdentityJsonBuilder
 
   def build_twitch_identity_json
     Jbuilder.encode do |json|
-      json.publisher      Channel::TWITCH
+      json.publisher      @publisher_name
       json.publisherType  'provider'
-      json.providerName   @parsed_publisher_name[1]
+      json.providerName   Channel::TWITCH
       json.providerSuffix @parsed_publisher_name[2]
       json.providerValue  @parsed_publisher_name[3]
       json.TLD            @publisher_name.split(':')[0]

--- a/app/models/json_builders/identity_json_builder.rb
+++ b/app/models/json_builders/identity_json_builder.rb
@@ -74,7 +74,7 @@ class JsonBuilders::IdentityJsonBuilder
   def build_site_identity_json
     public_suffix = PublicSuffix.parse(@publisher_name)
     Jbuilder.encode do |json|
-      json.publisher      @publisher_name
+      json.publisher      public_suffix.sld + '.' + public_suffix.tld
       json.SLD            public_suffix.sld + '.' + public_suffix.tld
       json.RLD            public_suffix.trd || ""
       json.QLD            public_suffix.trd.try(:split, '.').try(:last) || ""

--- a/app/models/json_builders/identity_json_builder.rb
+++ b/app/models/json_builders/identity_json_builder.rb
@@ -13,11 +13,10 @@ class JsonBuilders::IdentityJsonBuilder
     @errors = []
     @publisher_name = publisher_name
     @parsed_publisher_name = URL_REGULAR_EXPRESSION.match(@publisher_name)
-    find_channel_detail
   end
 
   def find_channel_detail
-    @channel_detail = if @parsed_publisher_name.present? && @parsed_publisher_name[1] == Channel::YOUTUBE
+    channel_detail = if @parsed_publisher_name.present? && @parsed_publisher_name[1] == Channel::YOUTUBE
       YoutubeChannelDetails.find_by(youtube_channel_id: @parsed_publisher_name[3])
     elsif @parsed_publisher_name.present? && @parsed_publisher_name[1] == Channel::TWITCH
       find_twitch_channel_detail
@@ -40,18 +39,11 @@ class JsonBuilders::IdentityJsonBuilder
   end
 
   def build
-    @json = if @channel_detail.nil?
-=begin
-  (Albert Wang): The implementation in the browser throws a 404 when a channel isn't found.
-  However, the browser seems to not particularly care about the status code.
-=end
-      # @errors << "Channel not found"
-      build_site_identity_json
-    elsif @channel_detail.is_a?(YoutubeChannelDetails)
+    @json = if @parsed_publisher_name.present? && @parsed_publisher_name[1] == Channel::YOUTUBE
       build_youtube_identity_json
-    elsif @channel_detail.is_a?(TwitchChannelDetails)
+    elsif @parsed_publisher_name.present? && @parsed_publisher_name[1] == Channel::TWITCH
       build_twitch_identity_json
-    elsif @channel_detail.is_a?(SiteChannelDetails)
+    else
       build_site_identity_json
     end
     self
@@ -95,7 +87,7 @@ class JsonBuilders::IdentityJsonBuilder
 
   def build_twitch_identity_json
     Jbuilder.encode do |json|
-      json.publisher      @publisher_name
+      json.publisher      Channel::TWITCH
       json.publisherType  'provider'
       json.providerName   @parsed_publisher_name[1]
       json.providerSuffix @parsed_publisher_name[2]
@@ -113,19 +105,27 @@ class JsonBuilders::IdentityJsonBuilder
   def build_properties(json)
     require 'publishers/excluded_channels'
 
-    if @channel_detail.present? && @channel_detail.channel.present?
+    channel_detail = find_channel_detail
+
+    if channel_detail.present? && channel_detail.channel.present?
 =begin
       (Albert Wang): To satisfy backwards compatibility in Ledger's v3.identity
       which erroneously uses Bson.timestamp().
 =end
-      json.timestamp (@channel_detail.channel.updated_at.to_i << 32).to_s
-      if @channel_detail.channel.verified?
+      json.timestamp (channel_detail.channel.updated_at.to_i << 32).to_s
+      if channel_detail.channel.verified?
         json.verified true
       end
     end
 
-    if Publishers::ExcludedChannels.excluded?(@channel_detail)
-      json.exclude true
+    if channel_detail.present?
+      if Publishers::ExcludedChannels.excluded?(channel_detail)
+        json.exclude true
+      end
+    else
+      if Publishers::ExcludedChannels.excluded_brave_publisher_id?(@publisher_name)
+        json.exclude true
+      end
     end
   end
 end

--- a/test/controllers/api/public/channels_controller_test.rb
+++ b/test/controllers/api/public/channels_controller_test.rb
@@ -81,16 +81,17 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
         headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
     response_body = JSON.parse(response.body)
 
-    assert_equal 200                                , response.status
-    assert_equal 'provider'                         , response_body['publisherType']
-    assert_equal Channel::YOUTUBE                   , response_body['providerName']
-    assert_equal 'channel'                           , response_body['providerSuffix']
-    assert_equal not_present_channel                , response_body['providerValue']
-    assert_equal "youtube#channel"                    , response_body["TLD"]
-    assert_equal "youtube#channel:#{not_present_channel}", response_body["SLD"]
-    assert_equal not_present_channel                , response_body["RLD"]
-    assert_equal ""                                 , response_body["QLD"]
-    assert_equal nil                                , response_body['properties']
+    assert_equal 200                                      , response.status
+    assert_equal "youtube#channel:#{not_present_channel}" , response_body["publisher"]
+    assert_equal 'provider'                               , response_body['publisherType']
+    assert_equal Channel::YOUTUBE                         , response_body['providerName']
+    assert_equal 'channel'                                , response_body['providerSuffix']
+    assert_equal not_present_channel                      , response_body['providerValue']
+    assert_equal "youtube#channel"                        , response_body["TLD"]
+    assert_equal "youtube#channel:#{not_present_channel}" , response_body["SLD"]
+    assert_equal not_present_channel                      , response_body["RLD"]
+    assert_equal ""                                       , response_body["QLD"]
+    assert_equal nil                                      , response_body['properties']
 
     channel = channels(:youtube_new)
     get "/api/public/channels/identity?publisher=youtube%23channel%3A#{channel.details.youtube_channel_id}",
@@ -134,16 +135,17 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
         headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
     response_body = JSON.parse(response.body)
 
-    assert_equal 200                                , response.status
-    assert_equal 'provider'                         , response_body['publisherType']
-    assert_equal Channel::TWITCH                    , response_body['providerName']
-    assert_equal 'author'                           , response_body['providerSuffix']
-    assert_equal not_present_channel                , response_body['providerValue']
-    assert_equal "twitch#author"                    , response_body["TLD"]
-    assert_equal "twitch#author:#{not_present_channel}", response_body["SLD"]
-    assert_equal not_present_channel                , response_body["RLD"]
-    assert_equal ""                                 , response_body["QLD"]
-    assert_equal nil                                , response_body['properties']
+    assert_equal 200                                    , response.status
+    assert_equal "twitch#author:#{not_present_channel}" , response_body["publisher"]
+    assert_equal 'provider'                             , response_body['publisherType']
+    assert_equal Channel::TWITCH                        , response_body['providerName']
+    assert_equal 'author'                               , response_body['providerSuffix']
+    assert_equal not_present_channel                    , response_body['providerValue']
+    assert_equal "twitch#author"                        , response_body["TLD"]
+    assert_equal "twitch#author:#{not_present_channel}" , response_body["SLD"]
+    assert_equal not_present_channel                    , response_body["RLD"]
+    assert_equal ""                                     , response_body["QLD"]
+    assert_equal nil                                    , response_body['properties']
 
     channel = channels(:twitch_verified)
     get "/api/public/channels/identity?publisher=twitch%23author%3A#{channel.details.twitch_channel_id}",

--- a/test/controllers/api/public/channels_controller_test.rb
+++ b/test/controllers/api/public/channels_controller_test.rb
@@ -61,7 +61,37 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_equal nil                                , response_body['properties']
   end
 
+  test 'an excluded site that was never registered with Publishers' do
+    file_path = Rails.root.join("test/config/excluded_site_channels.yml")
+    excluded_url = Set.new(YAML.load_file(file_path)).first
+    get "/api/public/channels/identity?publisher=#{excluded_url}",
+        headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    response_body = JSON.parse(response.body)
+
+    assert_equal excluded_url                       , response_body["SLD"]
+    assert_equal excluded_url                       , response_body["publisher"]
+    assert_equal ""                                 , response_body["RLD"]
+    assert_equal ""                                 , response_body["QLD"]
+    assert_equal true                               , response_body['properties']['exclude']
+  end
+
   test 'a youtube channel' do
+    not_present_channel = 'ipwnnoobs'
+    get "/api/public/channels/identity?publisher=youtube%23channel%3A#{not_present_channel}",
+        headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    response_body = JSON.parse(response.body)
+
+    assert_equal 200                                , response.status
+    assert_equal 'provider'                         , response_body['publisherType']
+    assert_equal Channel::YOUTUBE                   , response_body['providerName']
+    assert_equal 'channel'                           , response_body['providerSuffix']
+    assert_equal not_present_channel                , response_body['providerValue']
+    assert_equal "youtube#channel"                    , response_body["TLD"]
+    assert_equal "youtube#channel:#{not_present_channel}", response_body["SLD"]
+    assert_equal not_present_channel                , response_body["RLD"]
+    assert_equal ""                                 , response_body["QLD"]
+    assert_equal nil                                , response_body['properties']
+
     channel = channels(:youtube_new)
     get "/api/public/channels/identity?publisher=youtube%23channel%3A#{channel.details.youtube_channel_id}",
         headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
@@ -99,6 +129,22 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'a twitch channel' do
+    not_present_channel = 'ipwnnoobs'
+    get "/api/public/channels/identity?publisher=twitch%23author%3A#{not_present_channel}",
+        headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    response_body = JSON.parse(response.body)
+
+    assert_equal 200                                , response.status
+    assert_equal 'provider'                         , response_body['publisherType']
+    assert_equal Channel::TWITCH                    , response_body['providerName']
+    assert_equal 'author'                           , response_body['providerSuffix']
+    assert_equal not_present_channel                , response_body['providerValue']
+    assert_equal "twitch#author"                    , response_body["TLD"]
+    assert_equal "twitch#author:#{not_present_channel}", response_body["SLD"]
+    assert_equal not_present_channel                , response_body["RLD"]
+    assert_equal ""                                 , response_body["QLD"]
+    assert_equal nil                                , response_body['properties']
+
     channel = channels(:twitch_verified)
     get "/api/public/channels/identity?publisher=twitch%23author%3A#{channel.details.twitch_channel_id}",
         headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }

--- a/test/controllers/api/public/channels_controller_test.rb
+++ b/test/controllers/api/public/channels_controller_test.rb
@@ -48,6 +48,19 @@ class Api::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_equal true                               , response_body['properties']['verified']
   end
 
+  test 'an invalid url that was never registered with Publishers' do
+    random_url = "foo.amazon.com"
+    get "/api/public/channels/identity?publisher=#{random_url}",
+        headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    response_body = JSON.parse(response.body)
+
+    assert_equal 'amazon.com'                       , response_body["SLD"]
+    assert_equal 'amazon.com'                       , response_body["publisher"]
+    assert_equal "foo"                              , response_body["RLD"]
+    assert_equal "foo"                              , response_body["QLD"]
+    assert_equal nil                                , response_body['properties']
+  end
+
   test 'a site that was never registered with Publishers' do
     random_url = "shouldfail.github.io"
     get "/api/public/channels/identity?publisher=#{random_url}",


### PR DESCRIPTION
Closes #993

(2) Handle channels not present in our *_channel_details tables.
Closes #992.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
