### PR TITLE
Allow admins to search by channel

### DIFF
--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -20,25 +20,25 @@ def sql(query)
                              INNER JOIN site_channel_details 
                                      ON site_channel_details.id = channels.details_id 
                                         AND channels.details_type = 'SiteChannelDetails' 
-                                        AND site_channel_details.brave_publisher_id LIKE '%#{query}%' 
+                                        AND site_channel_details.brave_publisher_id ILIKE '%#{query}%' 
                       UNION ALL 
                       SELECT channels.* 
                       FROM   channels 
                              INNER JOIN youtube_channel_details 
                                      ON youtube_channel_details.id = 
                                         channels.details_id 
-                                        AND youtube_channel_details.title LIKE '%#{query}%' 
+                                        AND youtube_channel_details.title ILIKE '%#{query}%' 
                       UNION ALL 
                       SELECT channels.* 
                       FROM   channels 
                              INNER JOIN twitch_channel_details 
                                      ON twitch_channel_details.id = channels.details_id 
-                                        AND twitch_channel_details.NAME LIKE '%#{query}%') 
+                                        AND twitch_channel_details.NAME ILIKE '%#{query}%') 
                                        c 
                    ON c.publisher_id = publishers.id
     UNION ALL
     SELECT publishers.id
     FROM publishers
-    WHERE publishers.email LIKE '%#{query}%'
-          OR publishers.name LIKE '%#{query}%'}
+    WHERE publishers.email ILIKE '%#{query}%'
+          OR publishers.name ILIKE '%#{query}%'}
 end

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -2,14 +2,43 @@ class Admin::PublishersController < AdminController
   def index
     @publishers = Publisher
     if params[:q].present?
-      @publishers = @publishers.where("email ILIKE :email OR name ILIKE :name",
-                      {
-                        email: "%#{params[:q]}%",
-                        name: "%#{params[:q]}%"
-                      }
-                    )
+      # Returns an ActiveRecord::Relation of publishers for pagination
+      @publishers = Publisher.where("publishers.id IN (#{sql(params[:q])})").distinct
     end
-
     @publishers = @publishers.paginate(page: params[:page])
   end
+end
+
+private
+
+# Returns an array of publisher ids that match the query
+def sql(query)
+  %{SELECT publishers.id 
+    FROM   publishers 
+           INNER JOIN(SELECT channels.* 
+                      FROM   channels 
+                             INNER JOIN site_channel_details 
+                                     ON site_channel_details.id = channels.details_id 
+                                        AND channels.details_type = 'SiteChannelDetails' 
+                                        AND site_channel_details.brave_publisher_id LIKE '%#{query}%' 
+                      UNION ALL 
+                      SELECT channels.* 
+                      FROM   channels 
+                             INNER JOIN youtube_channel_details 
+                                     ON youtube_channel_details.id = 
+                                        channels.details_id 
+                                        AND youtube_channel_details.title LIKE '%#{query}%' 
+                      UNION ALL 
+                      SELECT channels.* 
+                      FROM   channels 
+                             INNER JOIN twitch_channel_details 
+                                     ON twitch_channel_details.id = channels.details_id 
+                                        AND twitch_channel_details.NAME LIKE '%#{query}%') 
+                                       c 
+                   ON c.publisher_id = publishers.id
+    UNION ALL
+    SELECT publishers.id
+    FROM publishers
+    WHERE publishers.email LIKE '%#{query}%'
+          OR publishers.name LIKE '%#{query}%'}
 end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,6 +1,6 @@
 class Publisher < ApplicationRecord
   has_paper_trail
-  self.per_page = 50
+  self.per_page = 20
 
   UPHOLD_CODE_TIMEOUT = 5.minutes
   UPHOLD_ACCESS_PARAMS_TIMEOUT = 2.hours

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,6 @@ Rails.application.routes.draw do
         patch :generate_statement
         get :statement_ready
         post :create_note
-        patch :update_note
       end
     end
     


### PR DESCRIPTION
Resolves #974 

This PR uses a single search bar for searching by publisher and channel. 

I also removed an unused route.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
