### PR TITLE
Continue to check authenticate_user to get

### DIFF
--- a/app/controllers/publishers/site_banners_controller.rb
+++ b/app/controllers/publishers/site_banners_controller.rb
@@ -1,5 +1,8 @@
 class Publishers::SiteBannersController < ApplicationController
   include ImageConversionHelper
+  protect_from_forgery prepend: true, with: :exception
+  before_action :authenticate_publisher!, only: [:create, :update_logo, :update_background]
+
 
   MAX_IMAGE_SIZE = 10_000_000
 


### PR DESCRIPTION
current_user/current_publisher by re-adjusting the action sequence in
the verification process.

Per Devise documents:
For Rails 5, note that protect_from_forgery is no longer prepended to the before_action chain, so if you have set authenticate_user before protect_from_forgery, your request will result in "Can't verify CSRF token authenticity." To resolve this, either change the order in which you call them, or use protect_from_forgery prepend: true.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
