### PR TITLE
Add object_changes column to versions

### DIFF
--- a/db/migrate/20180628164707_add_object_changes_to_versions.rb
+++ b/db/migrate/20180628164707_add_object_changes_to_versions.rb
@@ -1,0 +1,5 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :versions, :object_changes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180619210829) do
+ActiveRecord::Schema.define(version: 20180628164707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -272,12 +272,13 @@ ActiveRecord::Schema.define(version: 20180619210829) do
   end
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",  null: false
-    t.integer  "item_id",    null: false
-    t.string   "event",      null: false
+    t.string   "item_type",      null: false
+    t.integer  "item_id",        null: false
+    t.string   "event",          null: false
     t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"
+    t.text     "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
 


### PR DESCRIPTION
This allows easier comparison for between versions of an instance of a model.

Usage:
```
irb(main):007:0> publisher.versions.last.changeset
=> {"id"=>[nil, "7e916581-6679-40dd-86c0-175277ab2a5c"], "pending_email"=>[nil, "nickvonpentz@gmail.com"], "created_at"=>[nil, 2018-06-28 16:58:41 +0000], "updated_at"=>[nil, 2018-06-28 16:58:41 +0000]}

```


Resolves #1034 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
