### PR TITLE
[WIP] Store https check errors and display with the https check results

### DIFF
--- a/app/models/site_channel_details.rb
+++ b/app/models/site_channel_details.rb
@@ -99,6 +99,7 @@ class SiteChannelDetails < ApplicationRecord
       self.detected_web_host = nil
       self.host_connection_verified = false
     end
+    self.https_error = result[:https_error]
   end
 
   private

--- a/app/views/site_channels/_https_check.html.slim
+++ b/app/views/site_channels/_https_check.html.slim
@@ -6,6 +6,10 @@
   p.note-text
     = image_tag("x.png", alt: t(".no_https_alt"), class: "https-check-icon", width: 12, height: 12)
     = t ".no_https"
+  - if current_channel.details.https_error
+    p.note-text
+      = t ".https_error_encountered"
+      = current_channel.details.https_error
   = form_for(current_channel.details, method: :patch, url: check_for_https_site_channel_path(current_channel)) do |f|
     = f.submit(t(".button"), class: "btn btn-wide btn-primary")
 .clearfix

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,6 +520,7 @@ en:
       no_https_alt: Your domain is NOT using HTTPS.
       no_https: Uh oh! Your domain is NOT using HTTPS. You will need to fix that before continuing.
       button: Check for HTTPS
+      https_error_encountered: "The following error was encountered: "
     new:
       heading: Enter Domain Info
     progress:

--- a/db/migrate/20180629131919_add_https_error_to_site_channel_details.rb
+++ b/db/migrate/20180629131919_add_https_error_to_site_channel_details.rb
@@ -1,0 +1,5 @@
+class AddHttpsErrorToSiteChannelDetails < ActiveRecord::Migration[5.0]
+  def change
+    add_column :site_channel_details, :https_error, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180628164707) do
+ActiveRecord::Schema.define(version: 20180629131919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -233,6 +233,7 @@ ActiveRecord::Schema.define(version: 20180628164707) do
     t.string   "detected_web_host"
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
+    t.string   "https_error"
   end
 
   create_table "totp_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/lib/publishers/fetch.rb
+++ b/lib/publishers/fetch.rb
@@ -45,9 +45,10 @@ module Publishers
           else
             response.value
         end
-
+      rescue OpenSSL::SSL::SSLError, RedirectError, Errno::ECONNREFUSED, Net::OpenTimeout
+        raise
       rescue => e
-        raise ConnectionFailedError.new(e)
+        raise ConnectionFailedError.new(e.to_s)
       end
     end
   end

--- a/test/services/site_channel_host_inspector_test.rb
+++ b/test/services/site_channel_host_inspector_test.rb
@@ -90,7 +90,7 @@ class SiteChannelHostInspectorTest < ActiveJob::TestCase
     refute result[:host_connection_verified]
     refute result[:https]
     assert_nil result[:web_host]
-    assert result[:response].is_a?(Publishers::Fetch::ConnectionFailedError)
+    assert result[:response].is_a?(Errno::ECONNREFUSED)
   end
 
   test "connection to site fails when https fails and http is require_https is true" do
@@ -103,7 +103,7 @@ class SiteChannelHostInspectorTest < ActiveJob::TestCase
     refute result[:host_connection_verified]
     refute result[:https]
     assert_nil result[:web_host]
-    assert result[:response].is_a?(Publishers::Fetch::ConnectionFailedError)
+    assert result[:response].is_a?(Errno::ECONNREFUSED)
   end
 
   test "follows local redirects" do
@@ -145,7 +145,7 @@ class SiteChannelHostInspectorTest < ActiveJob::TestCase
     refute result[:host_connection_verified]
     refute result[:https]
     assert_nil result[:web_host]
-    assert result[:response].is_a?(Publishers::Fetch::ConnectionFailedError)
+    assert result[:response].is_a?(Publishers::Fetch::RedirectError)
     assert_equal "non local redirects prohibited", result[:response].to_s
   end
 


### PR DESCRIPTION
Records https inspection errors to the database. These can then be displayed to the publisher to assist in fixing https on their site.

Currently only `OpenSSL::SSL::SSLError` exceptions are captured, but there are other connection issues we should consider presenting to the publisher. Right now the actual text of the error message is output, but we should plan to do some further processing.

Fixes #253

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))