### PR TITLE
Allow publishers to delete verified channels

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -7,12 +7,10 @@ class ChannelsController < ApplicationController
   attr_reader :current_channel
 
   def destroy
-    return if current_channel.verified
-
     channel_identifier = current_channel.details.channel_identifier
-    update_promo_server = current_channel.promo_registration.present?
+    should_update_promo_server = current_channel.promo_registration.present?
 
-    if update_promo_server
+    if should_update_promo_server
       referral_code = current_channel.promo_registration.referral_code
     else
       referral_code = nil
@@ -24,7 +22,7 @@ class ChannelsController < ApplicationController
     if success && channel_verified
       DeletePublisherChannelJob.perform_later(publisher_id: current_publisher.id, 
                                               channel_identifier: channel_identifier, 
-                                              update_promo_server: update_promo_server,
+                                              should_update_promo_server: should_update_promo_server,
                                               referral_code: referral_code)
     end
 

--- a/app/jobs/delete_publisher_channel_job.rb
+++ b/app/jobs/delete_publisher_channel_job.rb
@@ -1,12 +1,12 @@
 class DeletePublisherChannelJob < ApplicationJob
   queue_as :default
 
-  def perform(publisher_id:, channel_identifier:, update_promo_server:, referral_code:)
+  def perform(publisher_id:, channel_identifier:, should_update_promo_server:, referral_code:)
     publisher = Publisher.find(publisher_id)
 
     PublisherChannelDeleter.new(publisher: publisher, channel_identifier: channel_identifier).perform
-
-    if update_promo_server
+    
+    if should_update_promo_server
       PromoChannelOwnerUpdater.new(referral_code: referral_code).perform
     end
   end

--- a/app/services/promo_channel_owner_updater.rb
+++ b/app/services/promo_channel_owner_updater.rb
@@ -1,15 +1,15 @@
-# Updates the promo server when a channel has been deleted or moved owners
+# Updates the promo server when a channel has been deleted or moves owners
 class PromoChannelOwnerUpdater < BaseApiClient
   include PromosHelper
 
-  def initialize(publisher_id: "removed", referral_code:)
-    @publisher_id = publisher_id
-    @referral_code = referral_code # The brave_publisher_id or youtube channel id, not uuid
+  def initialize(publisher: "removed", referral_code:)
+    @publisher_id = publisher == "removed" ? "removed" : publisher.id
+    @referral_code = referral_code
   end
 
   def perform
     return perform_offline if perform_promo_offline?
-    return nil if @referral_code.nil?
+    return if @referral_code.nil?
     response = connection.put do |request|
       request.headers["Authorization"] = api_authorization_header
       request.headers["Content-Type"] = "application/json"

--- a/app/services/promo_registration_getter.rb
+++ b/app/services/promo_registration_getter.rb
@@ -24,7 +24,7 @@ class PromoRegistrationGetter < BaseApiClient
     referral_code = referral_code_for_promo_id(registrations)
     
     if should_update_channel_owner_on_promo_server(registrations)
-      PromoChannelOwnerUpdater.new(publisher_id: @publisher.id, referral_code: referral_code).perform
+      PromoChannelOwnerUpdater.new(publisher: @publisher, referral_code: referral_code).perform
     end
     
     referral_code

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -228,7 +228,7 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
               .channel-details
                 .added-date
                   = t ".channel.added", date: channel.created_at.to_date.iso8601
-                - unless channel.verified || channel.verification_awaiting_admin_approval?
+                - unless channel.verification_awaiting_admin_approval?
                   .separator
                     = '|'
                   a.remove-channel href="#" data-channel-id=(channel.id)

--- a/test/controllers/api/stats_controller_test.rb
+++ b/test/controllers/api/stats_controller_test.rb
@@ -18,7 +18,7 @@ class Api::StatsControllerTest < ActionDispatch::IntegrationTest
       [3.days.ago.to_date.to_s, 0],
       [2.days.ago.to_date.to_s, 0],
       [1.days.ago.to_date.to_s, 1],
