### PR TITLE
Ensure twitch per channel balances are displayed

### DIFF
--- a/app/jobs/generate_payout_report_job.rb
+++ b/app/jobs/generate_payout_report_job.rb
@@ -68,7 +68,7 @@ class GeneratePayoutReportJob < ApplicationJob
   # instead when twitch#author is used everywhere
   def channel_identifier(channel)
     if channel.details_type == "TwitchChannelDetails" && !Rails.env.test?
-      "twitch#author:#{channel.details.name}"
+      channel.details.author_identifier
     else
       channel.details.channel_identifier
     end

--- a/app/models/twitch_channel_details.rb
+++ b/app/models/twitch_channel_details.rb
@@ -15,6 +15,10 @@ class TwitchChannelDetails < ApplicationRecord
     "twitch#channel:#{name}"
   end
 
+  def author_identifier 
+    "twitch#author:#{name}"
+  end
+
   def authorizer_email
     email
   end

--- a/app/services/publisher_balance_getter.rb
+++ b/app/services/publisher_balance_getter.rb
@@ -28,12 +28,12 @@ class PublisherBalanceGetter < BaseApiClient
 
   private
   
-  # TODO: Do not use twitch_author_id method when all twitch#author is used everywhere
+  # TODO: Do not use details.author_identifier when all twitch#author is used everywhere 
   def channels_query_string
     return "" if publisher.channels.verified.count == 0
     publisher.channels.verified.map { |channel|
       if channel.details_type == "TwitchChannelDetails" && !Rails.env.test?
-        channel_id = twitch_author_id(channel)
+        channel_id = channel.details.author_identifier
       else
         channel_id = channel.details.channel_identifier
       end
@@ -44,10 +44,10 @@ class PublisherBalanceGetter < BaseApiClient
   # with no balance, so we must fill in these values
   def fill_in_missing_accounts(accounts)
     # Find all of the publisher's verified channel ids
-    # TODO: Remove twitch_author_id method when all twitch#author is used everywhere
+    # TODO: Remove details.author_identifier when all twitch#author is used everywhere
     verified_channel_ids = publisher.channels.verified.map do |channel|
       if channel.details_type == "TwitchChannelDetails" && !Rails.env.test?
-        twitch_author_id(channel)
+        channel.details.author_identifier
       else
         channel.details.channel_identifier
       end
@@ -85,13 +85,6 @@ class PublisherBalanceGetter < BaseApiClient
     end
 
     accounts
-  end
-
-  # TODO: Remove this method when all we use twitch#author everywhere
-  # everywhere in the codebase
-  def twitch_author_id(twitch_channel)
-    raise if twitch_channel.details_type != "TwitchChannelDetails"
-    "twitch#author:#{twitch_channel.details.name}"
   end
 
   def api_base_uri

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -207,7 +207,11 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
                 .channel-status.float-right
                   .bat-channel
                     h4.bat-channel--amount id=("channel_amount_bat_#{channel.details.channel_identifier}")
-                      = publisher_channel_balance(current_publisher, channel.details.channel_identifier, "BAT")
+                      - if channel.details_type == "TwitchChannelDetails"
+                        = publisher_channel_balance(current_publisher, channel.details.author_identifier, "BAT")
+                      - else 
+                        = publisher_channel_balance(current_publisher, channel.details.channel_identifier, "BAT")
+
                     span.bat-channel--currency= " BAT"
                     .bat-channel--period
                       = t(".channel_balance_period")            


### PR DESCRIPTION
Resolves #1134 

* Add TwitchChannelDetails#author_identifier

* Use #author_identifier to replace other ways of writing 'twitch#author'

* Look for twitch channel balances using the twitch#author identifier to display on dashboard

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
