### PR TITLE
Allow admins to approve restricted site channels

### DIFF
--- a/app/assets/stylesheets/admin/style.scss
+++ b/app/assets/stylesheets/admin/style.scss
@@ -183,6 +183,21 @@ a.logo span {
         }
         .channel-info {
           flex: 2;
+          hr {
+            margin: 10px
+          }
+          .admin-approval {
+            display: flex;
+            justify-content: space-between;
+
+            .admin-approval-warning {
+              color: red;
+            }
+            .admin-approval-success {
+              color: green;
+            }
+
+          }
         }
       }      
     }

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -55,7 +55,6 @@ class AdminController < ApplicationController
     channel = Channel.find(admin_approval_channel_params)
     success = SiteChannelVerifier.new(admin_approval: true, channel: channel).perform
     if success
-      channel.verification_approved_by_admin!
       Rails.logger.info("#{channel.publication_title} has been approved by admin #{current_publisher.name}, #{current_publisher.owner_identifier}")
       SlackMessenger.new(message: "#{channel.details.brave_publisher_id} has been approved by admin #{current_publisher.name}, #{current_publisher.owner_identifier}").perform
     end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -42,7 +42,7 @@ class AdminController < ApplicationController
 
   def create_note
     publisher = Publisher.find(publisher_create_note_params[:publisher])
-    admin = current_publisher
+    admin = current_user
     note_content = publisher_create_note_params[:note]
 
     note = PublisherNote.new(publisher: publisher, created_by: admin, note: note_content)    
@@ -51,12 +51,13 @@ class AdminController < ApplicationController
     redirect_to(admin_publisher_path(publisher.id))
   end
 
+  # Allows a restricted channel to be verified
   def approve_channel
     channel = Channel.find(admin_approval_channel_params)
     success = SiteChannelVerifier.new(admin_approval: true, channel: channel).perform
     if success
-      Rails.logger.info("#{channel.publication_title} has been approved by admin #{current_publisher.name}, #{current_publisher.owner_identifier}")
-      SlackMessenger.new(message: "#{channel.details.brave_publisher_id} has been approved by admin #{current_publisher.name}, #{current_publisher.owner_identifier}").perform
+      Rails.logger.info("#{channel.publication_title} has been approved by admin #{current_user.name}, #{current_user.owner_identifier}")
+      SlackMessenger.new(message: "#{channel.details.brave_publisher_id} has been approved by admin #{current_user.name}, #{current_user.owner_identifier}").perform
     end
 
     redirect_to(admin_publisher_path(channel.publisher))

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -25,7 +25,7 @@ class Channel < ApplicationRecord
 
   validate :details_not_changed?
 
-  validates :verification_status, inclusion: { in: %w(started failed awaiting_admin_approval) }, allow_nil: true
+  validates :verification_status, inclusion: { in: %w(started failed awaiting_admin_approval approved_by_admin) }, allow_nil: true
 
   validate :site_channel_details_brave_publisher_id_unique_for_publisher, if: -> { details_type == 'SiteChannelDetails' }
 
@@ -146,6 +146,14 @@ class Channel < ApplicationRecord
 
   def verification_awaiting_admin_approval?
     self.verification_status == 'awaiting_admin_approval'
+  end
+
+  def verification_approved_by_admin!
+    update!(verification_status: 'approved_by_admin')
+  end
+
+  def verification_approved_by_admin?
+    self.verification_status == 'approved_by_admin'
   end
 
   def update_last_verification_timestamp

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -132,8 +132,14 @@ class Channel < ApplicationRecord
     update!(verified: false, verification_status: 'awaiting_admin_approval', verification_details: nil)
   end
 
-  def verification_succeeded!
-    update!(verified: true, verification_status: nil, verification_details: nil, verified_at: Time.now)
+  def verification_succeeded!(admin_approval)
+    if admin_approval
+      verification_status = 'approved_by_admin'
+    else
+      verification_status = nil
+    end
+    
+    update!(verified: true, verification_status: verification_status, verification_details: nil, verified_at: Time.now)
   end
 
   def verification_started?
