### PR TITLE
Don't use cache when attempting to use the SiteVerifier. Closes #1152

### DIFF
--- a/app/services/site_channel_verifier.rb
+++ b/app/services/site_channel_verifier.rb
@@ -18,7 +18,7 @@ class SiteChannelVerifier < BaseService
     return false if channel.verification_awaiting_admin_approval? && !has_admin_approval
 
     verification_result = verify_site_channel
-    
+
     if verification_result == false
       channel.verification_failed!(verification_details)
       return false
@@ -73,7 +73,7 @@ class SiteChannelVerifier < BaseService
 
   def verify_site_channel_dns
     require "dnsruby"
-    resolver = Dnsruby::Resolver.new
+    resolver = Dnsruby::Resolver.new({do_caching: false})
     message = resolver.query(channel.details.brave_publisher_id, "TXT")
     answer = message.answer
 
@@ -97,7 +97,7 @@ class SiteChannelVerifier < BaseService
         end
       end
     end
-    @verification_details = "token_not_found_dns"    
+    @verification_details = "token_not_found_dns"
     false
   rescue Dnsruby::NXDomain
     Rails.logger.debug("Dnsruby::NXDomain")


### PR DESCRIPTION
Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
