### PR TITLE
Still display dashboard and show balance "Unavailable" if PublisherBa…

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -25,12 +25,12 @@ module PublishersHelper
         publisher.wallet.contribution_balance
       '%.2f' % balance.convert_to(currency)
     else
-      I18n.t("helpers.publisher.conversion_unavailable", code: currency)
+      I18n.t("helpers.publisher.balance_unavailable")
     end
   rescue => e
     require "sentry-raven"
     Raven.capture_exception(e)
-    I18n.t("helpers.publisher.conversion_unavailable", code: currency)
+    I18n.t("helpers.publisher.balance_unavailable")
   end
 
   def next_deposit_date(today = DateTime.now)
@@ -108,7 +108,7 @@ module PublishersHelper
     )
       '%.2f' % balance.convert_to(currency)
     else
-      I18n.t("helpers.publisher.conversion_unavailable", code: currency)
+      I18n.t("helpers.publisher.balance_unavailable")
     end
   rescue => e
     require "sentry-raven"

--- a/app/services/publisher_balance_getter.rb
+++ b/app/services/publisher_balance_getter.rb
@@ -3,7 +3,7 @@ class PublisherBalanceGetter < BaseApiClient
   attr_reader :publisher
 
   def initialize(publisher:)
-    @publisher = publisher
+    @publisher = publisher 
   end
 
   def perform
@@ -20,6 +20,11 @@ class PublisherBalanceGetter < BaseApiClient
 
     complete_accounts = fill_in_missing_accounts(accounts)
     complete_accounts
+
+  rescue => e
+    require "sentry-raven"
+    Raven.capture_exception(e)
+    :unavailable
   end
 
   def perform_offline

--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -21,6 +21,7 @@ class PublisherWalletGetter < BaseApiClient
     if should_use_transaction_table?
       if publisher.channels.verified.present?
         accounts = PublisherBalanceGetter.new(publisher: publisher).perform
+        return if accounts == :unavailable
 
         # Override owner balance with transaction table value
         if wallet_hash.dig("contributions", "probi")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,6 +111,7 @@ en:
         no_https: "Please enabled HTTPS on your domain, or choose another verification method."
         generic: "If this verification failure continues to occur, please reach us at %{support_email}."
     publisher:
+      balance_unavailable: "Unavailable"
       conversion_unavailable: "%{code} unavailable"
       no_deposit: No deposit made yet
       balance_pending_approximate: ~ %{amount} %{code}

--- a/test/features/publishers_home_test.rb
+++ b/test/features/publishers_home_test.rb
@@ -174,7 +174,32 @@ class PublishersHomeTest < Capybara::Rails::TestCase
 
       refute publisher.wallet.present?
       assert_content page, publisher.name
-      assert_content page, "BAT unavailable"
+      assert_content page, "Unavailable"
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
+    end
+  end
+
+  test "dashboard can still load even when publisher's balance cannot be fetched from eyeshade" do
+    prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+      publisher = publishers(:uphold_connected)
+      sign_in publisher
+
+      wallet = { "wallet" => { "authorized" => false } }.to_json
+      stub_request(:get, %r{v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet}).
+        with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.9.2'}).
+        to_return(status: 200, body: wallet, headers: {})
+
+      stub_request(:get, "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23channel:ucTw&account=twitter%23channel:def456").
+        to_return(status: 200, body: "go away\nUser-agent: *\nDisallow:")
+
+      visit home_publishers_path
+
+      refute publisher.wallet.present?
+      assert_content page, publisher.name
+      assert_content page, "Unavailable"
     ensure
       Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
     end

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -93,6 +93,7 @@ uphold_connected:
   agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
   default_currency: "USD"
+  two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
 
 uphold_connected_currency_unconfirmed:

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -124,7 +124,7 @@ class PublishersHelperTest < ActionView::TestCase
     )
 
     assert_nil publisher.wallet
-    assert_equal "USD unavailable", publisher_humanize_balance(publisher, "USD")
+    assert_equal "Unavailable", publisher_humanize_balance(publisher, "USD")
   end
 
   test "uphold_status_class returns a css class that corresponds to a publisher's uphold_status" do


### PR DESCRIPTION
…lanceGetter errs

Resolves #1154 

* Rescue exceptions in PublisherBalanceGetter and pass :unavailable

* Add new translation to display "Unavailable {code}" instead of "BAT Unavailable BAT"

Previously: 
![image](https://user-images.githubusercontent.com/12549658/45221827-ae063300-b280-11e8-8429-cb21a432bebb.png)

After this PR:

![image](https://user-images.githubusercontent.com/12549658/45221853-c413f380-b280-11e8-967c-00448f847f0f.png)

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
