### PR TITLE
Update criteria for EnqueueSiteChannelVerifications

### DIFF
--- a/test/models/site_channel_test.rb
+++ b/test/models/site_channel_test.rb
@@ -105,11 +105,11 @@ class SiteChannelTest < ActiveSupport::TestCase
   end
 
   test "recent unverified site_channels ready to verify can be found" do
-    brave_publisher_ids = SiteChannelDetails.recent_ready_to_verify_site_channels(max_age: 12.weeks).pluck(:brave_publisher_id)
-
-    assert_equal 2, brave_publisher_ids.length
-    refute brave_publisher_ids.include?("stale.org")
-    assert brave_publisher_ids.include?("global3.org")
-    assert brave_publisher_ids.include?("global4.org")
+    sites = SiteChannelDetails.recent_ready_to_verify_site_channels(max_age: 6.weeks)
+    sites.each do |site|
+      refute site.channel.verified?
+      refute site.verification_method.nil?
+      assert site.updated_at > Time.now - 6.weeks # Updated within the last 6 weeks
+    end
   end
 end


### PR DESCRIPTION
Resolves #1148 

Only enqueue site channels for verification that are:
* Not verified
* Have a verification method
* Were updated as recently

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
