### PR TITLE
Only request individual balances for verified channels

### DIFF
--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -17,7 +17,7 @@ class PublisherWalletGetter < BaseApiClient
     end
 
     channel_responses = {}
-    publisher.channels.each do |channel|
+    publisher.channels.verified.each do |channel|
       identifier =  channel.details.channel_identifier
       channel_responses[identifier] = connection.get do |request|
         request.headers["Authorization"] = api_authorization_header

--- a/test/controllers/api/tokens_controller_test.rb
+++ b/test/controllers/api/tokens_controller_test.rb
@@ -33,7 +33,7 @@ class Api::TokensControllerTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
 
     response_json = JSON.parse(response.body)
-    assert_equal 17, response_json.length
+    assert_equal 18, response_json.length
 
     details = site_channel_details(:to_verify_details)
     assert_match /#{details.channel.publisher.owner_identifier}/, response.body

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -58,6 +58,16 @@ completed:
   details: completed_details (SiteChannelDetails)
   verified: true
 
+partially_completed_verified:
+  publisher: partially_completed
+  details: partially_completed_verified (SiteChannelDetails)
+  verified: true
+
+partially_completed_unverified:
+  publisher: partially_completed
+  details: partially_completed_unverified (SiteChannelDetails)
+  verified: false
+
 stale:
   created_at: <%= Time.now - 10.weeks %>
   updated_at: <%= Time.now - 10.weeks %>

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -205,3 +205,10 @@ suspended:
   name: "Susan the suspended"
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+
+# Has one verified channel, and one unverified channel
+partially_completed:
+  email: "partially_completed@example.com"
+  name: "Perry"
+  agreed_to_tos: "<%= 1.day.ago %>"
+  two_factor_prompted_at: "<%= 1.day.ago %>"

--- a/test/fixtures/site_channel_details.yml
+++ b/test/fixtures/site_channel_details.yml
@@ -17,6 +17,14 @@ completed_details:
   brave_publisher_id: "completed.org"
   verification_token: "e3d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
 
+partially_completed_unverified:
+  brave_publisher_id: "partially-completed-unverified.org"
+  verification_token: "e3d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
+
+partially_completed_verified:
+  brave_publisher_id: "partially-completed-verified.org"
+  verification_token: "e3d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
+
 stale_details:
   brave_publisher_id: "stale.org"
   verification_token: "x3d801860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"

--- a/test/models/site_channel_test.rb
+++ b/test/models/site_channel_test.rb
@@ -94,13 +94,13 @@ class SiteChannelTest < ActiveSupport::TestCase
 
     brave_publisher_ids = SiteChannelDetails.recent_unverified_site_channels(max_age: 12.weeks).pluck(:brave_publisher_id)
 
-    assert_equal 15, brave_publisher_ids.length
+    assert_equal 16, brave_publisher_ids.length
     assert brave_publisher_ids.include?("stale.org")
 
     # Default max_age of 6 weeks
     brave_publisher_ids = SiteChannelDetails.recent_unverified_site_channels.pluck(:brave_publisher_id)
 
-    assert_equal 14, brave_publisher_ids.length
+    assert_equal 15, brave_publisher_ids.length
     refute brave_publisher_ids.include?("stale.org")
   end
 

--- a/test/services/publisher_wallet_getter_test.rb
+++ b/test/services/publisher_wallet_getter_test.rb
@@ -95,4 +95,49 @@ class PublisherWalletGetterTest < ActiveJob::TestCase
     )
   end
 
+  test "when online only returns channel balances for verified channels" do
+    Rails.application.secrets[:api_eyeshade_offline] = false
+
+    # Has one verified, and one unverified channel
+    publisher = publishers(:partially_completed)
+
+    wallet = {
+      "wallet": {
+        "provider": "uphold",
+        "authorized": true,
+        "defaultCurrency": "USD",
+        "availableCurrencies": [ "EUR", "BTC", "ETH" ],
+        "possibleCurrencies": [ "USD", "EUR", "BTC", "ETH", "BAT" ],
+        "scope": ["cards:write"]
+      }
+    }.to_json
+
+    stub_request(:get, %r{v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet}).
+      with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+      to_return(status: 200, body: wallet, headers: {})
+
+    publisher.channels.each do |channel|
+      balance_json = {
+        "amount" => "5.80",
+        "currency" => "USD",
+        "altcurrency" => "BAT",
+        "probi" => "25000000000000000000",
+        "rates" => {
+          "BTC" => 0.00005418424016883016,
+          "ETH" => 0.000795331082073117,
+          "USD" => 0.2363863335301452,
+          "EUR" => 0.20187818378874756,
+          "GBP" => 0.1799810085548496
+        }
+      }.to_json
+
+      stub_request(:get, %r{v2/publishers/#{URI.escape(channel.details.channel_identifier)}/balance}).
+          with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+          to_return(status: 200, body: balance_json, headers: {})
+    end
+    result = PublisherWalletGetter.new(publisher: publisher).perform
+
+    # Ensure the wallet getter only returns channel balance for the verified channel
+    assert result.channel_balances.count == 1
+  end
 end


### PR DESCRIPTION
Resolves #1058 
Resolves https://github.com/brave/browser-laptop/issues/14658

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