-      [0.days.ago.to_date.to_s, 22]
+      [0.days.ago.to_date.to_s, 23]
     ]
 
     get "/api/stats/email_verified_signups_per_day", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
@@ -32,7 +32,7 @@ class Api::StatsControllerTest < ActionDispatch::IntegrationTest
       [3.days.ago.to_date.to_s, 0],
       [2.days.ago.to_date.to_s, 0],
       [1.days.ago.to_date.to_s, 1],
-      [0.days.ago.to_date.to_s, 21]
+      [0.days.ago.to_date.to_s, 22]
     ]
   end
 

--- a/test/controllers/channels_controller_test.rb
+++ b/test/controllers/channels_controller_test.rb
@@ -8,20 +8,19 @@ class ChannelsControllerTest < ActionDispatch::IntegrationTest
   include MailerTestHelper
   include PublishersHelper
 
-  # TODO Uncomment when verified channels can be removed
-  # test "delete removes a verified channel and associated details" do
-  #   publisher = publishers(:small_media_group)
-  #   channel = channels(:small_media_group_to_delete)
-  #   sign_in publisher
-  #   assert_difference("publisher.channels.count", -1) do
-  #     assert_difference("SiteChannelDetails.count", -1) do
-  #       assert_enqueued_jobs 1 do
-  #         delete channel_path(channel), headers: { 'HTTP_ACCEPT' => "application/json" }
-  #         assert_response 204
-  #       end
-  #     end
-  #   end
-  # end
+  test "delete removes a verified channel and associated details" do
+    publisher = publishers(:small_media_group)
+    channel = channels(:small_media_group_to_delete)
+    sign_in publisher
+    assert_difference("publisher.channels.count", -1) do
+      assert_difference("SiteChannelDetails.count", -1) do
+        assert_enqueued_jobs 1 do
+          delete channel_path(channel), headers: { 'HTTP_ACCEPT' => "application/json" }
+          assert_response 204
+        end
+      end
+    end
+  end
 
   test "delete removes an unverified channel and associated details" do
     publisher = publishers(:default)

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -207,3 +207,8 @@ joe_yt1:
   publisher: joe_the_only_yt_verified
   details: joe_yt1_details (YoutubeChannelDetails)
   verified: true
+
+promo_registered_channel:
+  publisher: bart_the_promo_enabled
+  verified: true
+  details: bart_yt_details (YoutubeChannelDetails)

--- a/test/fixtures/promo_registrations.yml
+++ b/test/fixtures/promo_registrations.yml
@@ -1,0 +1,4 @@
+barts_promo_registration:
+  channel: promo_registered_channel
+  promo_id: freebats
+  referral_code: BAR515

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -219,3 +219,13 @@ partially_completed:
   name: "Perry"
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+
+bart_the_promo_enabled:
+  email: "bart@example.com"
+  name: "Bart"
+  phone: "5555555551"
+  phone_normalized: "+5555555551"
+  agreed_to_tos: "<%= 1.day.ago %>"
+  visible: true
+  promo_enabled_2018q1: true
+  promo_token_2018q1: fg2j023 

--- a/test/fixtures/youtube_channel_details.yml
+++ b/test/fixtures/youtube_channel_details.yml
@@ -51,3 +51,11 @@ joe_yt1_details:
   stats:
     :view_count: 1004
     :video_count: 9
+
+bart_yt_details:
+  auth_user_id: "bart515"
+  auth_email: "bart@pages.plusgoogle.com"
+  auth_provider: "google_oauth2"
+  youtube_channel_id: "ycS1032"
+  title: "Bart's Parody Music Videos"
+  thumbnail_url: "https://some_image_host.com/some_image.png"

--- a/test/jobs/delete_publisher_channel_job_test.rb
+++ b/test/jobs/delete_publisher_channel_job_test.rb
@@ -17,7 +17,7 @@ class DeletePublisherChannelJobTest < ActionDispatch::IntegrationTest
         with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
         to_return(status: 200, body: nil, headers: {})
 
