### PR TITLE
Rescue Yt::Errors::NoItems errors in YoutubeChannelStatsService

### DIFF
--- a/app/services/channel_stats_services/youtube_channel_stats_service.rb
+++ b/app/services/channel_stats_services/youtube_channel_stats_service.rb
@@ -18,6 +18,10 @@ module ChannelStatsServices
 
       @channel_details.stats = stats
       @channel_details.save!
+    rescue Yt::Errors::NoItems => e
+      # Occurs when a youtube channel doesn't exist, only a google account
+      # We can safely ignore
+      nil
     end
 
     def perform_offline


### PR DESCRIPTION
Related to #1082 

The SyncChannelStatsJob fails on staging because some some of the youtube channels that we attempt to collect stats for do not actually exist (they are only google accounts - with no youtube channel), and thus return an error.  In this case we should just return nil, so the job can continue for the other youtube channels.

This occurs for 'non existent' youtube channels. That is, google accounts with no
associated youtube channels.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
