### PR TITLE
Enable U2F for all users

### DIFF
--- a/app/views/two_factor_registrations/index.html.slim
+++ b/app/views/two_factor_registrations/index.html.slim
@@ -65,38 +65,35 @@
                 = link_to t(".totp.confirm_disable.confirm"), "#", class: "js-confirm btn btn-wide btn-outline-secondary"
 
           - else
-            p= link_to t(".totp.button"), new_totp_registration_path, class: "btn btn-block btn-primary"
+            p= link_to t(".totp.button"), new_totp_registration_path, class: "btn btn-block btn-primary", :"data-piwik-action" => "CreateTOTPClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "2FA"
           p.icon= render "smartphone_with_code"
 
-        / FIXME: U2F is dark launched, and you need to specify params[:u2f]
-        / We will enable it when Brave is ready. See issue #442
-        - if @u2f_registrations.any? || params[:u2f].present?
-          .col-two-factor--content
-            h5= t ".u2f.heading"
-            p
-              = t ".u2f.intro"
-              br
-              small
-                = "*#{t ".u2f.intro_warning"} "
-                span.tf-tooltip
-                  span.icon= render "icon_help"
-                  span.tf-tooltip-content
-                    span.tf-tooltip-content-heading= t ".u2f.browser.heading"
-                    span.tf-tooltip-content-content== t ".u2f.browser.content_html"
-              br
-              small
-                = "*#{t ".u2f.device.tooltip"} "
-                span.tf-tooltip
-                  span.icon= render "icon_help"
-                  span.tf-tooltip-content
-                    span.tf-tooltip-content-heading= t ".u2f.device.heading"
-                    span.tf-tooltip-content-content== t ".u2f.device.content_html"
-            - if @u2f_registrations.any?
-              p= render @u2f_registrations
-            - else
-              p.two-factor-method-disabled
-                == "&bull; "
-                = t ".u2f.disabled"
-          .col-two-factor--action
-            p= link_to t(".u2f.button"), new_u2f_registration_path, class: "btn btn-block btn-primary"
-            p.icon= render "usb"
+        .col-two-factor--content
+          h5= t ".u2f.heading"
+          p
+            = t ".u2f.intro"
+            br
+            small
+              = "*#{t ".u2f.intro_warning"} "
+              span.tf-tooltip
+                span.icon= render "icon_help"
+                span.tf-tooltip-content
+                  span.tf-tooltip-content-heading= t ".u2f.browser.heading"
+                  span.tf-tooltip-content-content== t ".u2f.browser.content_html"
+            br
+            small
+              = "*#{t ".u2f.device.tooltip"} "
+              span.tf-tooltip
+                span.icon= render "icon_help"
+                span.tf-tooltip-content
+                  span.tf-tooltip-content-heading= t ".u2f.device.heading"
+                  span.tf-tooltip-content-content== t ".u2f.device.content_html"
+          - if @u2f_registrations.any?
+            p= render @u2f_registrations
+          - else
+            p.two-factor-method-disabled
+              == "&bull; "
+              = t ".u2f.disabled"
+        .col-two-factor--action
+          p= link_to t(".u2f.button"), new_u2f_registration_path, class: "btn btn-block btn-primary", :"data-piwik-action" => "CreateU2FClicked", :"data-piwik-name" => "Clicked", :"data-piwik-value" => "2FA"
+          p.icon= render "usb"


### PR DESCRIPTION
Resolves #991 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [] Added/updated tests for this change (for new code or code which already has tests).
- [x] Tagged reviewers.
- [x] Integrated piwik/matomo (for code that adds new buttons).
- [] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