@@ -146,10 +152,6 @@ class Channel < ApplicationRecord
 
   def verification_awaiting_admin_approval?
     self.verification_status == 'awaiting_admin_approval'
-  end
-
-  def verification_approved_by_admin!
-    update!(verification_status: 'approved_by_admin')
   end
 
   def verification_approved_by_admin?

--- a/app/services/site_channel_verifier.rb
+++ b/app/services/site_channel_verifier.rb
@@ -55,7 +55,7 @@ class SiteChannelVerifier < BaseService
       end
     end
 
-    verified_channel.verification_succeeded!
+    verified_channel.verification_succeeded!(admin_approval)
     verified_channel_post_verify
 
   rescue ActiveRecord::RecordNotFound => e

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -59,6 +59,17 @@
         .channel-link
           = link_to(on_channel_type(channel), channel_url(channel))
         .channel-info
+          - if channel.verification_awaiting_admin_approval?
+            .admin-approval
+              span.admin-approval-warning = "Admin approval required"
+              span.admin-approval-button
+                = form_for channel, as: :channel, method: :patch, url: approve_channel_admin_publishers_path(channel_id: channel.id) do |f|
+                  = f.submit("Approve", class: "btn btn-primary")
+            hr
+          - elsif channel.verification_approved_by_admin?
+            .admin-approval
+              span.admin-approval-success = "Admin approved"
+            hr
           .db-info-row
             .db-field = "Current contribution balance"
             .db-value = publisher_channel_balance(current_publisher, channel.details.channel_identifier, "BAT")
@@ -76,6 +87,7 @@
             .db-info-row
               .db-field = "Referral code:"
               .db-value = channel.promo_registration.referral_code
+
   hr
   h3.admin-header = "Notes"
   #notes-section

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :publishers do
       collection do
+        patch :approve_channel
         patch :generate_statement
         get :statement_ready
         post :create_note

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -102,6 +102,7 @@ development:
   bat_rocketchat_url: "https://basicattentiontoken.rocket.chat/"
   max_site_age: 6
   should_send_notifications: true
+  slack_webhook_url: false
 
 test:
   <<: *default
@@ -135,6 +136,7 @@ test:
   sendgrid_api_offline: true
   sendgrid_api_key: <%= ENV["SENDGRID_API_KEY"] || "fakeapikey" %>
   sendgrid_publishers_list_id: 3648346
+  slack_webhook_url: false
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/test/controllers/admin/publishers_controller_test.rb
+++ b/test/controllers/admin/publishers_controller_test.rb
@@ -2,10 +2,21 @@ require 'test_helper'
 require "webmock/minitest"
 
 class Admin::PublishersControllerTest < ActionDispatch::IntegrationTest
-  # For Devise >= 4.1.1
   include Devise::Test::IntegrationHelpers
-  # Use the following instead if you are on Devise <= 4.1.0
-  # include Devise::TestHelpers
+
+  def stub_verification_public_file(channel, body: nil, status: 200)
+    url = "https://#{channel.details.brave_publisher_id}/.well-known/brave-payments-verification.txt"
+    headers = {
+      'Accept' => '*/*',
+      'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      'Host' => channel.details.brave_publisher_id,
+      'User-Agent' => 'Ruby'
+    }
+    body ||= SiteChannelVerificationFileGenerator.new(site_channel: channel).generate_file_content
+    stub_request(:get, url).
+      with(headers: headers).
+      to_return(status: status, body: body, headers: {})
+  end
 
   test "regular users cannot access" do
     publisher = publishers(:completed)
@@ -86,5 +97,24 @@ class Admin::PublishersControllerTest < ActionDispatch::IntegrationTest
 
     # ensure it has the created by admin flag
     assert created_statement.created_by_admin
