### PR TITLE
Add z-index to admin top nav

### DIFF
--- a/app/assets/stylesheets/admin/style.scss
+++ b/app/assets/stylesheets/admin/style.scss
@@ -4,6 +4,7 @@
   top: 0;
   position: fixed;
   width: 100%;
+  z-index: 1;
 }
 
 /*sidebar navigation*/


### PR DESCRIPTION
Before this PR
![image](https://user-images.githubusercontent.com/12549658/42224121-4eebb5e6-7ea7-11e8-9635-d971a780dd44.png)


After this PR
![image](https://user-images.githubusercontent.com/12549658/42224097-4070f40e-7ea7-11e8-8fb2-6ddc8bf41339.png)



Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
