### PR TITLE
Allow admins to filter publishers by suspended status

### DIFF
--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -3,10 +3,16 @@ class Admin::PublishersController < AdminController
 
   def index
     @publishers = Publisher
+
     if params[:q].present?
       # Returns an ActiveRecord::Relation of publishers for pagination
       @publishers = Publisher.where("publishers.id IN (#{sql(params[:q])})").distinct
     end
+
+    if params[:suspended].present?
+      @publishers = @publishers.suspended
+    end
+
     @publishers = @publishers.paginate(page: params[:page])
   end
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -236,6 +236,15 @@ class Publisher < ApplicationRecord
     role == PUBLISHER
   end
 
+  def inferred_status
+    return last_status_update.status if last_status_update.present?
+    if verified?
+      return PublisherStatusUpdate::ACTIVE
+    else
+      return PublisherStatusUpdate::ONBOARDING
+    end
+  end
+  
   def last_status_update
     status_updates.first
   end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -68,6 +68,14 @@ class Publisher < ApplicationRecord
 
   scope :email_verified, -> { where.not(email: nil) }
   scope :not_admin, -> { where.not(role: ADMIN) }
+  scope :suspended, -> {
+    joins(:status_updates)
+    .where('publisher_status_updates.created_at =
+            (SELECT MAX(publisher_status_updates.created_at)
+            FROM publisher_status_updates
+            WHERE publisher_status_updates.publisher_id = publishers.id)')
+    .where("publisher_status_updates.status = 'suspended'")
+  }
 
   # publishers that have uphold codes that have been sitting for five minutes
   # can be cleared if publishers do not create wallet within 5 minute window
@@ -226,15 +234,6 @@ class Publisher < ApplicationRecord
 
   def publisher?
     role == PUBLISHER
-  end
-
-  def inferred_status
-    return last_status_update.status if last_status_update.present?
-    if verified?
-      return PublisherStatusUpdate::ACTIVE
-    else
-      return PublisherStatusUpdate::ONBOARDING
-    end
   end
 
   def last_status_update

--- a/app/views/admin/publishers/index.html.slim
+++ b/app/views/admin/publishers/index.html.slim
@@ -6,6 +6,9 @@ div.row
       = form_tag(admin_publishers_path, method: "get")
         = text_field_tag(:q)
         = submit_tag("Search")
+        .filters
+          = label_tag('Suspended')
+          = check_box_tag('suspended', 1, params[:suspended].present?)
       br
       div.panel-body
         div.adv-table

--- a/test/fixtures/publisher_status_updates.yml
+++ b/test/fixtures/publisher_status_updates.yml
@@ -17,3 +17,7 @@ created:
 onboarding:
   publisher: onboarding
   status: "onboarding"
+
+suspended:
+  publisher: suspended
+  status: "suspended"

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -199,3 +199,9 @@ onboarding:
   name: "Owen the onboard"
   agreed_to_tos:
   two_factor_prompted_at:
+
+suspended:
+  email: "susanthesuspended@example.com"
+  name: "Susan the suspended"
+  agreed_to_tos: "<%= 1.day.ago %>"
+  two_factor_prompted_at: "<%= 1.day.ago %>"

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -574,4 +574,16 @@ class PublisherTest < ActiveSupport::TestCase
     end
   end
 
+  test "suspended scope returns suspended publishers" do
+    # ensure all suspended publishers are included in the scope
+    suspended_publishers = Publisher.suspended
+    suspended_publishers.each {|publisher| assert publisher.last_status_update, PublisherStatusUpdate::SUSPENDED}
+
+    # ensure a publisher that is unsuspended does not appear in scope
+    publisher = publishers(:suspended)
+    assert suspended_publishers.include?(publisher)
+    status_update = PublisherStatusUpdate.new(status: "active", publisher: publisher)
+    status_update.save!
+    assert Publisher.suspended.exclude?(publisher)
+  end
 end


### PR DESCRIPTION
Resolves #1029 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
