### PR TITLE
Ensure that dashboard can be loaded even if wallet cannot

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -151,6 +151,10 @@ module PublishersHelper
     Rails.application.secrets[:terms_of_service_url]
   end
 
+  def possible_currencies(publisher)
+    publisher.wallet.present? ? publisher.wallet.possible_currencies : []
+  end
+
   def uphold_status_class(publisher)
     case publisher.uphold_status
     when :verified
@@ -167,7 +171,7 @@ module PublishersHelper
   end
 
   def last_settlement_class(publisher)
-    if publisher.wallet.last_settlement_date
+    if publisher.wallet.present? && publisher.wallet.last_settlement_date
       'settlement-made'
     else
       'no-settlement-made'

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -153,11 +153,12 @@ class Publisher < ApplicationRecord
 
   def uphold_reauthorization_needed?
     self.uphold_verified? &&
+      self.wallet.present? &&
       ['re-authorize', 'authorize'].include?(self.wallet.action)
   end
 
   def uphold_incomplete?
-    self.uphold_verified? && !self.wallet.authorized?
+    self.uphold_verified? && self.wallet.present? && !self.wallet.authorized?
   end
 
   def uphold_status
@@ -247,6 +248,7 @@ class Publisher < ApplicationRecord
 
   def can_create_uphold_cards?
     uphold_verified? &&
+      wallet.present? &&
       wallet.authorized? &&
       wallet.scope &&
       wallet.scope.include?("cards:write")

--- a/app/views/publishers/_confirm_default_currency_modal.html.slim
+++ b/app/views/publishers/_confirm_default_currency_modal.html.slim
@@ -5,7 +5,7 @@
     p=t(".leadin")
 
     = form_for current_publisher, url: confirm_default_currency_publishers_path, html: { id: "confirm_default_currency_form" } do |f|
-      = f.select(:default_currency, options_for_select(current_publisher.wallet.possible_currencies || []))
+      = f.select(:default_currency, options_for_select(possible_currencies(current_publisher)))
       = f.submit(t(".confirm"), class: "btn btn-primary btn-wide")
   .transition
     #confirm_default_currency_spinner.spinner

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -7,7 +7,7 @@ noscript
 
 - open_confirm_default_currency_modal = !flash[:taken_channel_id] && \
     current_publisher.uphold_verified? && \
-    current_publisher.wallet.authorized? && \
+    current_publisher.wallet.present? && current_publisher.wallet.authorized? && \
     (current_publisher.default_currency_confirmed_at.nil? || !current_publisher.default_currency.present?)
 
 script type="text/html" id="confirm_default_currency_modal_wrapper"
@@ -24,7 +24,7 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
 .dashboard
   #uphold_status { class=uphold_status_class(current_publisher)
                    data-open-confirm-default-currency-modal=(open_confirm_default_currency_modal ? "true" : "false")
-                   data-possible-currencies=current_publisher.wallet.possible_currencies
+                   data-possible-currencies=possible_currencies(current_publisher)
                    data-default-currency=current_publisher.default_currency }
     .row
       .col

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -157,5 +157,27 @@ class PublishersHomeTest < Capybara::Rails::TestCase
       Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
     end
   end
+
+  test "dashboard can still load even when publisher's wallet cannot be fetched from eyeshade" do
+    prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+      publisher = publishers(:uphold_connected_currency_unconfirmed)
+      sign_in publisher
+
+      wallet = { "wallet" => { "authorized" => false } }.to_json
+      stub_request(:get, %r{v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet}).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 404, headers: {})
+
+      visit home_publishers_path
+
+      refute publisher.wallet.present?
+      assert_content page, publisher.name
+      assert_content page, "BAT unavailable"
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
+    end
+  end
 end
 


### PR DESCRIPTION
In the case of a connection issue between publishers and eyeshade, the publisher’s wallet will not be present. However, the dashboard should still be viewable and “BAT unavailable” should be displayed.

Fixes #1039

/cc @yachtcaptain23 @nvonpentz 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
