### PR TITLE
Prevent users from adding site banners if they're not in the whitelist

### DIFF
--- a/app/controllers/publishers/site_banners_controller.rb
+++ b/app/controllers/publishers/site_banners_controller.rb
@@ -9,6 +9,7 @@ class Publishers::SiteBannersController < ApplicationController
   end
 
   def create
+    head 401 unless current_publisher.in_brave_rewards_whitelist?
     site_banner = current_publisher.site_banner || SiteBanner.new
     donation_amounts = JSON.parse(params[:donation_amounts])
     site_banner.update(
@@ -34,6 +35,7 @@ class Publishers::SiteBannersController < ApplicationController
   end
 
   def update_logo
+    head 401 unless current_publisher.in_brave_rewards_whitelist?
     if params[:image].length > MAX_IMAGE_SIZE
       # (Albert Wang): We should consider supporting alerts. This might require a UI redesign
       # alert[:error] = "File size too big!"
@@ -45,6 +47,7 @@ class Publishers::SiteBannersController < ApplicationController
   end
 
   def update_background_image
+    head 401 unless current_publisher.in_brave_rewards_whitelist?
     if params[:image].length > MAX_IMAGE_SIZE
       # (Albert Wang): We should consider supporting alerts. This might require a UI redesign
       # alert[:error] = "File size too big!"


### PR DESCRIPTION
Closes #1237

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
