### PR TITLE
Prevent default currency modal from appearing

### DIFF
--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -237,6 +237,7 @@ function disconnectUphold() {
 }
 
 function openDefaultCurrencyModal() {
+  return // TODO Uncomment when cards:write works
   let template = document.querySelector('#confirm_default_currency_modal_wrapper');
   let closeFn = openModal(template.innerHTML);
 

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -115,10 +115,11 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
               label= t ".uphold.deposit_currency_label"
               .value#default_currency_code= current_publisher.default_currency.present? ? current_publisher.default_currency : t(".uphold.no_currency_selected")
               .action
-                span= "("
+                / TODO Fill in when cards:write works 
+                span= ""
                 a#change_default_currency href="#"
-                  = t ".uphold.change"
-                span= ")"
+                  = ""
+                span= ""
             .last-deposit-date.field
               label= t ".uphold.last_deposit_date"
               .value.deposit-date#last_deposit_date= publisher_humanize_last_settlement_date(current_publisher)

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -123,13 +123,14 @@ class PublishersHomeTest < Capybara::Rails::TestCase
     wait_until { publisher.reload.javascript_last_detected_at != nil }
   end
 
-  test "confirm default currency modal appears after uphold signup" do
-    publisher = publishers(:uphold_connected_currency_unconfirmed)
-    sign_in publisher
+  # TODO Uncomment when cards:write works
+  # test "confirm default currency modal appears after uphold signup" do
+  #   publisher = publishers(:uphold_connected_currency_unconfirmed)
+  #   sign_in publisher
 
-    visit home_publishers_path
-    assert_content page, I18n.t("publishers.confirm_default_currency_modal.headline")
-  end
+  #   visit home_publishers_path
+  #   assert_content page, I18n.t("publishers.confirm_default_currency_modal.headline")
+  # end
 
   test "confirm default currency modal does not appear for non uphold verified publishers" do
     publisher = publishers(:uphold_connected)


### PR DESCRIPTION
This prevents the default currency modal from automatically appearing.  This also removes the link to change default currency which would normally trigger the default currency modal.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