+  end
+
+  test "admins can approve channels waiting for admin approval" do
+    admin = publishers(:admin)
+    c = channels(:to_verify_restricted)
+    stub_verification_public_file(c)
+
+    # simulate verification attempt that will be blocked
+    verifier = SiteChannelVerifier.new(channel: c)
+    verifier.perform
+    c.reload
+    assert c.verification_awaiting_admin_approval?
+
+    # simulate admin approving channel
+    sign_in admin
+    patch approve_channel_admin_publishers_path(channel_id: c.id)
+    c.reload
+    assert c.verified?
+    assert c.verification_approved_by_admin?
   end
 end

--- a/test/controllers/channels_controller_test.rb
+++ b/test/controllers/channels_controller_test.rb
@@ -113,7 +113,7 @@ class ChannelsControllerTest < ActionDispatch::IntegrationTest
         '"details":"something happened"}',
       response.body)
 
-    channel.verification_succeeded!
+    channel.verification_succeeded!(false)
 
     get(verification_status_channel_path(channel), headers: { 'HTTP_ACCEPT' => "application/json" })
     assert_response 200

--- a/test/helpers/channels_helper_test.rb
+++ b/test/helpers/channels_helper_test.rb
@@ -13,7 +13,7 @@ class PublishersHelperTest < ActionView::TestCase
     channel.verification_failed!('something happened')
     assert_equal 'failed', channel_verification_status(channel)
 
-    channel.verification_succeeded!
+    channel.verification_succeeded!(false)
     assert_equal 'verified', channel_verification_status(channel)
   end
 
@@ -30,7 +30,7 @@ class PublishersHelperTest < ActionView::TestCase
     channel.verification_failed!('something happened')
     assert_equal 'something happened', channel_verification_details(channel)
 
-    channel.verification_succeeded!
+    channel.verification_succeeded!(false)
     assert_nil channel_verification_details(channel)
   end
 end

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -164,7 +164,7 @@ class ChannelTest < ActiveSupport::TestCase
     refute channel.verification_failed?
     assert channel.verification_started?
 
-    channel.verification_succeeded!
+    channel.verification_succeeded!(false)
 
     assert channel.verified?
     assert_not_nil channel.verified_at
@@ -177,7 +177,7 @@ class ChannelTest < ActiveSupport::TestCase
 
     channel.verification_started!
     assert_raise do
-      channel.verification_succeeded!
+      channel.verification_succeeded!(false)
     end
     assert_equal Channel::VERIFICATION_RESTRICTION_ERROR, \
       channel.errors.messages[:verified][0]
@@ -194,7 +194,7 @@ class ChannelTest < ActiveSupport::TestCase
 
     channel.verification_started!
     channel.verification_admin_approval = true
-    channel.verification_succeeded!
+    channel.verification_succeeded!(false)
 
     channel.reload
     assert channel.verified?
@@ -221,12 +221,20 @@ class ChannelTest < ActiveSupport::TestCase
     channel = channels(:default)
 
     channel.verification_started!
-    channel.verification_succeeded!
+    channel.verification_succeeded!(false)
 
     assert channel.verified?
     assert_not_nil channel.verified_at
 
     channel.update(verified: false)
     assert_nil channel.verified_at
+  end
+
+  test "verification_succeeded!() sets approved_by_admin flag" do
+    channel = channels(:default)
+
+    channel.verification_started!
+    channel.verification_succeeded!(true)
+    assert channel.verification_status = "approved_by_admin"
   end
 end


### PR DESCRIPTION
Resolves #1005 

Before approval
![image](https://user-images.githubusercontent.com/12549658/41748314-54406626-757f-11e8-90b0-f121c11eb7fd.png)

After approval
![image](https://user-images.githubusercontent.com/12549658/41748282-291ab53c-757f-11e8-9505-13c91d88813b.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
