### PR TITLE
Lower frequency of SyncPublisherPromoStatsJob

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -24,9 +24,9 @@
     cron: "0 8 * * *"
     description: "Complete transfer of channels that have exceeded their timeout time without being rejected"
   SyncPublisherPromoStatsJob:
-    cron: "0 */3 * * *"
-    description: "For Publishers who have enabled a promo, sync their referral stats with the promo server"
-    queue: transactional
+    cron: "15 3 * * *"
+    description: "For Publishers who have enabled a promo, sync their referral stats with the promo server once a day."
+    queue: scheduler
   SyncChannelStatsJob:
     cron: "0 1 * * *"
     description: "Syncs the channel stats via youtube and twitch apis"


### PR DESCRIPTION
From once every three hours to once a day.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
