### PR TITLE
Use presence of YOUTUBE_API_KEY instead of API_TWITCH_BASE_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Setup a google API project:
   * Authorized redirect URIs is `http://localhost:3000/publishers/auth/google_oauth2/callback`
   * select "Create"
 * Record the Client ID and Client secret and enter them in your Env variables
+* Back at the console select "Create credentials" and select API key.  This will be used for youtube channel stats via the data api.
+* Record the API and enter it in your Env variables
 
 You may need to wait up to 10 minutes for the changes to propagate.
 

--- a/app/services/channel_stats_services/youtube_channel_stats_service.rb
+++ b/app/services/channel_stats_services/youtube_channel_stats_service.rb
@@ -6,7 +6,7 @@ module ChannelStatsServices
     end
 
     def perform
-      return perform_offline if Rails.application.secrets[:api_twitch_base_uri].blank? # Currently using twitch api as a proxy
+      return perform_offline if Rails.application.secrets[:youtube_api_key].blank?
       response = Yt::Channel.new id: @channel_details.youtube_channel_id
             
       stats = {


### PR DESCRIPTION
to determine whether to perform yt stats offline.  Also Update README with instructions to get youtube API keys.

Cleans up #1082.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
