### PR TITLE
Keep Admin's U2F check on production only. Make non-production check …

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,7 +9,7 @@ class Ability
     ADMIN_IP_WHITELIST = [].freeze
   end
 
-  def initialize(publisher, ip)    
+  def initialize(publisher, ip)
     @publisher = publisher || Publisher.new
     @ip = ip
 
@@ -33,7 +33,11 @@ class Ability
 
   def admin
     raise AdminNotOnIPWhitelistError.new("Administrator must be IP whitelisted") unless admin_ip_whitelisted?
-    raise U2fDisabledError.new("U2F must be enabled for administrators") unless u2f_enabled?(@publisher)
+    if Rails.env.production?
+      raise U2fDisabledError.new("U2F must be enabled for administrators") unless u2f_enabled?(@publisher)
+    else
+      raise TwoFactorDisabledError.new("2fa must be enabled for administrators") unless two_factor_enabled?(@publisher)
+    end
     can :manage, :all
     can :access, :all
   end
@@ -46,7 +50,10 @@ class Ability
 
   class U2fDisabledError < RuntimeError
   end
-  
+
   class AdminNotOnIPWhitelistError < RuntimeError
+  end
+
+  class TwoFactorDisabledError < RuntimeError
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -35,8 +35,6 @@ class Ability
     raise AdminNotOnIPWhitelistError.new("Administrator must be IP whitelisted") unless admin_ip_whitelisted?
     if Rails.env.production?
       raise U2fDisabledError.new("U2F must be enabled for administrators") unless u2f_enabled?(@publisher)
-    else
-      raise TwoFactorDisabledError.new("2fa must be enabled for administrators") unless two_factor_enabled?(@publisher)
     end
     can :manage, :all
     can :access, :all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -33,7 +33,7 @@ class Ability
 
   def admin
     raise AdminNotOnIPWhitelistError.new("Administrator must be IP whitelisted") unless admin_ip_whitelisted?
-    if Rails.env.production?
+    if Rails.env.production? || Rails.env.test?
       raise U2fDisabledError.new("U2F must be enabled for administrators") unless u2f_enabled?(@publisher)
     end
     can :manage, :all
@@ -50,8 +50,5 @@ class Ability
   end
 
   class AdminNotOnIPWhitelistError < RuntimeError
-  end
-
-  class TwoFactorDisabledError < RuntimeError
   end
 end


### PR DESCRIPTION
…against 2FA. Closes #1040

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
