### PR TITLE
Fix missing translation in suspend_publisher email

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,7 +194,7 @@ en:
       subject: Brave Publisher statement is ready to view
       body: "The following statement has recently been generated:"
       expiration_note: This statement must be downloaded within the next 24 hours.
-    suspended_publisher:
+    suspend_publisher:
       subject: Suspicious Activity on Your Account
       intro: Thank you for being a Brave publisher.
       body_html: In the past few months, we have noticed some unusual or suspicious contributions to your Publishers account.  As a result, we have frozen payment to your account.<br/><br/>Suspicious contributions include (but are not limited to) unreasonably large contributions for small channels, and/or contributions that solely originate from the user growth pool. Any contributions that seem out of the ordinary get flagged as suspicious leading to frozen accounts immediately.<br/><br/>If you feel this is in error, please reply and provide further details or explain the various contributions made to your account.


### PR DESCRIPTION
Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
