### PR TITLE
V1 API for stats

### DIFF
--- a/app/controllers/api/v1/stats/channels_controller.rb
+++ b/app/controllers/api/v1/stats/channels_controller.rb
@@ -3,45 +3,53 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
   def channels
 
     if params[:uuid] == nil
+
       channels = Channel.all.map { |channel| channel.id }
       data = JSON.pretty_generate(channels)
       render(json: data)
+
     else
+
       channel = Channel.find_by_id(params[:uuid])
 
-      case channel.details_type
-        when "SiteChannelDetails"
-          channel_details = SiteChannelDetails.find_by_id(channel.details_id)
-          channel_type = "website"
-          channel_name = channel_details.url
-        when "YoutubeChannelDetails"
-          channel_details = YoutubeChannelDetails.find_by_id(channel.details_id)
-          channel_type = "youtube"
-          channel_name = channel_details.name
-        when "TwitterChannelDetails"
-          channel_details = TwitterChannelDetails.find_by_id(channel.details_id)
-          channel_type = "twitter"
-          channel_name = channel_details.name
-        when "TwitchChannelDetails"
-          channel_details = TwitchChannelDetails.find_by_id(channel.details_id)
-          channel_type = "twitch"
-          channel_name = channel_details.name
-        end
+      if(channel == nil)
+        redirect_to "/404"
+      else
 
-        data = JSON.pretty_generate({
-          uuid: channel.id,
-          channel_id: channel_details.channel_identifier,
-          channel_type: channel_type,
-          name: channel_name,
-          stats: channel_details.stats,
-          url: channel_details.url,
-          owner_id: channel.publisher.owner_identifier,
-          created_at: channel.created_at,
-          verified: channel.verified
-          })
+        case channel.details_type
+          when "SiteChannelDetails"
+            channel_details = SiteChannelDetails.find_by_id(channel.details_id)
+            channel_type = "website"
+            channel_name = channel_details.url
+          when "YoutubeChannelDetails"
+            channel_details = YoutubeChannelDetails.find_by_id(channel.details_id)
+            channel_type = "youtube"
+            channel_name = channel_details.name
+          when "TwitterChannelDetails"
+            channel_details = TwitterChannelDetails.find_by_id(channel.details_id)
+            channel_type = "twitter"
+            channel_name = channel_details.name
+          when "TwitchChannelDetails"
+            channel_details = TwitchChannelDetails.find_by_id(channel.details_id)
+            channel_type = "twitch"
+            channel_name = channel_details.name
+          end
 
-        render(json: data)
+          data = JSON.pretty_generate({
+            uuid: channel.id,
+            channel_id: channel_details.channel_identifier,
+            channel_type: channel_type,
+            name: channel_name,
+            stats: channel_details.stats,
+            url: channel_details.url,
+            owner_id: channel.publisher.owner_identifier,
+            created_at: channel.created_at,
+            verified: channel.verified
+            })
 
+          render(json: data)
+
+      end
     end
   end
 end

--- a/app/controllers/api/v1/stats/channels_controller.rb
+++ b/app/controllers/api/v1/stats/channels_controller.rb
@@ -1,0 +1,48 @@
+class Api::V1::Stats::ChannelsController < Api::BaseController
+
+def channels
+  channels = Channel.all.map { |channel| channel.id }
+  data = JSON.pretty_generate(channels)
+
+  render(json: data)
+
+end
+
+def channels_uuid
+
+  channel = Channel.find_by_id(params[:uuid])
+
+  case channel.details_type
+  when "SiteChannelDetails"
+    channel_details = SiteChannelDetails.find_by_id(channel.details_id)
+    platform = "Site"
+    channel_id = channel_details.brave_publisher_id
+  when "YoutubeChannelDetails"
+    channel_details = YoutubeChannelDetails.find_by_id(channel.details_id)
+    platform = "Youtube"
+    channel_id = channel_details.youtube_channel_id
+  when "TwitterChannelDetails"
+    channel_details = TwitterChannelDetails.find_by_id(channel.details_id)
+    platform = "Twitter"
+    channel_id = channel_details.twitter_channel_id
+  when "TwitchChannelDetails"
+    channel_details = TwitchChannelDetails.find_by_id(channel.details_id)
+    platform = "Twitch"
+    channel_id = channel_details.twitch_channel_id
+  end
+
+  data = JSON.pretty_generate({
+    uuid: channel.id,
+    platform: platform,
+    name: channel_details.name,
+    channel_id: channel_id,
+    stats: channel_details.stats,
+    publisher_id: channel.publisher_id,
+    created_at: channel.created_at,
+    verified: channel.verified
+  })
+
+  render(json: data)
+
+end
+end

