### PR TITLE
Replace render nothing with head

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -34,9 +34,9 @@ class AdminController < ApplicationController
   def statement_ready
     statement = PublisherStatement.find(params[:id])
     if statement && statement.contents
-      render(nothing: true, status: 204)
+      head 204
     else
-      render(nothing: true, status: 404)
+      head 404
     end
   end
 

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -411,9 +411,9 @@ class PublishersController < ApplicationController
   def statement_ready
     statement = PublisherStatement.find(params[:id])
     if statement && statement.contents
-      render(nothing: true, status: 204)
+      head 204
     else
-      render(nothing: true, status: 404)
+      head 404
     end
   end
 
@@ -423,7 +423,7 @@ class PublishersController < ApplicationController
     if statement
       send_data statement.contents, filename: publisher_statement_filename(statement)
     else
-      render(nothing: true, status: 404)
+      head 404
     end
   end
 
@@ -447,7 +447,7 @@ class PublishersController < ApplicationController
       json = JsonBuilders::WalletJsonBuilder.new(publisher: current_publisher, wallet: wallet).build
       render(json: json, status: :ok)
     else
-      render(nothing: true, status: 404)
+      head 404
     end
   end
 


### PR DESCRIPTION
In Rails 5 `render nothing` is deprecated, and we should use `head` instead according to this [stack overflow](https://stackoverflow.com/questions/4632271/render-nothing-true-returns-empty-plaintext-file)

Resolves #1083

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
