### PR TITLE
Update PublisherBalanceGetter and PublisherWalletGetter

### DIFF
--- a/app/services/publisher_balance_getter.rb
+++ b/app/services/publisher_balance_getter.rb
@@ -12,37 +12,48 @@ class PublisherBalanceGetter < BaseApiClient
 
     channel_balances_response = connection.get do |request|
       request.headers["Authorization"] = api_authorization_header
-      request.url("/v1/balances?account=#{URI.escape(publisher.owner_identifier)}#{URI.escape(channels_query_string)}")
+      request.options.params_encoder = Faraday::FlatParamsEncoder
+      request.url("v1/balances?account=#{URI.escape(publisher.owner_identifier)}#{channels_query_string}")
     end
 
     channel_balances = JSON.parse(channel_balances_response.body)
 
-    # Eyeshade returns an empty response for verified channels
-    # with no balance, so we must fill in 0.00 balances
+    # Eyeshade returns an empty response for verified channels/owners
+    # that have never received a transaction, and 0.000 for
+    # verified channels with settled transactions.
+    #
+    # So we must fill in 0.00 balances for verified channels
+    # that have never received a transaction.
 
-    # Find verified channel IDs with no balance
+    # Select all verified channel identifiers
     verified_channel_ids = []
     publisher.channels.verified.each {|channel| verified_channel_ids.push(channel.details.channel_identifier)}
 
     channel_balances.each do |channel_balance|
-      channel_identifier = channel_balance["account"]
+      channel_identifier = channel_balance["account_id"]
+
+      # Remove the owner balance from the channel_balances response to prevent incorrect sums
+      channel_balances.delete(channel_balance) if channel_balance["account_type"] == "owner"
+
+      # Remove those which eyeshade has returned a response for
       verified_channel_ids.delete(channel_identifier) if verified_channel_ids.include?(channel_identifier)
     end
-    # Set balances to 0.00
-    channel_balances += verified_channel_ids.map { |verified_channel_id| { "account" => "#{verified_channel_id}", "balance" => "0.00" } }
+
+    # Set balances for channels not included in eyeshade reponse to 0.00
+    channel_balances += verified_channel_ids.map { |verified_channel_id| { "account_id" => "#{verified_channel_id}", "balance" => "0.00" } }
   
     channel_balances
   end
 
   def perform_offline
-    @publisher.channels.verified.map { |channel| { "account" => "#{channel.details.channel_identifier}", "balance" => "#{rand(0..3000)}"} }
+    @publisher.channels.verified.map { |channel| { "account_id" => "#{channel.details.channel_identifier}", "balance" => "#{rand(0..3000)}"} }
   end
 
   private
 
   def channels_query_string
     return "" if publisher.channels.verified.count == 0
-    publisher.channels.verified.map { |channel| "&account=#{channel.details.channel_identifier}" }.reduce(:+)
+    publisher.channels.verified.map { |channel| "&account=#{URI.escape(channel.details.channel_identifier)}" }.reduce(:+)
   end
 
   def api_base_uri

--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -90,7 +90,7 @@ class PublisherWalletGetter < BaseApiClient
   def parse_channel_balances_response(channel_balances_response, rates, default_currency)
     channel_hash = {}
     channel_balances_response.each do |channel_balance|
-      channel_id = channel_balance["account"]
+      channel_id = channel_balance["account_id"]
       channel_bat = channel_balance["balance"].to_d
       channel_probi = channel_bat * 1E18
 
@@ -109,6 +109,7 @@ class PublisherWalletGetter < BaseApiClient
   def sum_channel_balances(channel_balances_response)
     sum = 0
     channel_balances_response.each do |channel_balance|
+      next if channel_balance["account_type"] == "owner" # Do not sum owner accounts
       sum += channel_balance["balance"].to_d
     end
     sum

--- a/test/services/publisher_balance_getter_test.rb
+++ b/test/services/publisher_balance_getter_test.rb
@@ -18,7 +18,7 @@ class PublisherBalanceGetterTest < ActiveJob::TestCase
     channel_without_balance_id = publisher.channels.second.details.channel_identifier
 
     stubbed_response_body = [{
-      "account" => "#{channel_with_balance_id}",
+      "account_id" => "#{channel_with_balance_id}",
       "balance" => "900"
     }]
     
@@ -31,10 +31,10 @@ class PublisherBalanceGetterTest < ActiveJob::TestCase
     assert_equal result.length, 3
 
     # demonstrate first result has balance
-    assert_equal result.first["account"], channel_with_balance_id
+    assert_equal result.first["account_id"], channel_with_balance_id
     assert_equal result.first["balance"], "900"
 
-    assert_equal result.third["account"], channel_without_balance_id
+    assert_equal result.third["account_id"], channel_without_balance_id
     assert_equal result.third["balance"], "0.00"
   end
 

--- a/test/services/publisher_wallet_getter_test.rb
+++ b/test/services/publisher_wallet_getter_test.rb
@@ -67,11 +67,11 @@ class PublisherWalletGetterTest < ActiveJob::TestCase
     # stub balance respose
     channel_balances_response = [
       {
-        "account" => "completed.org",
+        "account_id" => "completed.org",
         "balance" => "25.00"
       },
       {
-        "account" => "youtube#channeldef456",
+        "account_id" => "youtube#channeldef456",
         "balance" => "10014"
       }
     ]


### PR DESCRIPTION
Refs #1095 

* Look for "account_id" instead of "account" in /balances response

* Specify Faraday::FlatParamsEncoder so params with the same name are not lost (ie. with '&account=')

* Ensure we do not sum over the owner balance if given

* Update tests

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
