### PR TITLE
Replace Cancel button with Choose Different Verification Method on verification pages

### DIFF
--- a/app/views/layouts/site_channels.html.slim
+++ b/app/views/layouts/site_channels.html.slim
@@ -8,7 +8,10 @@
         .nav.float-left
           h5.nav--title= t("shared.add_channel")
         .nav.float-right
-          = link_to(t("shared.cancel"), home_publishers_path, class: 'btn btn-secondary btn-outline-primary')
+          - if params[:action] != "verification_choose_method" && params[:id].present?
+            = link_to(t("shared.choose_different_verification_method"), verification_choose_method_site_channel_path(current_channel), class: 'btn btn-secondary btn-outline-primary')
+          - else
+            = link_to(t("shared.cancel"), home_publishers_path, class: 'btn btn-secondary btn-outline-primary')
         = yield(:site_channel_progress)
 
 - content_for(:content) do

--- a/app/views/site_channels/verification_wordpress.html.slim
+++ b/app/views/site_channels/verification_wordpress.html.slim
@@ -9,13 +9,9 @@
   .single-panel--content
     .single-panel--padded-content.text-left
       h3.single-panel--headline.text-center= t ".heading"
-      .single-panel.text-center
-        p#wordpress_escape_hatch = t(".escape_hatch_html", { :href => link_to(t(".verify_dns_record"), verification_dns_record_site_channel_path, :"data-piwik-action" => "WordpressEscapeHatchClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "WordpressFlow") })
-        
       .col-small-centered.text-left
         .site-channels--https-check
           = render :partial => 'https_check', :locals => { current_channel: current_channel }
-
         div class=(current_channel.details.supports_https? ? "instructions" : "instructions dimmed")
           ol.site-channels--body-list
             li

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -588,7 +588,6 @@ en:
         that this may take a few days due to our current backlog.</p>
       review_options: I'd like to review my options
     verification_wordpress:
-      escape_hatch_html: Not using wordpress, or unable to verify your site with the plugin? %{href}
       verify_dns_record: Verify via a DNS record.
       heading: Hello. It looks like you are using WordPress!
       install_plugin_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     remove: Remove
     terms_of_service: Terms of Service
     ok: OK
+    choose_different_verification_method: Choose Different Verification Method
   activerecord:
     shared:
       errors: "There were errors saving your request:"

--- a/test/features/site_channel_verification_test.rb
+++ b/test/features/site_channel_verification_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class SiteChannelVerificationTest < Capybara::Rails::TestCase
+  include Devise::Test::IntegrationHelpers
+
+  test "Cancel and Choose Different Verification Method buttons only appear in appropriate places" do
+    publisher = publishers(:default)
+    sign_in publisher
+
+    visit new_site_channel_path
+    assert_content "Cancel"
+
+    fill_in "channel_details_attributes_brave_publisher_id_unnormalized", with: "example.com"
+    
+    click_button("Continue")
+    channel = publisher.channels.order("created_at").last
+    assert_current_path verification_choose_method_site_channel_path(channel)
+    assert_content "Cancel"
+    
+    click_link "I'll use a trusted file"
+    assert_current_path verification_public_file_site_channel_path(channel)
+    assert_content "Choose Different Verification Method"
+    refute_content "Cancel"
+
+    visit verification_dns_record_site_channel_path(channel)
+    assert_content "Choose Different Verification Method"
+    refute_content "Cancel"
+
+    visit verification_wordpress_site_channel_path(channel)
+    assert_content "Choose Different Verification Method"
+    refute_content "Cancel"
+  end
+end


### PR DESCRIPTION
Resolves #1022 

![image](https://user-images.githubusercontent.com/12549658/41869086-e3313f1e-7885-11e8-827e-8b4a0d549b5b.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