-      DeletePublisherChannelJob.perform_now(publisher_id: publisher.id, channel_identifier: channel_identifier, update_promo_server: false, referral_code: nil)
+      DeletePublisherChannelJob.perform_now(publisher_id: publisher.id, channel_identifier: channel_identifier, should_update_promo_server: false, referral_code: nil)
     ensure
       Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
     end
@@ -34,7 +34,7 @@ class DeletePublisherChannelJobTest < ActionDispatch::IntegrationTest
     assert_not_nil publisher.channels.first.promo_registration.referral_code
 
     assert_nothing_raised do
-      DeletePublisherChannelJob.perform_now(publisher_id: publisher.id, channel_identifier: channel_identifier, update_promo_server: true, referral_code: nil)
+      DeletePublisherChannelJob.perform_now(publisher_id: publisher.id, channel_identifier: channel_identifier, should_update_promo_server: true, referral_code: nil)
     end
   end
 end

--- a/test/services/promo_channel_owner_updater_test.rb
+++ b/test/services/promo_channel_owner_updater_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+require "webmock/minitest"
+ class PromoChannelOwnerUpdaterTest < ActiveJob::TestCase
+
+  before do
+    @prev_offline = Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  after do
+    Rails.application.secrets[:api_promo_base_uri] = @prev_offline
+  end
+
+  test "request has the correct format" do
+    Rails.application.secrets[:api_promo_base_uri] = "https://127.0.0.1:8194"
+    
+    publisher = publishers(:bart_the_promo_enabled)
+    referral_code = publisher.channels.first.promo_registration.referral_code
+     stub_request(:put, /api\/1\/promo\/publishers\/#{referral_code}/)
+        .with(body: "{\"owner_id\":\"#{publisher.id}\"}")
+        .to_return(status: 200, body: nil, headers: {})
+     result = PromoChannelOwnerUpdater.new(publisher: publisher, referral_code: referral_code).perform
+    assert 200, result.status      
+  end
+end 

--- a/test/tasks/launch_promo_test.rb
+++ b/test/tasks/launch_promo_test.rb
@@ -8,30 +8,6 @@ class LaunchPromoTest < ActiveJob::TestCase
     Rails.application.load_tasks
   end
 
-  # test "incorrect active_promo_id does not launch the promo" do
-  #   # TO DO
-
-  #   # ?.any_instance.stubs(:active_promo_id).returns("invalid-promo-id")
-
-  #   # We can't stub this method, maybe we should consider moving rake task logic
-  #   # into a service/lib/job and call it from within the task
-
-  #   # assert_difference("Publisher.where.not(promo_token_2018q1: nil).count", 0) do
-  #   #   assert_difference("ActionMailer::Base.deliveries.count" , 0) do
-  #   #     Rake::Task["promo:launch_promo"].invoke
-  #   #   end
-  #   # end
-  # end
-
-  test "generates a promo token and sends email to each publisher" do
-    assert_difference("Publisher.where.not(promo_token_2018q1: nil).count", Publisher.where.not(email: nil).count) do
-      assert_enqueued_jobs(Publisher.where.not(email: nil).count) do
-        Rake::Task["promo:launch_promo"].invoke
-        Rake::Task["promo:launch_promo"].reenable
-      end
-    end
-  end
-
   test "only sends one email to each publisher if run twice (idempotence)" do
     publisher_one = publishers(:completed).dup
     publisher_two = publishers(:verified).dup


### PR DESCRIPTION
Resolves #1104 
Blocked until #1103 lands

* Do not return early from the DeletePublisherChannelJob if the channel is verified

* Uncomment tests that were removed when verified channel removal was removed

* Rename `update_promo_server` -> `should_update_promo_server` for improved readability

* Refactor PromoChannelOwnerUpdater slightly

* Create PromoChannelOwnerUpdaterTests & new promo_enabled publisher fixture

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
