### PR TITLE
Allow admins to search for publishers by publisher.id and channel.id

### DIFF
--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -102,8 +102,17 @@ class Admin::PublishersController < AdminController
 
   private
 
+  def remove_prefix_if_necessary(query)
+    query = query.sub("publishers#uuid:", "")
+    query = query.sub("youtube#channel:", "")
+    query = query.sub("twitch#channel:", "")
+    query = query.sub("twitch#author:", "")
+    query = query.sub("twitter#channel:", "")
+  end
+
   # Returns an array of publisher ids that match the query
   def sql(query)
+    query = remove_prefix_if_necessary(query)
     %{SELECT publishers.id
       FROM   publishers
              INNER JOIN(SELECT channels.*
@@ -119,6 +128,7 @@ class Admin::PublishersController < AdminController
                                        ON youtube_channel_details.id =
                                           channels.details_id
                                           AND youtube_channel_details.title ILIKE '%#{query}%'
+                                          OR youtube_channel_details.youtube_channel_id ILIKE '%#{query}%'
                         UNION ALL
                         SELECT channels.*
                         FROM   channels
@@ -131,6 +141,7 @@ class Admin::PublishersController < AdminController
       SELECT publishers.id
       FROM publishers
       WHERE publishers.email ILIKE '%#{query}%'
-            OR publishers.name ILIKE '%#{query}%'}
+            OR publishers.name ILIKE '%#{query}%'
+            OR publishers.id::text = '#{query}'}
   end
 end

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -99,38 +99,38 @@ class Admin::PublishersController < AdminController
       :excluded_from_payout
     )
   end
-end
 
-private
+  private
 
-# Returns an array of publisher ids that match the query
-def sql(query)
-  %{SELECT publishers.id
-    FROM   publishers
-           INNER JOIN(SELECT channels.*
-                      FROM   channels
-                             INNER JOIN site_channel_details
-                                     ON site_channel_details.id = channels.details_id
-                                        AND channels.details_type = 'SiteChannelDetails'
-                                        AND site_channel_details.brave_publisher_id ILIKE '%#{query}%'
-                      UNION ALL
-                      SELECT channels.*
-                      FROM   channels
-                             INNER JOIN youtube_channel_details
-                                     ON youtube_channel_details.id =
-                                        channels.details_id
-                                        AND youtube_channel_details.title ILIKE '%#{query}%'
-                      UNION ALL
-                      SELECT channels.*
-                      FROM   channels
-                             INNER JOIN twitch_channel_details
-                                     ON twitch_channel_details.id = channels.details_id
-                                        AND twitch_channel_details.NAME ILIKE '%#{query}%')
-                                       c
-                   ON c.publisher_id = publishers.id
-    UNION ALL
-    SELECT publishers.id
-    FROM publishers
-    WHERE publishers.email ILIKE '%#{query}%'
-          OR publishers.name ILIKE '%#{query}%'}
+  # Returns an array of publisher ids that match the query
+  def sql(query)
+    %{SELECT publishers.id
+      FROM   publishers
+             INNER JOIN(SELECT channels.*
+                        FROM   channels
+                               INNER JOIN site_channel_details
+                                       ON site_channel_details.id = channels.details_id
+                                          AND channels.details_type = 'SiteChannelDetails'
+                                          AND site_channel_details.brave_publisher_id ILIKE '%#{query}%'
+                        UNION ALL
+                        SELECT channels.*
+                        FROM   channels
+                               INNER JOIN youtube_channel_details
+                                       ON youtube_channel_details.id =
+                                          channels.details_id
+                                          AND youtube_channel_details.title ILIKE '%#{query}%'
+                        UNION ALL
+                        SELECT channels.*
+                        FROM   channels
+                               INNER JOIN twitch_channel_details
+                                       ON twitch_channel_details.id = channels.details_id
+                                          AND twitch_channel_details.NAME ILIKE '%#{query}%')
+                                         c
+                     ON c.publisher_id = publishers.id
+      UNION ALL
+      SELECT publishers.id
+      FROM publishers
+      WHERE publishers.email ILIKE '%#{query}%'
+            OR publishers.name ILIKE '%#{query}%'}
+  end
 end


### PR DESCRIPTION
Resolves #1107 

Admins will be able to search with or without the channel/owner prefixes.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