--- a/app/controllers/api/v1/stats/channels_controller.rb
+++ b/app/controllers/api/v1/stats/channels_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
 
   def channels
 
-    if(params[:uuid] == nil)
+    if params[:uuid].nil?
 
       channels = Channel.all.map { |channel| channel.id }
       data = JSON.pretty_generate(channels)
@@ -10,20 +10,20 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
 
     else
 
-      channel = Channel.find_by_id(params[:uuid])
+      begin
 
-      if(channel == nil)
+        channel = Channel.find(params[:uuid])
 
-        error_response = JSON.pretty_generate({
-          errors: [{
-            status: "404",
-            title: "Not Found",
-            detail: "Channel with uuid " + params[:uuid] + " not found"
-          }]
-        })
-        render(json: error_response)
-
-      else
+        rescue ActiveRecord::RecordNotFound
+          error_response = JSON.pretty_generate({
+            errors: [{
+              status: "404",
+              title: "Not Found",
+              detail: "Channel with uuid #{params[:uuid]} not found"
+              }]
+            })
+          render(json: error_response) and return
+        end
 
         case channel.details_type
 
@@ -59,7 +59,6 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
 
           render(json: data)
 
-      end
     end
   end
 end

--- a/app/controllers/api/v1/stats/channels_controller.rb
+++ b/app/controllers/api/v1/stats/channels_controller.rb
@@ -13,10 +13,20 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
       channel = Channel.find_by_id(params[:uuid])
 
       if(channel == nil)
-        redirect_to "/404"
+
+        error_response = JSON.pretty_generate({
+          errors: [{
+            status: "404",
+            title: "Not Found",
+            detail: "Channel with uuid " + params[:uuid] + " not found"
+          }]
+        })
+        render(json: error_response)
+
       else
 
         case channel.details_type
+
           when "SiteChannelDetails"
             channel_details = SiteChannelDetails.find_by_id(channel.details_id)
             channel_type = "website"

--- a/app/controllers/api/v1/stats/channels_controller.rb
+++ b/app/controllers/api/v1/stats/channels_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
 
   def channels
 
-    if params[:uuid] == nil
+    if(params[:uuid] == nil)
 
       channels = Channel.all.map { |channel| channel.id }
       data = JSON.pretty_generate(channels)

--- a/app/controllers/api/v1/stats/channels_controller.rb
+++ b/app/controllers/api/v1/stats/channels_controller.rb
@@ -1,28 +1,28 @@
 class Api::V1::Stats::ChannelsController < Api::BaseController
 
-  def channels
-
-    if params[:uuid].nil?
+  def index
 
       channels = Channel.all.map { |channel| channel.id }
-      data = JSON.pretty_generate(channels)
-      render(json: data)
+      data = channels.to_json
+      render(status: 200, json: data)
 
-    else
+  end
+
+  def show
 
       begin
 
         channel = Channel.find(params[:uuid])
 
         rescue ActiveRecord::RecordNotFound
-          error_response = JSON.pretty_generate({
+          error_response = {
             errors: [{
               status: "404",
               title: "Not Found",
               detail: "Channel with uuid #{params[:uuid]} not found"
               }]
-            })
-          render(json: error_response) and return
+            }
+          render(status: 404, json: error_response) and return
         end
 
         case channel.details_type
@@ -45,7 +45,7 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
             channel_name = channel_details.name
           end
 
