### PR TITLE
Move statements into publisher info section on admin dashboard

### DIFF
--- a/app/assets/stylesheets/admin/style.scss
+++ b/app/assets/stylesheets/admin/style.scss
@@ -119,6 +119,13 @@ a.logo span {
       margin: 10px 0px;
     }
 
+    .split-row-container {
+      display: flex;
+    }
+
+    .split-row {
+      flex: 1;
+    }
     .db-info-row {
       display: flex;
       .db-field {

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -7,55 +7,55 @@
       .alert.alert-danger role="alert"
         = flash[:alert]
     h2 = @publisher.name
-    .rounded-box
-      .db-info-row
-        .db-field = "Email:"
-        .db-value = @publisher.email
-      .db-info-row
-        .db-field = "Status:"
-        .db-value = link_to(@publisher.last_status_update.present? ? @publisher.last_status_update.status : "active", admin_publisher_publisher_status_updates_path(@publisher), class: "btn btn-primary")
-      .db-info-row
-        .db-field = "Uphold connected:"
-        .db-value = @publisher.uphold_verified?
-      .db-info-row
-        .db-field = "Current contribution balance:"
-        .db-value = publisher_converted_balance(@publisher) || publisher_humanize_balance(@publisher, "BAT")
-      .db-info-row
-        .db-field = "Default currency:"
-        .db-value = @publisher.default_currency
-      - if @publisher.promo_enabled_2018q1
+    .rounded-box.split-row-container
+      .split-row
         .db-info-row
-          .db-field = "Referral downloads:"
-          .db-value = total_referral_downloads(@publisher)
+          .db-field = "Email:"
+          .db-value = @publisher.email
         .db-info-row
-          .db-field = "Referral confirmations:"
-          .db-value = confirmed_referral_downloads(@publisher)
-  hr
-    h3.admin-header = "Statements"
-    #statement-section
-      .statement
-        = form_for(@publisher, url: generate_statement_admin_publishers_path, html: { id: "statement_generator" }, method: :patch) do |f|
-          .form-group
-            = hidden_field_tag(:id, @publisher.id)
-            = select_tag(:statement_period, options_for_select(statement_periods_as_options(unused_statement_periods), :past_30_days))
-            a#generate_statement href="#" class="btn btn-primary"
-              = "Generate statement"
-      .statements-table.rounded-box
-        .header
-          .created-at= t ".created_at"
-          .period= t ".period"
-          .status= t ".status"
-        .content#generated_statements
-          - @publisher.statements.each do |s|
-            .statement
-              .created-at= statement_period_date(s.created_at)
-              .period= statement_period_description(s.period.to_sym)
-              .status
-                - if s.encrypted_contents?
-                  span= 'Ready'
-                  = link_to(t("shared.download"), statement_publishers_url(id: s.id), class: 'download')
-                - else
-                  = t ".statements.delayed"
+          .db-field = "Status:"
+          .db-value = link_to(@publisher.last_status_update.present? ? @publisher.last_status_update.status : "active", admin_publisher_publisher_status_updates_path(@publisher), class: "btn btn-primary")
+        .db-info-row
+          .db-field = "Uphold connected:"
+          .db-value = @publisher.uphold_verified?
+        .db-info-row
+          .db-field = "Current contribution balance:"
+          .db-value = publisher_converted_balance(@publisher) || publisher_humanize_balance(@publisher, "BAT")
+        .db-info-row
+          .db-field = "Default currency:"
+          .db-value = @publisher.default_currency
+        - if @publisher.promo_enabled_2018q1
+          .db-info-row
+            .db-field = "Referral downloads:"
+            .db-value = total_referral_downloads(@publisher)
+          .db-info-row
+            .db-field = "Referral confirmations:"
+            .db-value = confirmed_referral_downloads(@publisher)
+      #statement-section.split-row
+        h3.admin-header = "Statements"
+        .statement
+          = form_for(@publisher, url: generate_statement_admin_publishers_path, html: { id: "statement_generator" }, method: :patch) do |f|
+            .form-group
+              = hidden_field_tag(:id, @publisher.id)
+              = select_tag(:statement_period, options_for_select(statement_periods_as_options(unused_statement_periods), :past_30_days))
+              a#generate_statement href="#" class="btn btn-primary"
+                = "Generate statement"
+        .statements-table.rounded-box
+          .header
+            .created-at= t ".created_at"
+            .period= t ".period"
+            .status= t ".status"
+          .content#generated_statements
+            - @publisher.statements.each do |s|
+              .statement
+                .created-at= statement_period_date(s.created_at)
+                .period= statement_period_description(s.period.to_sym)
+                .status
+                  - if s.encrypted_contents?
+                    span= 'Ready'
+                    = link_to(t("shared.download"), statement_publishers_url(id: s.id), class: 'download')
+                  - else
+                    = t ".statements.delayed"
   hr
 
   h3.admin-header = "Channels (#{@publisher.channels.count})"


### PR DESCRIPTION
This PR moves the statement section into the same row as the publisher information.

Now:
![image](https://user-images.githubusercontent.com/12549658/41673612-6b3b0808-748b-11e8-9738-1d4f7c6a4eab.png)


After this PR:
![image](https://user-images.githubusercontent.com/12549658/41673426-e74e2bec-748a-11e8-9657-accd29250f29.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
