### PR TITLE
Add Brave to list of browsers that support U2F

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -640,7 +640,7 @@ en:
     index:
       u2f_unavailable_html: |
         <strong>Security key not supported by your browser.</strong><br>
-        Switch to Google Chrome or Opera browser to log in. We also recommend
+        Switch to Brave, Google Chrome or Opera browser to log in. We also recommend
         setting up authenticator app as a backup method for two-factor
         authentication for this situation.
       u2f-error:
@@ -718,7 +718,7 @@ en:
         browser:
           heading: Limited Browser Support
           content_html: |
-            This means you will need to update to the latest <strong>Google
+            This means you will need to update to the latest <strong>Brave</strong>, <strong>Google
             Chrome</strong> or <strong>Opera</strong> in order to set up and
             log in using security keys. More browsers will start supporting the
             security key in the near future. We will inform you on the changes.
@@ -759,8 +759,8 @@ en:
         it's blinking.
       u2f-unavailable: |
         Your browser doesn't look like it supports U2F, the two factor auth
-        platform supported by Brave. Please use the latest version of Chrome
-        to register your U2F-compatible device, for example a YubiKey.
+        platform supported by Brave. Please use the latest version of Brave, Chrome
+        or Opera to register your U2F-compatible device, for example a YubiKey.
       u2f-error:
         bad-request: |
           There was an unexpected error in the registration request made by
@@ -780,8 +780,8 @@ en:
           the security key when it is blinking. (TIMEOUT)
         implementation-incomplete: |
           Please insert your security key and re-attempt registration. Some
-          browsers (like Brave) have an incomplete implementation of this
-          protocol. Please use a current release of Google Chrome or Opera.
+          browsers have an incomplete implementation of this
+          protocol. Please use a current release of Brave, Google Chrome or Opera.
           (IMPLEMENTATION_INCOMPLETE)
     u2f_registration:
       name_default: Anonymous Key


### PR DESCRIPTION
Brave supports U2F now, so this PR adds Brave to the list of browsers we instruct publishers to use.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