-          data = JSON.pretty_generate({
+          data = {
             uuid: channel.id,
             channel_id: channel_details.channel_identifier,
             channel_type: channel_type,
@@ -55,10 +55,9 @@ class Api::V1::Stats::ChannelsController < Api::BaseController
             owner_id: channel.publisher.owner_identifier,
             created_at: channel.created_at,
             verified: channel.verified
-            })
+            }
 
-          render(json: data)
+          render(status: 200, json: data)
 
-    end
   end
 end

--- a/app/controllers/api/v1/stats/statistics_controller.rb
+++ b/app/controllers/api/v1/stats/statistics_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::Stats::StatsController < Api::BaseController
+class Api::V1::Stats::StatisticsController < Api::BaseController
 
   def signups_per_day
     sql =

--- a/app/controllers/api/v1/stats/stats_controller.rb
+++ b/app/controllers/api/v1/stats/stats_controller.rb
@@ -1,4 +1,5 @@
-class Api::StatsController < Api::BaseController
+class Api::V1::Stats::StatsController < Api::BaseController
+
   def signups_per_day
     sql =
     """
@@ -120,4 +121,5 @@ class Api::StatsController < Api::BaseController
 
     new_result
   end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,17 +86,24 @@ Rails.application.routes.draw do
     end
     resources :tokens, only: %i(index)
     resources :channels, constraints: { channel_id: %r{[^\/]+} }
-    namespace :stats do
-      get :signups_per_day
-      get :email_verified_signups_per_day
-      get :youtube_channels_by_view_count
-      get :twitch_channels_by_view_count
-      get :javascript_enabled_usage
-    end
+
+    # /api/v1/
     namespace :v1, defaults: { format: :json } do
+      # /api/v1/stats/
+      namespace :stats, defaults: { format: :json } do
+        get "channels", to: "channels#channels"
+        get "channels/:uuid", to: "channels#channels_uuid"
+        get :signups_per_day
+        get :email_verified_signups_per_day
+        get :youtube_channels_by_view_count
+        get :twitch_channels_by_view_count
+        get :javascript_enabled_usage
+      end
+      # /api/v1/public/
       namespace :public, defaults: { format: :json } do
         get "channels", controller: "channels"
       end
+
     end
   end
 
@@ -104,7 +111,7 @@ Rails.application.routes.draw do
     resources :faq_categories, except: [:show]
     resources :faqs, except: [:show]
     resources :payout_reports, only: %i(index show create) do
-      member do 
+      member do
         get :download
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,8 +91,8 @@ Rails.application.routes.draw do
     namespace :v1, defaults: { format: :json } do
       # /api/v1/stats/
       namespace :stats, defaults: { format: :json } do
-        get "/channels", to: "channels#channels"
-        get "/channels/:uuid", to: "channels#channels"
+        get '/channels', to: 'channels#index'
+        get '/channels/:uuid', to: 'channels#show'
         get "/signups_per_day", to: "statistics#signups_per_day"
         get "/email_verified_signups_per_day", to: "statistics#email_verified_signups_per_day"
         get "/youtube_channels_by_view_count", to: "statistics#youtube_channels_by_view_count"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,13 +91,13 @@ Rails.application.routes.draw do
     namespace :v1, defaults: { format: :json } do
       # /api/v1/stats/
       namespace :stats, defaults: { format: :json } do
-        get "channels", to: "channels#channels"
-        get "channels/:uuid", to: "channels#channels_uuid"
-        get :signups_per_day
-        get :email_verified_signups_per_day
-        get :youtube_channels_by_view_count
-        get :twitch_channels_by_view_count
-        get :javascript_enabled_usage
+        get "/channels", to: "channels#channels"
+        get "/channels/:uuid", to: "channels#channels"
+        get "/signups_per_day", to: "statistics#signups_per_day"
+        get "/email_verified_signups_per_day", to: "statistics#email_verified_signups_per_day"
+        get "/youtube_channels_by_view_count", to: "statistics#youtube_channels_by_view_count"
+        get "/twitch_channels_by_view_count", to: "statistics#twitch_channels_by_view_count"
+        get "/javascript_enabled_usage", to: "statistics#javascript_enabled_usage"
       end
       # /api/v1/public/
       namespace :public, defaults: { format: :json } do

--- a/test/controllers/api/v1/stats/channels_controller_test.rb
+++ b/test/controllers/api/v1/stats/channels_controller_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "shared/mailer_test_helper"
+
+class Api::V1::Stats::ChannelsControllerTest < ActionDispatch::IntegrationTest
+  test "/api/v1/stats/channels returns list of all channel uuids" do
+
+    get "/api/v1/stats/channels", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    result = JSON.parse(response.body)
+
+    assert result.is_a?(Array)
+    assert_equal(Channel.count, result.length)
+
+  end
+
+  test "/api/v1/stats/channels/:uuid returns json representation of channel" do
+
+    get "/api/v1/stats/channels/" + Channel.last.id, headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    result = JSON.parse(response.body)
+
+    assert(result.key?("uuid"))
+    assert(result.key?("channel_id"))
+    assert(result.key?("channel_type"))
+    assert(result.key?("name"))
+    assert(result.key?("stats"))
+    assert(result.key?("url"))
+    assert(result.key?("owner_id"))
+    assert(result.key?("created_at"))
+    assert(result.key?("verified"))
+
+  end
+
+end

--- a/test/controllers/api/v1/stats/channels_controller_test.rb
+++ b/test/controllers/api/v1/stats/channels_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "shared/mailer_test_helper"
 
 class Api::V1::Stats::ChannelsControllerTest < ActionDispatch::IntegrationTest
   test "/api/v1/stats/channels returns list of all channel uuids" do

--- a/test/controllers/api/v1/stats/channels_controller_test.rb
+++ b/test/controllers/api/v1/stats/channels_controller_test.rb
@@ -27,8 +27,9 @@ class Api::V1::Stats::ChannelsControllerTest < ActionDispatch::IntegrationTest
         assert(result.key?("created_at"))
         assert(result.key?("verified"))
 
-    else get "/api/v1/stats/channels/invalid_uuid"
-      assert_equal(403, response.status)
+    else get "/api/v1/stats/channels/invalid_uuid", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+      result = JSON.parse(response.body)
+      assert_equal(404, Integer(result["errors"][0]["status"]))
     end
   end
 end

--- a/test/controllers/api/v1/stats/channels_controller_test.rb
+++ b/test/controllers/api/v1/stats/channels_controller_test.rb
@@ -12,21 +12,23 @@ class Api::V1::Stats::ChannelsControllerTest < ActionDispatch::IntegrationTest
 
   end
 
-  test "/api/v1/stats/channels/:uuid returns json representation of channel" do
+  test "/api/v1/stats/channels/:uuid returns json representation of channel, or 404 if not found" do
 
-    get "/api/v1/stats/channels/" + Channel.last.id, headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
-    result = JSON.parse(response.body)
+    if(Channel.last != nil)
+      get "/api/v1/stats/channels/" + Channel.last.id, headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+      result = JSON.parse(response.body)
+        assert(result.key?("uuid"))
+        assert(result.key?("channel_id"))
+        assert(result.key?("channel_type"))
+        assert(result.key?("name"))
+        assert(result.key?("stats"))
+        assert(result.key?("url"))
+        assert(result.key?("owner_id"))
+        assert(result.key?("created_at"))
+        assert(result.key?("verified"))
 
-    assert(result.key?("uuid"))
-    assert(result.key?("channel_id"))
-    assert(result.key?("channel_type"))
-    assert(result.key?("name"))
-    assert(result.key?("stats"))
-    assert(result.key?("url"))
-    assert(result.key?("owner_id"))
-    assert(result.key?("created_at"))
-    assert(result.key?("verified"))
-
+    else get "/api/v1/stats/channels/invalid_uuid"
+      assert_equal(403, response.status)
+    end
   end
-
 end

--- a/test/controllers/api/v1/stats/statistics_controller_test.rb
+++ b/test/controllers/api/v1/stats/statistics_controller_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 require "shared/mailer_test_helper"
 
-class Api::StatsControllerTest < ActionDispatch::IntegrationTest
+class Api::V1::Stats::StatisticsControllerTest < ActionDispatch::IntegrationTest
   test "does signups per day and handles blanks" do
     publishers(:verified).update(created_at: 6.days.ago)
     publishers(:completed).update(created_at: 1.day.ago)
 
-    get "/api/stats/signups_per_day", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    get "/api/v1/stats/signups_per_day", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
 
     assert_equal 200, response.status
     resp = JSON.parse(response.body)
@@ -21,7 +21,7 @@ class Api::StatsControllerTest < ActionDispatch::IntegrationTest
       [0.days.ago.to_date.to_s, 24]
     ]
 
-    get "/api/stats/email_verified_signups_per_day", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    get "/api/v1/stats/email_verified_signups_per_day", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
 
     assert_equal 200, response.status
     resp = JSON.parse(response.body)
@@ -37,14 +37,14 @@ class Api::StatsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "youtube_channels_by_view_count returns an array of four arrays" do
-    get "/api/stats/youtube_channels_by_view_count", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    get "/api/v1/stats/youtube_channels_by_view_count", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
     result = JSON.parse(response.body)
     assert result.is_a?(Array)
     assert_equal result.length, 4
   end
 
   test "youtube_channels_by_view_count returns sorts channels into buckets by view count" do
-    get "/api/stats/youtube_channels_by_view_count", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    get "/api/v1/stats/youtube_channels_by_view_count", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
     result = JSON.parse(response.body)
 
     # ensure all view counts are within bucket_one range
@@ -77,7 +77,7 @@ class Api::StatsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "twitch_channels_by_view_count returns sorts channels into buckets by view count" do
-    get "/api/stats/twitch_channels_by_view_count", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    get "/api/v1/stats/twitch_channels_by_view_count", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
     result = JSON.parse(response.body)
 
     # ensure all view counts are within bucket_one range
@@ -111,7 +111,7 @@ class Api::StatsControllerTest < ActionDispatch::IntegrationTest
 
   test 'counts number of users with javascript enabled and disabled' do
     Publisher.update_all(last_sign_in_at: Time.now)
-    get "/api/stats/javascript_enabled_usage", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    get "/api/v1/stats/javascript_enabled_usage", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
     assert_equal response.status, 200
     assert_equal response.body, {
       active_users_with_javascript_enabled: 0,
@@ -120,7 +120,7 @@ class Api::StatsControllerTest < ActionDispatch::IntegrationTest
 
     Publisher.joins("inner join channels on channels.publisher_id = publishers.id").last.update(javascript_last_detected_at: Time.now)
 
-    get "/api/stats/javascript_enabled_usage", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+    get "/api/v1/stats/javascript_enabled_usage", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
     assert_equal response.status, 200
     assert_equal response.body, {
       active_users_with_javascript_enabled: 1,

--- a/test/fixtures/site_channel_details.yml
+++ b/test/fixtures/site_channel_details.yml
@@ -89,7 +89,7 @@ to_verify_file_details:
 to_verify_support_details:
   brave_publisher_id: "to_verify_support.org"
   verification_token: "xxxx01860b2185931ae4dbec06f7119712f928eaf39f0fe0c5a335e42b7eb1c6"
-  verification_method: 
+  verification_method:
 
 to_verify_wordpress_details:
   brave_publisher_id: "to_verify_wordpress.org"
@@ -132,4 +132,3 @@ fraudulently_verified_site_details:
 
 locked_out_site_details:
   brave_publisher_id: "contested.com"
-


### PR DESCRIPTION
#### API for stats, v1

* `api/v1/stats/channels`
`returns list of channel uuids`

* `api/v1/stats/channels/:uuid`
`returns the following for a given channel :`
```
{
  "uuid": 
  "channel_id": 
  "channel_type": 
  "name": 
  "stats": 
  "url": 
  "owner_id": 
  "created_at": 
  "verified": 
}
```
* `api/v1/stats/channels/:uuid` returns `404` if channel not found
* `api/v1/stats/` + `signups_per_day`, `email_verified_signups_per_day`, `etc...`
`returns results of the query`

##### Tests 

Found at `/test/controllers/api/v1/stats/channels_controller_test.rb`

Closes #896  