### PR TITLE
Do not apply fee twice to last settlement balance

### DIFF
--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -79,6 +79,12 @@ class PublisherWalletGetter < BaseApiClient
           "EUR" => 0.20187818378874756,
           "GBP" => 0.1799810085548496
         },
+        "lastSettlement"=>
+          {"altcurrency"=>"BAT",
+           "currency"=>"USD",
+           "probi"=>"405520562799219044167",
+           "amount"=>"69.78",
+           "timestamp"=>1536361540000},
         "wallet" => {
             "provider" => "uphold",
             "authorized" => true,
@@ -86,7 +92,8 @@ class PublisherWalletGetter < BaseApiClient
             "availableCurrencies" => [ "USD", "EUR", "BTC", "ETH", "BAT" ],
             "possibleCurrencies"=> ["AED", "ARS", "AUD", "BRL", "CAD", "CHF", "CNY", "DKK", "EUR", "GBP", "HKD", "ILS", "INR", "JPY", "KES", "MXN", "NOK", "NZD", "PHP", "PLN", "SEK", "SGD", "USD", "XAG", "XAU", "XPD", "XPT"],
             "scope"=> "cards:read user:read"
-        }
+        },
+
       }
 
     if publisher.channels.verified.any?

--- a/lib/eyeshade/balance.rb
+++ b/lib/eyeshade/balance.rb
@@ -2,12 +2,13 @@ module Eyeshade
   class Balance
     attr_reader :balance_json, :probi, :probi_before_fees, :fee, :currency, :altcurrency, :amount, :rates
 
-    def initialize(balance_json:)
+    def initialize(balance_json:, apply_fee: true)
       @balance_json = balance_json
       @probi_before_fees = balance_json['probi'] ? Integer(balance_json['probi']) : 0
 
       balance_and_fee = PublisherBalanceFeeCalculator.new(probi: probi_before_fees).perform
-      @probi = balance_and_fee[:balance_after_fee]
+      @probi = apply_fee ? balance_and_fee[:balance_after_fee] : @probi_before_fees
+
       @fee = balance_and_fee[:fee]
 
       @currency = balance_json['currency']

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -39,7 +39,7 @@ module Eyeshade
       end
 
       if wallet_json["lastSettlement"]
-        @last_settlement_balance = Eyeshade::Balance.new(balance_json: wallet_json["lastSettlement"].merge({'rates' => @rates}))
+        @last_settlement_balance = Eyeshade::Balance.new(balance_json: wallet_json["lastSettlement"].merge({'rates' => @rates}), apply_fee: false)
         @last_settlement_date = Time.at(wallet_json["lastSettlement"]["timestamp"]/1000).to_datetime
       end
     end

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -981,4 +981,33 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
       Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
     end
   end
+
+  test "fees aren't applied to last settlement balance" do
+    prev_api_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
+    begin
+      Rails.application.secrets[:api_eyeshade_offline] = false
+      publisher = publishers(:completed)
+      sign_in publisher
+      wallet = {"lastSettlement"=>
+                {"altcurrency"=>"BAT",
+                 "currency"=>"USD",
+                 "probi"=>"405520562799219044167",
+                 "amount"=>"69.78",
+                 "timestamp"=>1536361540000},
+               }.to_json
+    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+      to_return(status: 200, body: wallet, headers: {})
+
+    stub_request(:get, "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/accounts/balances?account=publishers%23uuid:4b296ba7-e725-5736-b402-50f4d15b1ac7&account=completed.org").
+      to_return(status: 200, body: [].to_json)
+
+    get home_publishers_path(publisher)
+
+    # ensure the last settlement balance does not have fees applied
+    assert_match "\"last_deposit_bat_amount\">405.52", response.body 
+
+    ensure
+      Rails.application.secrets[:api_eyeshade_offline] = prev_api_eyeshade_offline
+    end
+  end
 end

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -80,7 +80,7 @@ class PublishersHelperTest < ActionView::TestCase
     assert_equal "b8317d8a-78a4-48a6-9eeb-a2674c6455c4", publisher_id_from_owner_identifier("publishers#uuid:b8317d8a-78a4-48a6-9eeb-a2674c6455c4")
   end
 
-  test "publisher_humanize_balance should return a formatted & converted wallet balance" do
+  test "publisher_humanize_balance should return a formatted & converted wallet balance, last settlement balances do not apply fee" do
     class FakePublisher
       attr_reader :default_currency, :wallet
 
@@ -108,6 +108,12 @@ class PublishersHelperTest < ActionView::TestCase
           "EUR" => 0.20187818378874756,
           "GBP" => 0.1799810085548496
         },
+        "lastSettlement"=>
+          {"altcurrency"=>"BAT",
+           "currency"=>"USD",
+           "probi"=>"405520562799219044167",
+           "amount"=>"69.78",
+           "timestamp"=>1536361540000},
         "wallet" => {
           "provider" => "uphold",
           "authorized" => true,
@@ -118,6 +124,12 @@ class PublishersHelperTest < ActionView::TestCase
     )
     assert_not_nil publisher.wallet
     assert_equal "9001.00", publisher_humanize_balance(publisher, "USD")
+
+    # ensure last settlement balance does not have fee applied
+    assert_equal publisher_humanize_last_settlement(publisher, "BAT"), "405.52"
+
+    # ensure publisher_converted_last_settlement does not have fee applied
+    assert_equal publisher_converted_last_settlement(publisher), "~ 95.86 USD"
 
     publisher = FakePublisher.new(
       wallet_json: nil


### PR DESCRIPTION
The last settlement balance returned by eyeshade in the /wallet response is the amount that was settled, so it already has taken fees into account.  However, when we display a publishers last settlement balance we are applying the fee twice.

This happens in two places:

1. When we calculate the last settlement balance with ruby in PublishersHelper#publisher_humanize_last_settlement and PublishersHelperpublisher_converted_last_settlement

2.  When the default currency is changed, we us JS to get the latest balance and update the DOM. 
since we use `probi` instead of `probi_before_fees` in the wallet JSON that's sent to the dashboard.

https://github.com/brave-intl/publishers/blob/08928c4c12cda5cd0d0d5228ef44ec4f27056fed/app/models/json_builders/wallet_json_builder.rb#L47-L49

This might lead publishers who didn't view their statement to believe they have received less than they actually did.

Thanks to @evq for finding the bug.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
