### PR TITLE
Add admin interface for referral code creation / management / reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ On debian you can install it like:
 ```sh
 sudo apt-get install chromium
 ```
+And on mac with:
+
+```
+brew cask install chromium
+```
+
+We also use ImageMagick to process user uploaded images. If you don't have it already, you might get an error "You must have ImageMagick or GraphicsMagick installed".  You can install on mac with:
+
+```
+brew install imagemagick
+```
 
 ## Running locally with docker-compose
 

--- a/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
+++ b/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
@@ -19,4 +19,76 @@
     width: 100%;
     text-align: center;
   }
+
+  .table {
+    text-align: center;
+    
+    tr {
+      td {
+        padding: 0;
+      }
+    }
+  }
+
+  span.tf-tooltip {
+    position: relative;
+    display: inline-block;
+    color: $link-color;
+
+    span.icon {
+      position: relative;
+      padding-left: 3px;
+    }
+
+    span.tf-tooltip-content {
+      display: none;
+      position: absolute;
+      z-index: 5;
+      left: 50%;
+      bottom: 100%;
+      width: 300px;
+      margin-left: -200px;
+      padding: 30px 40px;
+      background: white;
+      border: solid 1px $braveGray-8;
+      border-radius: 4px;
+      box-shadow: 0 0 10px 0 rgba(34,35,38,0.15);
+      color: $braveText-3;
+      font-size: 14px;
+      line-height: 22px;
+
+      &::after {
+        content: " ";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        width: 10px;
+        height: 10px;
+        margin-top: -5px;
+        margin-left: -5px;
+        background: white;
+        transform: rotate(45deg);
+        border: solid 1px $braveGray-8;
+        border-top-color: transparent;
+        border-left-color: transparent;
+      }
+
+      span.tf-tooltip-content-heading {
+        display: block;
+        font-family: $headings-font-family;
+        font-weight: $headings-font-weight;
+        color: $braveAccent-Dark;
+      }
+
+      span.tf-tooltip-content-content {
+        display: block;
+      }
+    }
+
+    &:hover {
+      span.tf-tooltip-content {
+        display: block;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
+++ b/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
@@ -1,0 +1,22 @@
+.unattached-promo-registrations {
+  .btn {
+    margin: 0px 5px 5px 5px;
+  }
+  .unattached-referral-code-form--submissions {
+    display: flex;
+  }
+  .unattached-referral-code-form--submission {
+    flex: 1;
+  }
+
+  label {
+    font-weight: bold;
+  }
+  .unattached-referral-code-form--submission--element {
+    padding: 0px 0px 15px 0px;
+  }
+  .unattached-referral-code-form--submission--submit {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
+++ b/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
@@ -42,6 +42,22 @@
     flex: 1;
   }
 
+  .flex-one {
+    flex: 2;
+  }
+
+  .flex-three {
+    flex: 3;
+  }
+
+  .align-self-center {
+    align-self: center;
+  }
+
+  .align-self-flex-end {
+    align-self: flex-end;
+  }
+
   .btn {
     margin: 0px 5px 5px 5px;
   }

--- a/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
+++ b/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
@@ -1,23 +1,59 @@
+
 .unattached-promo-registrations {
+
+  .row {
+    display: flex;
+  }
+
+  .panel {
+    background: aliceblue;
+    flex: 1;
+    border-width: 1px;
+    border-radius: 15px;
+    margin: 15px;
+    padding: 20px 50px 20px 50px;
+
+    .panel--header {
+      font-size: 20px;
+      font-weight: bold;
+    }
+
+    .panel--sub-panel-header {
+      font-size: 18px;
+      font-weight: bold;
+    }
+
+    &--color-offset {
+      background: white;      
+    }
+
+  .download-button {
+    padding-top: 10px;
+    text-align: center;
+  }
+  }
+  .panel--double {
+  }
+
+  .panel--single {
+  }
+
+  .flex-one {
+    flex: 1;
+  }
+
   .btn {
     margin: 0px 5px 5px 5px;
   }
   .unattached-referral-code-form--submissions {
     display: flex;
+    width: 100%;
   }
   .unattached-referral-code-form--submission {
-    flex: 1;
   }
 
   label {
     font-weight: bold;
-  }
-  .unattached-referral-code-form--submission--element {
-    padding: 0px 0px 15px 0px;
-  }
-  .unattached-referral-code-form--submission--submit {
-    width: 100%;
-    text-align: center;
   }
 
   .table {

--- a/app/controllers/admin/promo_campaigns_controller.rb
+++ b/app/controllers/admin/promo_campaigns_controller.rb
@@ -1,0 +1,13 @@
+class Admin::PromoCampaignsController < AdminController
+  def create
+    campaign_name = create_params
+    PromoCampaign.create(name: campaign_name)
+    redirect_to admin_unattached_promo_registrations_path, notice: "Created campaign '#{campaign_name}'."
+  end
+  
+  private
+
+  def create_params
+    params.require(:campaign_name)
+  end
+end

--- a/app/controllers/admin/promo_campaigns_controller.rb
+++ b/app/controllers/admin/promo_campaigns_controller.rb
@@ -1,8 +1,14 @@
 class Admin::PromoCampaignsController < AdminController
   def create
     campaign_name = create_params
-    PromoCampaign.create(name: campaign_name)
-    redirect_to admin_unattached_promo_registrations_path, notice: "Created campaign '#{campaign_name}'."
+    campaign_name.strip!
+    campaign = PromoCampaign.create(name: campaign_name)
+    if campaign.errors.any?
+      # TODO Deal with other error types beyond :taken
+      redirect_to admin_unattached_promo_registrations_path, alert: "Campaign name '#{campaign_name}' is already taken."
+    else
+      redirect_to admin_unattached_promo_registrations_path, notice: "Created campaign '#{campaign_name}'."
+    end
   end
   
   private

--- a/app/controllers/admin/unattached_promo_registrations_controller.rb
+++ b/app/controllers/admin/unattached_promo_registrations_controller.rb
@@ -44,7 +44,7 @@ class Admin::UnattachedPromoRegistrationsController < AdminController
     @report_contents = report_info["contents"]
 
     report_string = render_to_string :layout => false
-    send_data report_string, filename: "BraveReferralPromoStatement.html", type: "application/html"
+    send_data report_string, filename: "BraveReferralPromoReport.html", type: "application/html"
   end
 
   def update_statuses

--- a/app/controllers/admin/unattached_promo_registrations_controller.rb
+++ b/app/controllers/admin/unattached_promo_registrations_controller.rb
@@ -24,7 +24,7 @@ class Admin::UnattachedPromoRegistrationsController < AdminController
     redirect_to admin_unattached_promo_registrations_path, notice: "#{number} codes created."
   end
 
-  def statement
+  def report
     referral_codes = params[:referral_codes]
     @reporting_interval = params[:reporting_interval]
     @event_types = params[:event_types]
@@ -33,18 +33,18 @@ class Admin::UnattachedPromoRegistrationsController < AdminController
                         alert: "Please check at least one of downloads, installs, or confirmations."
     end
     
-    statement_start_and_end_date = parse_statement_dates(params[:referral_code_statement_period], @reporting_interval)
-    statement_info = PromoStatementGenerator.new(referral_codes: referral_codes,
-                                                  start_date: statement_start_and_end_date[:start_date],
-                                                  end_date: statement_start_and_end_date[:end_date],
+    report_start_and_end_date = parse_report_dates(params[:referral_code_report_period], @reporting_interval)
+    report_info = PromoReportGenerator.new(referral_codes: referral_codes,
+                                                  start_date: report_start_and_end_date[:start_date],
+                                                  end_date: report_start_and_end_date[:end_date],
                                                   reporting_interval: @reporting_interval).perform
 
-    @start_date = statement_info["start_date"]
-    @end_date = statement_info["end_date"]
-    @statement_contents = statement_info["contents"]
+    @start_date = report_info["start_date"]
+    @end_date = report_info["end_date"]
+    @report_contents = report_info["contents"]
 
-    statement_string = render_to_string :layout => false
-    send_data statement_string, filename: "BraveReferralPromoStatement.html", type: "application/html"
+    report_string = render_to_string :layout => false
+    send_data report_string, filename: "BraveReferralPromoStatement.html", type: "application/html"
   end
 
   def update_statuses
@@ -67,13 +67,13 @@ class Admin::UnattachedPromoRegistrationsController < AdminController
 
   private
 
-  def parse_statement_dates(statement_period, reporting_interval)
-    start_date = Date.new(statement_period["start(1i)"].to_i,
-                          statement_period["start(2i)"].to_i,
-                          statement_period["start(3i)"].to_i)
-    end_date = Date.new(statement_period["end(1i)"].to_i,
-                        statement_period["end(2i)"].to_i,
-                        statement_period["end(3i)"].to_i)
+  def parse_report_dates(report_period, reporting_interval)
+    start_date = Date.new(report_period["start(1i)"].to_i,
+                          report_period["start(2i)"].to_i,
+                          report_period["start(3i)"].to_i)
+    end_date = Date.new(report_period["end(1i)"].to_i,
+                        report_period["end(2i)"].to_i,
+                        report_period["end(3i)"].to_i)
     {
       start_date: start_date,
       end_date: end_date

--- a/app/controllers/admin/unattached_promo_registrations_controller.rb
+++ b/app/controllers/admin/unattached_promo_registrations_controller.rb
@@ -5,12 +5,12 @@ class Admin::UnattachedPromoRegistrationsController < AdminController
     filter = params[:filter]
     case filter
     when "All codes", nil, ""
-      @promo_registrations = PromoRegistration.where(kind: "unattached").order("created_at DESC")
+      @promo_registrations = PromoRegistration.unattached.order("created_at DESC")
     when "Not assigned"
-      @promo_registrations = PromoRegistration.where(kind: "unattached").where(promo_campaign_id: nil).order("created_at DESC")
+      @promo_registrations = PromoRegistration.unattached.where(promo_campaign_id: nil).order("created_at DESC")
     else
       @promo_registrations = PromoRegistration.joins(:promo_campaign).
-                                               where(kind: "unattached").
+                                               unattached.
                                                where(promo_campaigns: {name: filter}).
                                                order("created_at DESC")
     end

--- a/app/controllers/admin/unattached_promo_registrations_controller.rb
+++ b/app/controllers/admin/unattached_promo_registrations_controller.rb
@@ -1,0 +1,86 @@
+class Admin::UnattachedPromoRegistrationsController < AdminController
+  include PromosHelper
+
+  def index
+    filter = params[:filter]
+    case filter
+    when "All codes", nil, ""
+      @promo_registrations = PromoRegistration.where(kind: "unattached").order("created_at DESC")
+    when "Not assigned"
+      @promo_registrations = PromoRegistration.where(kind: "unattached").where(promo_campaign_id: nil).order("created_at DESC")
+    else
+      @promo_registrations = PromoRegistration.joins(:promo_campaign).
+                                               where(kind: "unattached").
+                                               where(promo_campaigns: {name: filter}).
+                                               order("created_at DESC")
+    end
+    @current_campaign = params[:filter] || "All codes"
+    @campaigns = PromoCampaign.all.map {|campaign| campaign.name}
+  end
+
+  def create
+    number = create_params.to_i
+    PromoRegistrarUnattached.new(number: number).perform
+    redirect_to admin_unattached_promo_registrations_path, notice: "#{number} codes created."
+  end
+
+  def statement
+    referral_codes = params[:referral_codes]
+    @reporting_interval = params[:reporting_interval]
+    @event_types = params[:event_types]
+    if @event_types.nil?
+      return redirect_to admin_unattached_promo_registrations_path(filter: params[:filter]),
+                        alert: "Please check at least one of downloads, installs, or confirmations."
+    end
+    
+    statement_start_and_end_date = parse_statement_dates(params[:referral_code_statement_period], @reporting_interval)
+    statement_info = PromoStatementGenerator.new(referral_codes: referral_codes,
+                                                  start_date: statement_start_and_end_date[:start_date],
+                                                  end_date: statement_start_and_end_date[:end_date],
+                                                  reporting_interval: @reporting_interval).perform
+
+    @start_date = statement_info["start_date"]
+    @end_date = statement_info["end_date"]
+    @statement_contents = statement_info["contents"]
+
+    statement_string = render_to_string :layout => false
+    send_data statement_string, filename: "BraveReferralPromoStatement.html", type: "application/html"
+  end
+
+  def update_statuses
+    referral_codes = params[:referral_codes]
+    referral_code_status = params[:referral_code_status]
+    promo_registrations = PromoRegistration.where(referral_code: referral_codes)
+    PromoUnattachedStatusUpdater.new(promo_registrations: promo_registrations, status: referral_code_status).perform
+    redirect_to admin_unattached_promo_registrations_path(filter: params[:filter]),
+                notice: "#{referral_codes.count} codes updated to '#{referral_code_status}' status."
+  end
+
+  def assign
+    referral_codes = params[:referral_codes]
+    promo_campaign_target = PromoCampaign.where(name: params[:promo_campaign_target]).first
+    promo_registrations = PromoRegistration.where(referral_code: referral_codes)
+    promo_registrations.update_all(promo_campaign_id: promo_campaign_target.id)
+    redirect_to admin_unattached_promo_registrations_path(filter: params[:promo_campaign_target]),
+                notice: "Assigned #{referral_codes.count} codes to campaign '#{params[:promo_campaign_target]}'."
+  end
+
+  private
+
+  def parse_statement_dates(statement_period, reporting_interval)
+    start_date = Date.new(statement_period["start(1i)"].to_i,
+                          statement_period["start(2i)"].to_i,
+                          statement_period["start(3i)"].to_i)
+    end_date = Date.new(statement_period["end(1i)"].to_i,
+                        statement_period["end(2i)"].to_i,
+                        statement_period["end(3i)"].to_i)
+    {
+      start_date: start_date,
+      end_date: end_date
+    }
+  end
+
+  def create_params
+    params.require(:number_of_codes_to_create)
+  end
+end

--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -83,14 +83,14 @@ module PromosHelper
 
   def reporting_interval_column_header(reporting_interval)
     case reporting_interval
-    when "by_day"
+    when PromoRegistration::DAILY
       "Day"
-    when "by_week"
+    when PromoRegistration::WEEKLY
       "Week"
-    when "by_month"
+    when PromoRegistration::MONTHLY
       "Month"
-    when "cumulative"
-      "cumulative"
+    when PromoRegistration::RUNNING_TOTAL
+      "Cumulative"
     else
       raise
     end
@@ -111,11 +111,11 @@ module PromosHelper
 
   def coerce_date_to_start_or_end_of_reporting_interval(date, reporting_interval, start)
     case reporting_interval
-    when "by_day", "cumulative"
+    when PromoRegistration::DAILY, PromoRegistration::RUNNING_TOTAL
       date
-    when "by_week"
+    when PromoRegistration::WEEKLY
       start ? date.at_beginning_of_week : date.at_end_of_week
-    when "by_month"
+    when PromoRegistration::MONTHLY
       start ? date.at_beginning_of_month : date.at_end_of_month
     else
       raise

--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -80,4 +80,45 @@ module PromosHelper
       raise
     end
   end
+
+  def reporting_interval_column_header(reporting_interval)
+    case reporting_interval
+    when "by_day"
+      "Day"
+    when "by_week"
+      "Week"
+    when "by_month"
+      "Month"
+    when "cumulative"
+      "cumulative"
+    else
+      raise
+    end
+  end
+
+  def event_type_column_header(event_type)
+    case event_type
+    when "retrievals"
+      "Downloads"
+    when "first_runs"
+      "Installs"
+    when "finalized"
+      "Confirmations"
+    else
+      raise
+    end
+  end
+
+  def coerce_date_to_start_or_end_of_reporting_interval(date, reporting_interval, start)
+    case reporting_interval
+    when "by_day", "cumulative"
+      date
+    when "by_week"
+      start ? date.at_beginning_of_week : date.at_end_of_week
+    when "by_month"
+      start ? date.at_beginning_of_month : date.at_end_of_month
+    else
+      raise
+    end
+  end
 end

--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -98,11 +98,11 @@ module PromosHelper
 
   def event_type_column_header(event_type)
     case event_type
-    when "retrievals"
+    when PromoRegistration::RETRIEVALS
       "Downloads"
-    when "first_runs"
+    when PromoRegistration::FIRST_RUNS
       "Installs"
-    when "finalized"
+    when PromoRegistration::FINALIZED
       "Confirmations"
     else
       raise

--- a/app/javascript/admin/dashboard/unattached_promo_registration.js
+++ b/app/javascript/admin/dashboard/unattached_promo_registration.js
@@ -1,0 +1,24 @@
+import {
+  fetchAfterDelay,
+  submitForm
+} from '../../utils/request';
+
+document.addEventListener('DOMContentLoaded', function() {
+  var unattachedReferralCodeForm = document.getElementById('unattached-referral-code-form');
+
+  let assignToCampaignButton = document.getElementById('assign-to-campaign')
+  assignToCampaignButton.addEventListener('click', function(event){
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/assign'
+  })
+
+  let downloadReferralStatementButton = document.getElementById('download-referral-statements')
+  downloadReferralStatementButton.addEventListener('click', function(event){
+    unattachedReferralCodeForm.method = 'get'
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/statement'
+  })
+
+  let updateReferralCodeStatusesButton = document.getElementById('update-referral-code-statuses')
+  updateReferralCodeStatusesButton.addEventListener('click', function(event){
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/update_statuses'
+  })
+})

--- a/app/javascript/admin/dashboard/unattached_promo_registration.js
+++ b/app/javascript/admin/dashboard/unattached_promo_registration.js
@@ -11,10 +11,10 @@ document.addEventListener('DOMContentLoaded', function() {
     unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/assign'
   })
 
-  let downloadReferralStatementButton = document.getElementById('download-referral-statements')
-  downloadReferralStatementButton.addEventListener('click', function(event){
+  let downloadReferralReportButton = document.getElementById('download-referral-reports')
+  downloadReferralReportButton.addEventListener('click', function(event){
     unattachedReferralCodeForm.method = 'get'
-    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/statement'
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/report'
   })
 
   let updateReferralCodeStatusesButton = document.getElementById('update-referral-code-statuses')

--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -1,5 +1,6 @@
 import 'utils/request';
 import 'admin/dashboard/index';
+import 'admin/dashboard/unattached_promo_registration'
 import Rails from 'rails-ujs';
 
 /*

--- a/app/jobs/sync_admin_promo_stats_job.rb
+++ b/app/jobs/sync_admin_promo_stats_job.rb
@@ -4,7 +4,11 @@ class SyncAdminPromoStatsJob < ApplicationJob
   queue_as :low
 
   def perform(promo_id: active_promo_id)
-    promo_registrations = PromoRegistration.where(kind: "unattached")
-    AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+    promo_registrations = PromoRegistration.unattached
+    success = AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+
+    if success
+      Rails.cache.write("unattached_promo_registration_stats_last_synced_at", Time.now)
+    end
   end
 end

--- a/app/jobs/sync_admin_promo_stats_job.rb
+++ b/app/jobs/sync_admin_promo_stats_job.rb
@@ -1,0 +1,10 @@
+# Fetches and saves the referral stats for admins
+class SyncAdminPromoStatsJob < ApplicationJob
+  include PromosHelper
+  queue_as :low
+
+  def perform(promo_id: active_promo_id)
+    promo_registrations = PromoRegistration.where(kind: "unattached")
+    AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+  end
+end

--- a/app/models/promo_campaign.rb
+++ b/app/models/promo_campaign.rb
@@ -1,0 +1,4 @@
+class PromoCampaign < ApplicationRecord
+  has_many :promo_registrations
+  validates :name, uniqueness: true
+end

--- a/app/models/promo_campaign.rb
+++ b/app/models/promo_campaign.rb
@@ -1,4 +1,4 @@
 class PromoCampaign < ApplicationRecord
   has_many :promo_registrations
-  validates :name, uniqueness: true
+  validates :name, :uniqueness => {:case_sensitive => false}
 end

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -5,17 +5,21 @@ class PromoRegistration < ApplicationRecord
   # a publisher, or be unattached.  Unattached codes
   # are created by admins.
 
-  KINDS = ["channel", "owner", "unattached"].freeze
+  CHANNEL = "channel".freeze
+  OWNER = "owner".freeze
+  UNATTACHED ="unattached".freeze
+  KINDS = [CHANNEL, OWNER, UNATTACHED].freeze
   
   belongs_to :channel, validate: true, autosave: true
   belongs_to :promo_campaign
 
-  validates :channel_id, presence: true, if: -> { kind == "channel"}
-
+  validates :channel_id, presence: true, if: -> { kind == CHANNEL}
   validates :promo_id, presence: true
   validates :kind, presence: true
   validates :kind, inclusion: { in: KINDS, message: "%{value} is not a valid kind of promo registration." }
   validates :referral_code, presence: true, uniqueness: { scope: :promo_id }
+
+  scope :unattached, -> { where(kind: "unattached") }
 
   def aggregate_stats
     JSON.parse(stats).reduce({"retrievals" => 0,

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -1,11 +1,30 @@
 class PromoRegistration < ApplicationRecord
   has_paper_trail
+
+  # A promo registration can belong to a channel,
+  # a publisher, or be unattached.  Unattached codes
+  # are created by admins.
+
+  KINDS = ["channel", "owner", "unattached"].freeze
   
   belongs_to :channel, validate: true, autosave: true
+  belongs_to :promo_campaign
 
-  validates :channel_id, presence: true
+  validates :channel_id, presence: true, if: -> { kind == "channel"}
 
   validates :promo_id, presence: true
-
+  validates :kind, presence: true
+  validates :kind, inclusion: { in: KINDS, message: "%{value} is not a valid kind of promo registration." }
   validates :referral_code, presence: true, uniqueness: { scope: :promo_id }
+
+  def aggregate_stats
+    JSON.parse(stats).reduce({"retrievals" => 0,
+                              "first_runs" => 0,
+                              "finalized" => 0}) { |aggregate_stats, event|
+      aggregate_stats["retrievals"] += event["retrievals"]
+      aggregate_stats["first_runs"] += event["first_runs"]
+      aggregate_stats["finalized"] += event["finalized"]
+      aggregate_stats.slice("retrievals", "first_runs", "finalized")
+    }
+  end
 end

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -5,10 +5,15 @@ class PromoRegistration < ApplicationRecord
   # a publisher, or be unattached.  Unattached codes
   # are created by admins.
 
+  # Constants
   CHANNEL = "channel".freeze
   OWNER = "owner".freeze
   UNATTACHED ="unattached".freeze
   KINDS = [CHANNEL, OWNER, UNATTACHED].freeze
+
+  RETRIEVALS = "retrievals" # Aliased as 'Downloads'
+  FIRST_RUNS = "first_runs" # Aliased as 'Installs'
+  FINALIZED = "finalized" # Aliased as 'Confirmed'
   
   belongs_to :channel, validate: true, autosave: true
   belongs_to :promo_campaign
@@ -19,16 +24,16 @@ class PromoRegistration < ApplicationRecord
   validates :kind, inclusion: { in: KINDS, message: "%{value} is not a valid kind of promo registration." }
   validates :referral_code, presence: true, uniqueness: { scope: :promo_id }
 
-  scope :unattached, -> { where(kind: "unattached") }
+  scope :unattached, -> { where(kind: UNATTACHED) }
 
   def aggregate_stats
-    JSON.parse(stats).reduce({"retrievals" => 0,
-                              "first_runs" => 0,
-                              "finalized" => 0}) { |aggregate_stats, event|
-      aggregate_stats["retrievals"] += event["retrievals"]
-      aggregate_stats["first_runs"] += event["first_runs"]
-      aggregate_stats["finalized"] += event["finalized"]
-      aggregate_stats.slice("retrievals", "first_runs", "finalized")
+    JSON.parse(stats).reduce({RETRIEVALS => 0,
+                              FIRST_RUNS => 0,
+                              FINALIZED => 0}) { |aggregate_stats, event|
+      aggregate_stats[RETRIEVALS] += event[RETRIEVALS]
+      aggregate_stats[FIRST_RUNS] += event[FIRST_RUNS]
+      aggregate_stats[FINALIZED] += event[FINALIZED]
+      aggregate_stats.slice(RETRIEVALS, FIRST_RUNS, FINALIZED)
     }
   end
 end

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -14,6 +14,11 @@ class PromoRegistration < ApplicationRecord
   RETRIEVALS = "retrievals" # Aliased as 'Downloads'
   FIRST_RUNS = "first_runs" # Aliased as 'Installs'
   FINALIZED = "finalized" # Aliased as 'Confirmed'
+
+  DAILY = "daily"
+  WEEKLY = "weekly"
+  MONTHLY = "monthly"
+  RUNNING_TOTAL = "running_total"
   
   belongs_to :channel, validate: true, autosave: true
   belongs_to :promo_campaign

--- a/app/services/admin_promo_stats_fetcher.rb
+++ b/app/services/admin_promo_stats_fetcher.rb
@@ -1,0 +1,51 @@
+# Fetches and updates the stats for unattached codes
+class AdminPromoStatsFetcher < BaseApiClient
+  include PromosHelper
+
+  def initialize(promo_registrations:)
+    @referral_codes = promo_registrations.map { |promo_registration|
+      promo_registration.referral_code
+    }
+  end
+
+  def perform
+    return perform_offline if Rails.application.secrets[:api_promo_base_uri].blank?
+    response = connection.get do |request|
+      request.options.params_encoder = Faraday::FlatParamsEncoder
+      request.headers["Authorization"] = api_authorization_header
+      request.headers["Content-Type"] = "application/json"
+      request.url("/api/2/promo/statsByReferralCode#{query_string}")
+    end
+    referral_code_events_date_list = JSON.parse(response.body)
+
+    @referral_codes.each do |referral_code|
+      promo_registration = PromoRegistration.find_by_referral_code(referral_code)
+      promo_registration.stats = referral_code_events_date_list.select {|referral_code_event_date|
+        referral_code_event_date["referral_code"] == referral_code
+      }.to_json
+      promo_registration.save!
+    end
+  end
+
+  def perform_offline
+    true
+  end
+
+  private
+
+  def api_base_uri
+    Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  def api_authorization_header
+    "Bearer #{Rails.application.secrets[:api_promo_key]}"
+  end
+
+  def query_string
+    query_string = "?"
+    @referral_codes.each do |referral_code|
+      query_string = "#{query_string}referral_code=#{referral_code}&"
+    end
+    query_string.chomp("&") # Remove the final ampersand
+  end
+end

--- a/app/services/promo_registrar.rb
+++ b/app/services/promo_registrar.rb
@@ -14,7 +14,7 @@ class PromoRegistrar < BaseApiClient
       if should_register_channel?(channel)
         referral_code = register_channel(channel)
         if referral_code.present?
-          promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: @promo_id, referral_code: referral_code)
+          promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: @promo_id, kind: "channel", referral_code: referral_code)
           promo_registration.save!
         end
       end

--- a/app/services/promo_registrar_unattached.rb
+++ b/app/services/promo_registrar_unattached.rb
@@ -21,7 +21,7 @@ class PromoRegistrarUnattached < BaseApiClient
     promo_registrations.each do |promo_registration|
       PromoRegistration.create!(referral_code: promo_registration["referral_code"],
                                 promo_id: active_promo_id,
-                                kind: "unattached")
+                                kind: PromoRegistration::UNATTACHED)
     end
   end
 

--- a/app/services/promo_registrar_unattached.rb
+++ b/app/services/promo_registrar_unattached.rb
@@ -1,0 +1,42 @@
+# Registers infinity codes for a Brave admin
+class PromoRegistrarUnattached < BaseApiClient
+  include PromosHelper
+
+  def initialize(number:, promo_id: active_promo_id, campaign: nil)
+    @number = number
+    @promo_id = promo_id
+    @campaign
+  end
+
+  def perform
+    return if @number <= 0
+    return register_unattached_offline if perform_promo_offline?
+    response = connection.put do |request|
+      request.headers["Authorization"] = api_authorization_header
+      request.headers["Content-Type"] = "application/json"
+      request.url("/api/2/promo/referral_code/unattached?number=#{@number}")
+    end
+
+    promo_registrations = JSON.parse(response.body)
+    promo_registrations.each do |promo_registration|
+      PromoRegistration.create!(referral_code: promo_registration["referral_code"],
+                                promo_id: active_promo_id,
+                                kind: "unattached")
+    end
+  end
+
+  def register_unattached_offline
+    Rails.logger.info("PromoRegistrar #register_channel offline.")
+    offline_referral_code
+  end
+
+  private
+
+  def api_base_uri
+    Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  def api_authorization_header
+    "Bearer #{Rails.application.secrets[:api_promo_key]}"
+  end
+end

--- a/app/services/promo_report_generator.rb
+++ b/app/services/promo_report_generator.rb
@@ -26,9 +26,9 @@ class PromoReportGenerator < BaseService
         (event["ymd"].to_date >= @start_date) && (event["ymd"].to_date <= @end_date)
       }
 
-      if @reporting_interval == "cumulative"
-        base_case = {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, "finalized" => 0 }
-        cumulative_report_contents = events_within_report_period.reduce(base_case) { |aggregate_stats, event|
+      if @reporting_interval == PromoRegistration::RUNNING_TOTAL
+        base_case = {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, PromoRegistration::FINALIZED => 0 }
+        running_total_report_contents = events_within_report_period.reduce(base_case) { |aggregate_stats, event|
           aggregate_stats[PromoRegistration::RETRIEVALS] += event[PromoRegistration::RETRIEVALS]
           aggregate_stats[PromoRegistration::FIRST_RUNS] += event[PromoRegistration::FIRST_RUNS]
           aggregate_stats[PromoRegistration::FINALIZED] += event[PromoRegistration::FINALIZED]
@@ -36,7 +36,7 @@ class PromoReportGenerator < BaseService
         }
 
         report_contents_for_referral_code = {
-          @start_date => cumulative_report_contents
+          @start_date => running_total_report_contents
         }
 
         report_contents["#{promo_registration.referral_code}"] = report_contents_for_referral_code
@@ -99,11 +99,11 @@ class PromoReportGenerator < BaseService
         PromoRegistration::FINALIZED => 0
       }
       case reporting_interval
-      when "by_day"
+      when PromoRegistration::DAILY
         current_date = current_date + 1.day
-      when "by_week"
+      when PromoRegistration::WEEKLY
         current_date = current_date + 1.week
-      when "by_month"
+      when PromoRegistration::MONTHLY
         current_date = current_date + 1.month
       else
         raise

--- a/app/services/promo_statement_generator.rb
+++ b/app/services/promo_statement_generator.rb
@@ -28,7 +28,7 @@ class PromoStatementGenerator < BaseService
 
       if @reporting_interval == "cumulative"
         base_case = {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, "finalized" => 0 }
-        culmative_statement_contents = events_within_statement_period.reduce(base_case) { |aggregate_stats, event|
+        cumulative_statement_contents = events_within_statement_period.reduce(base_case) { |aggregate_stats, event|
           aggregate_stats[PromoRegistration::RETRIEVALS] += event[PromoRegistration::RETRIEVALS]
           aggregate_stats[PromoRegistration::FIRST_RUNS] += event[PromoRegistration::FIRST_RUNS]
           aggregate_stats[PromoRegistration::FINALIZED] += event[PromoRegistration::FINALIZED]

--- a/app/services/promo_statement_generator.rb
+++ b/app/services/promo_statement_generator.rb
@@ -1,0 +1,114 @@
+# Creates a statement to be converted into tables and downloaded by admins
+class PromoStatementGenerator < BaseService
+  include PromosHelper
+
+  def initialize(referral_codes:, start_date:, end_date:, reporting_interval:)
+    @referral_codes = referral_codes
+    @start_date = coerce_date_to_start_or_end_of_reporting_interval(start_date, reporting_interval, true)
+    @end_date = coerce_date_to_start_or_end_of_reporting_interval(end_date, reporting_interval, false)
+    @reporting_interval = reporting_interval
+  end
+
+  def perform
+    # Fetch the most recent stats
+    promo_registrations = PromoRegistration.where(referral_code: @referral_codes)
+    AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+    promo_registrations.reload
+
+    # Build the statement contents
+    statement_contents = {}
+    promo_registrations.each do |promo_registration|
+      # Pull all statistics associated with a code
+      events = JSON.parse(promo_registration.stats)
+
+      # Select only those within date range supplied
+      events_within_statement_period = events.select { |event|
+        (event["ymd"].to_date >= @start_date) && (event["ymd"].to_date <= @end_date)
+      }
+
+      if @reporting_interval == "cumulative"
+        base_case = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0 }
+        culmative_statement_contents = events_within_statement_period.reduce(base_case) { |aggregate_stats, event|
+          aggregate_stats["retrievals"] += event["retrievals"]
+          aggregate_stats["first_runs"] += event["first_runs"]
+          aggregate_stats["finalized"] += event["finalized"]
+          aggregate_stats.slice("retrievals", "first_runs", "finalized")
+        }
+
+        statement_contents_for_referral_code = {
+          @start_date => culmative_statement_contents
+        }
+
+        statement_contents["#{promo_registration.referral_code}"] = statement_contents_for_referral_code
+      else
+        statement_contents_for_referral_code = empty_statement_contents_for_referral_code(@start_date, @end_date, @reporting_interval)
+        events_within_statement_period.each do |event|
+          interval_start_date = coerce_date_to_start_or_end_of_reporting_interval(event["ymd"].to_date, @reporting_interval, true)
+          existing_event = statement_contents_for_referral_code[interval_start_date]
+          existing_event["retrievals"] += event["retrievals"]
+          existing_event["first_runs"] += event["first_runs"]
+          existing_event["finalized"] += event["finalized"]
+        end
+        statement_contents["#{promo_registration.referral_code}"] = statement_contents_for_referral_code
+      end
+    end
+    #
+    # Example statement_contents:
+    #
+    # {"YYY999"=>
+    #    {Sun, 01 Oct 2017=>{"retrievals"=>40, "first_runs"=>33, "finalized"=>3},
+    #     Wed, 01 Nov 2017=>{"retrievals"=>45, "first_runs"=>30, "finalized"=>3},
+    #     Fri, 01 Dec 2017=>{"retrievals"=>30, "first_runs"=>19, "finalized"=>4},
+    #     Mon, 01 Jan 2018=>{"retrievals"=>34, "first_runs"=>20, "finalized"=>6},
+    #     Thu, 01 Feb 2018=>{"retrievals"=>25, "first_runs"=>19, "finalized"=>5}},
+    # "ZZZ000"=>
+    #    {Sun, 01 Oct 2017=>{"retrievals"=>4, "first_runs"=>2, "finalized"=>0},
+    #     Wed, 01 Nov 2017=>{"retrievals"=>3, "first_runs"=>1, "finalized"=>0},
+    #     Fri, 01 Dec 2017=>{"retrievals"=>2, "first_runs"=>0, "finalized"=>0},
+    #     Mon, 01 Jan 2018=>{"retrievals"=>1, "first_runs"=>0, "finalized"=>1},
+    #     Thu, 01 Feb 2018=>{"retrievals"=>2, "first_runs"=>2, "finalized"=>1}}
+    # 
+    # The dates indicate the the start date of a reporting interval.
+    # In this case the reporting interval is 'by_month'.
+    #
+    # If the reporting interval is 'cumulative', then there is only one reporting interval,
+    # the beginning on the period start_date. e.g:
+    #
+    # {"XEN116"=>
+    #   {Sun, 22 Oct 2017=>{"retrievals"=>0, "first_runs"=>1679, "finalized"=>43}},
+    #  "AAD116"=>
+    #   {Sun, 22 Oct 2017=>{"retrievals"=>0, "first_runs"=>11, "finalized"=>2}}}
+
+    statement_hash = {
+      "contents" => statement_contents,
+      "start_date" => "#{@start_date}",
+      "end_date" => "#{@end_date}"
+   }
+  end
+
+  private
+
+  # Creates a statement_contents for a single referral code with all 0 values
+  def empty_statement_contents_for_referral_code(start_date, end_date, reporting_interval)
+    statement_contents_for_referral_code = {}
+    current_date = start_date
+    while current_date <= end_date do 
+      statement_contents_for_referral_code[current_date] = {
+        "retrievals" => 0,
+        "first_runs" => 0,
+        "finalized" => 0
+      }
+      case reporting_interval
+      when "by_day"
+        current_date = current_date + 1.day
+      when "by_week"
+        current_date = current_date + 1.week
+      when "by_month"
+        current_date = current_date + 1.month
+      else
+        raise
+      end
+    end
+    statement_contents_for_referral_code
+  end
+end

--- a/app/services/promo_statement_generator.rb
+++ b/app/services/promo_statement_generator.rb
@@ -27,12 +27,12 @@ class PromoStatementGenerator < BaseService
       }
 
       if @reporting_interval == "cumulative"
-        base_case = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0 }
+        base_case = {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, "finalized" => 0 }
         culmative_statement_contents = events_within_statement_period.reduce(base_case) { |aggregate_stats, event|
-          aggregate_stats["retrievals"] += event["retrievals"]
-          aggregate_stats["first_runs"] += event["first_runs"]
-          aggregate_stats["finalized"] += event["finalized"]
-          aggregate_stats.slice("retrievals", "first_runs", "finalized")
+          aggregate_stats[PromoRegistration::RETRIEVALS] += event[PromoRegistration::RETRIEVALS]
+          aggregate_stats[PromoRegistration::FIRST_RUNS] += event[PromoRegistration::FIRST_RUNS]
+          aggregate_stats[PromoRegistration::FINALIZED] += event[PromoRegistration::FINALIZED]
+          aggregate_stats.slice(PromoRegistration::RETRIEVALS, PromoRegistration::FIRST_RUNS, PromoRegistration::FINALIZED)
         }
 
         statement_contents_for_referral_code = {
@@ -45,9 +45,9 @@ class PromoStatementGenerator < BaseService
         events_within_statement_period.each do |event|
           interval_start_date = coerce_date_to_start_or_end_of_reporting_interval(event["ymd"].to_date, @reporting_interval, true)
           existing_event = statement_contents_for_referral_code[interval_start_date]
-          existing_event["retrievals"] += event["retrievals"]
-          existing_event["first_runs"] += event["first_runs"]
-          existing_event["finalized"] += event["finalized"]
+          existing_event[PromoRegistration::RETRIEVALS] += event[PromoRegistration::RETRIEVALS]
+          existing_event[PromoRegistration::FIRST_RUNS] += event[PromoRegistration::FIRST_RUNS]
+          existing_event[PromoRegistration::FINALIZED] += event[PromoRegistration::FINALIZED]
         end
         statement_contents["#{promo_registration.referral_code}"] = statement_contents_for_referral_code
       end
@@ -94,9 +94,9 @@ class PromoStatementGenerator < BaseService
     current_date = start_date
     while current_date <= end_date do 
       statement_contents_for_referral_code[current_date] = {
-        "retrievals" => 0,
-        "first_runs" => 0,
-        "finalized" => 0
+        PromoRegistration::RETRIEVALS => 0,
+        PromoRegistration::FIRST_RUNS => 0,
+        PromoRegistration::FINALIZED => 0
       }
       case reporting_interval
       when "by_day"

--- a/app/services/promo_unattached_status_updater.rb
+++ b/app/services/promo_unattached_status_updater.rb
@@ -1,0 +1,50 @@
+# Tells the promo server to pause or unpause tracking for a list of referral codes
+class PromoUnattachedStatusUpdater < BaseApiClient
+  include PromosHelper
+  STATUSES = ["active", "paused"].freeze
+
+  def initialize(promo_registrations:, status:)
+    raise if STATUSES.exclude?(status)
+    @status = status
+    @promo_registrations = promo_registrations
+    @referral_codes = promo_registrations.map { |promo_registration|
+      promo_registration.referral_code
+    }
+  end
+
+  def perform
+    return if @referral_codes.count <= 0
+    return true if perform_promo_offline?
+    response = connection.patch do |request|
+      request.options.params_encoder = Faraday::FlatParamsEncoder
+      request.headers["Authorization"] = api_authorization_header
+      request.headers["Content-Type"] = "application/json"
+      request.url("/api/2/promo/referral#{query_string}")
+      request.body = {status: @status}.to_json
+    end
+
+    if response.status == 200
+      @status == "active" ? @promo_registrations.update_all(active: true) : @promo_registrations.update_all(active: false)
+    end
+
+    response
+  end
+
+  private
+
+  def api_base_uri
+    Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  def api_authorization_header
+    "Bearer #{Rails.application.secrets[:api_promo_key]}"
+  end
+
+  def query_string
+    query_string = "?"
+    @referral_codes.each do |referral_code|
+      query_string = "#{query_string}referral_code=#{referral_code}&"
+    end
+    query_string.chomp("&") # Remove the final ampersand
+  end
+end

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -15,3 +15,6 @@ aside
           li 
             = link_to admin_payout_reports_path
               span Payout Reports
+          li 
+            = link_to admin_unattached_promo_registrations_path
+              span Referral Promo

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -1,99 +1,111 @@
 .unattached-promo-registrations
-  h1 Referral Promo
-  hr
-  = form_tag admin_unattached_promo_registrations_path, id: "create-referral-codes" do
-    = label_tag "Create referral codes"
-    .
-      = number_field_tag "number_of_codes_to_create", nil, placeholder: "# codes"
-      = submit_tag "+ Referral codes", class: "btn btn-info"
+  .row
+    h1 Referral Promo
+    hr
+  .row
+    .panel.panel--double
+      = form_tag admin_unattached_promo_registrations_path, id: "create-referral-codes" do
+        .panel--header = "Create codes"
+        hr
+        .
+          = number_field_tag "number_of_codes_to_create", nil, placeholder: "# codes"
+          = submit_tag "+ Referral codes", class: "btn btn-info"
+    .panel.panel--double
+      = form_tag admin_promo_campaigns_path, id: "create-promo-campaign" do
+        .panel--header = "Create campaigns"
+        hr
+        .
+          = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
+          = submit_tag "+ Campaign", class: "btn btn-info"
+  - if @promo_registrations.any?
+    .row
+      .panel.panel--single
+        .panel--header = "Manage"
+        hr
+        = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
+          = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
+          = submit_tag "Filter by campaign", class: "btn btn-success"
+          = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in statements are always up-to-date."
+        = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
+          table.table
+            tr
+              th 
+              th = "Code"
+              th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
+              th
+                = "Status"
+                span.tf-tooltip
+                  span.icon= render "icon_help"
+                  span.tf-tooltip-content
+                    span.tf-tooltip-content-heading= "Status"
+                    span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
+              th = "Downloads"
+              th 
+                = "Installs"
+                span.tf-tooltip
+                  span.icon= render "icon_help"
+                  span.tf-tooltip-content
+                    span.tf-tooltip-content-heading= "Installs"
+                    span.tf-tooltip-content-content== "An install is counted when a user downloads the browser and opens it the first time."
 
-  = form_tag admin_promo_campaigns_path, id: "create-promo-campaign" do
-    = label_tag "Initialize a campaign"
-    .
-      = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
-      = submit_tag "+ Campaign", class: "btn btn-info"
-
-  hr
-
-  = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
-    = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
-    = submit_tag "Filter by campaign", class: "btn btn-success"
-    = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in statements are always up-to-date."
-  = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
-    table.table.table-bordered.table-striped
-      tr
-        th 
-        th = "Code"
-        th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
-        th
-          = "Status"
-          span.tf-tooltip
-            span.icon= render "icon_help"
-            span.tf-tooltip-content
-              span.tf-tooltip-content-heading= "Status"
-              span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
-        th = "Downloads"
-        th 
-          = "Installs"
-          span.tf-tooltip
-            span.icon= render "icon_help"
-            span.tf-tooltip-content
-              span.tf-tooltip-content-heading= "Installs"
-              span.tf-tooltip-content-content== "An install is counted when a user downloads the browser and opens it the first time."
-
-        th
-          = "Confirmed"
-          span.tf-tooltip
-            span.icon= render "icon_help"
-            span.tf-tooltip-content
-              span.tf-tooltip-content-heading= "Confirmed"
-              span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens it, then opens it again at least 30 days later."
-      tbody
-        - @promo_registrations.each do |promo_registration| 
-          - promo_registration_aggregate_stats = promo_registration.aggregate_stats
-          tr
-            td = check_box_tag "referral_codes[]", "#{promo_registration.referral_code}", 1
-            td = promo_registration.referral_code
-            td = promo_registration.promo_campaign&.name
-            td = promo_registration.active ? "active" : "paused"
-            td = promo_registration_aggregate_stats[PromoRegistration::RETRIEVALS] || 0
-            td = promo_registration_aggregate_stats[PromoRegistration::FIRST_RUNS] || 0
-            td = promo_registration_aggregate_stats[PromoRegistration::FINALIZED] || 0
-    .unattached-referral-code-form--submissions
-      .unattached-referral-code-form--submission
-        .unattached-referral-code-form--submission--element
-          . = label_tag "Campaign"
-          . = select_tag :promo_campaign_target, options_for_select(@campaigns)
-          = hidden_field_tag :filter, params[:filter]
-        .unattached-referral-code-form--submission--submit        
-          = submit_tag "Assign codes to campaign", id: "assign-to-campaign", class: "btn btn-primary"
-      .unattached-referral-code-form--submission
-        .unattached-referral-code-form--submission--element
-          . = label_tag "Referral code statuses"
-          . = select_tag :referral_code_status, options_for_select([["Active", "active"], ["Paused", "paused"]])
-          = hidden_field_tag :filter, params[:filter]
-        .unattached-referral-code-form--submission--submit
-          = submit_tag "Update code statuses", id: "update-referral-code-statuses", class: "btn btn-primary"
-      .unattached-referral-code-form--submission
-        .unattached-referral-code-form--submission--element
-          . = label_tag "Statement period start"
-          . = date_select :referral_code_statement_period, :start
-        .unattached-referral-code-form--submission--element
-          . = label_tag "Statement period end"
-          . = date_select :referral_code_statement_period, :end
-        .unattached-referral-code-form--submission--element
-          . = label_tag "Reporting interval"
-          . = select_tag :reporting_interval, options_for_select([["By day","by_day"], ["By week","by_week"], ["By month","by_month"], ["cumulative", "cumulative"]])
-        .unattached-referral-code-form--submission--element
-          . style="font-weight: bold" = label_tag = "Event types"
-          .
-            = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
-            = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
-          .
-            = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
-            = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
-          .
-            = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
-            = check_box_tag "event_types[]", PromoRegistration::FINALIZED
-        .unattached-referral-code-form--submission--submit
-          = submit_tag "Download statement", id: "download-referral-statements", class: "btn btn-primary", data: { disable_with: false }
+              th
+                = "Confirmed"
+                span.tf-tooltip
+                  span.icon= render "icon_help"
+                  span.tf-tooltip-content
+                    span.tf-tooltip-content-heading= "Confirmed"
+                    span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens it, then opens it again at least 30 days later."
+            tbody
+              - @promo_registrations.each do |promo_registration| 
+                - promo_registration_aggregate_stats = promo_registration.aggregate_stats
+                tr
+                  td = check_box_tag "referral_codes[]", "#{promo_registration.referral_code}", 1
+                  td = promo_registration.referral_code
+                  td = promo_registration.promo_campaign&.name
+                  td = promo_registration.active ? "active" : "paused"
+                  td = promo_registration_aggregate_stats[PromoRegistration::RETRIEVALS] || 0
+                  td = promo_registration_aggregate_stats[PromoRegistration::FIRST_RUNS] || 0
+                  td = promo_registration_aggregate_stats[PromoRegistration::FINALIZED] || 0
+          .row
+            .unattached-referral-code-form--submissions
+              .panel.panel--color-offset
+                .panel--sub-panel-header = "Assign codes to campaign"
+                hr
+                .row.flex-one
+                  .flex-one = select_tag :promo_campaign_target, options_for_select(@campaigns)
+                  = hidden_field_tag :filter, params[:filter]
+                  = submit_tag "Assign", id: "assign-to-campaign", class: "btn btn-primary"
+              .panel.panel--color-offset
+                .panel--sub-panel-header = "Update code statuses"
+                hr
+                .row
+                  .flex-one = select_tag :referral_code_status, options_for_select([["Active", "active"], ["Paused", "paused"]])
+                  = hidden_field_tag :filter, params[:filter]
+                  = submit_tag "Update", id: "update-referral-code-statuses", class: "btn btn-primary"
+          .row
+            .panel.panel--color-offset
+              .panel--sub-panel-header = "Report generation"
+              hr
+              .row
+                .flex-one
+                  . = label_tag "Report period start"
+                  . = date_select :referral_code_statement_period, :start
+                .flex-one
+                  . = label_tag "Report period end"
+                  . = date_select :referral_code_statement_period, :end
+                .flex-one
+                  . = label_tag "Reporting interval"
+                  . = select_tag :reporting_interval, options_for_select([["By day","by_day"], ["By week","by_week"], ["By month","by_month"], ["cumulative", "cumulative"]])
+                .flex-one
+                  . style="font-weight: bold" = label_tag = "Event types"
+                  .
+                    = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
+                    = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
+                  .
+                    = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
+                    = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
+                  .
+                    = check_box_tag "event_types[]", PromoRegistration::FINALIZED
+                    = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
+              .flex-one.download-button
+                = submit_tag "Download", id: "download-referral-statements", class: "btn btn-primary", data: { disable_with: false }

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -1,8 +1,6 @@
 .unattached-promo-registrations
   h1 Referral Promo
-
   hr
-
   = form_tag admin_unattached_promo_registrations_path, id: "create-referral-codes" do
     = label_tag "Create referral codes"
     .
@@ -20,6 +18,7 @@
   = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
     = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
     = submit_tag "Filter by campaign", class: "btn btn-success"
+    = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in statements are always up-to-date."
   = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
     table.table.table-bordered.table-striped
       tr

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -94,7 +94,7 @@
                 . = date_select :referral_code_report_period, :end
               .flex-one
                 . = label_tag "Reporting interval"
-                . = select_tag :reporting_interval, options_for_select([["By day","by_day"], ["By week","by_week"], ["By month","by_month"], ["cumulative", "cumulative"]])
+                . = select_tag :reporting_interval, options_for_select([["Daily",PromoRegistration::DAILY], ["Weekly",PromoRegistration::WEEKLY], ["Monthly",PromoRegistration::MONTHLY], ["Running total", PromoRegistration::RUNNING_TOTAL]])
               .flex-one
                 . style="font-weight: bold" = label_tag = "Event types"
                 .

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -1,0 +1,77 @@
+.unattached-promo-registrations
+  h1 Referral Promo
+  
+  hr
+
+  = form_tag admin_unattached_promo_registrations_path, id: "create-referral-codes" do
+    = number_field_tag "number_of_codes_to_create", nil, placeholder: "1"
+    = submit_tag "Create referral codes", class: "btn btn-info"
+
+  = form_tag admin_promo_campaigns_path, id: "create-promo-campaign" do
+    = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
+    = submit_tag "Create campaign", class: "btn btn-info"
+
+  hr
+
+  = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
+    = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
+    = submit_tag "Filter by campaign", class: "btn btn-success"
+  = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
+    table.display.table.table-bordered.table-striped.dynamic-table id="dynamic-table"
+      tr
+        th 
+        th Code
+        th Campaign
+        th Status
+        th Downloads
+        th Installs
+        th Confirmed
+      tbody
+        - @promo_registrations.each do |promo_registration| 
+          - promo_registration_aggregate_stats = promo_registration.aggregate_stats
+          tr
+            td = check_box_tag "referral_codes[]", "#{promo_registration.referral_code}", 1
+            td = promo_registration.referral_code
+            td = promo_registration.promo_campaign&.name
+            td = promo_registration.active ? "active" : "paused"
+            td = promo_registration_aggregate_stats["retrievals"] || 0
+            td = promo_registration_aggregate_stats["first_runs"] || 0
+            td = promo_registration_aggregate_stats["finalized"] || 0
+    .unattached-referral-code-form--submissions
+      .unattached-referral-code-form--submission
+        .unattached-referral-code-form--submission--element
+          . = label_tag "Campaign"
+          . = select_tag :promo_campaign_target, options_for_select(@campaigns)
+          = hidden_field_tag :filter, params[:filter]
+        .unattached-referral-code-form--submission--submit        
+          = submit_tag "Assign codes to campaign", id: "assign-to-campaign", class: "btn btn-primary"
+      .unattached-referral-code-form--submission
+        .unattached-referral-code-form--submission--element
+          . = label_tag "Referral code statuses"
+          . = select_tag :referral_code_status, options_for_select([["Active", "active"], ["Paused", "paused"]])
+          = hidden_field_tag :filter, params[:filter]
+        .unattached-referral-code-form--submission--submit
+          = submit_tag "Update code statuses", id: "update-referral-code-statuses", class: "btn btn-primary"
+      .unattached-referral-code-form--submission
+        .unattached-referral-code-form--submission--element
+          . = label_tag "Statement period start"
+          . = date_select :referral_code_statement_period, :start
+        .unattached-referral-code-form--submission--element
+          . = label_tag "Statement period end"
+          . = date_select :referral_code_statement_period, :end
+        .unattached-referral-code-form--submission--element
+          . = label_tag "Reporting interval"
+          . = select_tag :reporting_interval, options_for_select([["By day","by_day"], ["By week","by_week"], ["By month","by_month"], ["cumulative", "cumulative"]])
+        .unattached-referral-code-form--submission--element
+          . style="font-weight: bold" = label_tag = "Event types"
+          .
+            = label_tag = event_type_column_header("retrievals") + " "
+            = check_box_tag "event_types[]", "retrievals"
+          .
+            = label_tag = event_type_column_header("first_runs") + " "
+            = check_box_tag "event_types[]", "first_runs"
+          .
+            = label_tag = event_type_column_header("finalized") + " "
+            = check_box_tag "event_types[]", "finalized"
+        .unattached-referral-code-form--submission--submit
+          = submit_tag "Download statement", id: "download-referral-statements", class: "btn btn-primary", data: { disable_with: false }

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -17,95 +17,94 @@
         .
           = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
           = submit_tag "+ Campaign", class: "btn btn-info"
-  - if @promo_registrations.any?
-    .row
-      .panel.panel--single
-        .panel--header = "Manage"
-        hr
-        = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
-          = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
-          = submit_tag "Filter by campaign", class: "btn btn-success"
-          = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in statements are always up-to-date."
-        = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
-          table.table
-            tr
-              th 
-              th = "Code"
-              th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
-              th
-                = "Status"
-                span.tf-tooltip
-                  span.icon= render "icon_help"
-                  span.tf-tooltip-content
-                    span.tf-tooltip-content-heading= "Status"
-                    span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
-              th = "Downloads"
-              th 
-                = "Installs"
-                span.tf-tooltip
-                  span.icon= render "icon_help"
-                  span.tf-tooltip-content
-                    span.tf-tooltip-content-heading= "Installs"
-                    span.tf-tooltip-content-content== "An install is counted when a user downloads the browser and opens it the first time."
+  .row
+    .panel.panel--single
+      .panel--header = "Manage"
+      hr
+      = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
+        = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
+        = submit_tag "Filter by campaign", class: "btn btn-success"
+        = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in reports are always up-to-date."
+      = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
+        table.table
+          tr
+            th 
+            th = "Code"
+            th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
+            th
+              = "Status"
+              span.tf-tooltip
+                span.icon= render "icon_help"
+                span.tf-tooltip-content
+                  span.tf-tooltip-content-heading= "Status"
+                  span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
+            th = "Downloads"
+            th 
+              = "Installs"
+              span.tf-tooltip
+                span.icon= render "icon_help"
+                span.tf-tooltip-content
+                  span.tf-tooltip-content-heading= "Installs"
+                  span.tf-tooltip-content-content== "An install is counted when a user downloads the browser and opens it the first time."
 
-              th
-                = "Confirmed"
-                span.tf-tooltip
-                  span.icon= render "icon_help"
-                  span.tf-tooltip-content
-                    span.tf-tooltip-content-heading= "Confirmed"
-                    span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens it, then opens it again at least 30 days later."
-            tbody
-              - @promo_registrations.each do |promo_registration| 
-                - promo_registration_aggregate_stats = promo_registration.aggregate_stats
-                tr
-                  td = check_box_tag "referral_codes[]", "#{promo_registration.referral_code}", 1
-                  td = promo_registration.referral_code
-                  td = promo_registration.promo_campaign&.name
-                  td = promo_registration.active ? "active" : "paused"
-                  td = promo_registration_aggregate_stats[PromoRegistration::RETRIEVALS] || 0
-                  td = promo_registration_aggregate_stats[PromoRegistration::FIRST_RUNS] || 0
-                  td = promo_registration_aggregate_stats[PromoRegistration::FINALIZED] || 0
-          .row
-            .unattached-referral-code-form--submissions
-              .panel.panel--color-offset
-                .panel--sub-panel-header = "Assign codes to campaign"
-                hr
-                .row.flex-one
-                  .flex-one = select_tag :promo_campaign_target, options_for_select(@campaigns)
-                  = hidden_field_tag :filter, params[:filter]
-                  = submit_tag "Assign", id: "assign-to-campaign", class: "btn btn-primary"
-              .panel.panel--color-offset
-                .panel--sub-panel-header = "Update code statuses"
-                hr
-                .row
-                  .flex-one = select_tag :referral_code_status, options_for_select([["Active", "active"], ["Paused", "paused"]])
-                  = hidden_field_tag :filter, params[:filter]
-                  = submit_tag "Update", id: "update-referral-code-statuses", class: "btn btn-primary"
-          .row
+            th
+              = "Confirmed"
+              span.tf-tooltip
+                span.icon= render "icon_help"
+                span.tf-tooltip-content
+                  span.tf-tooltip-content-heading= "Confirmed"
+                  span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens it, then opens it again at least 30 days later."
+          tbody
+            - @promo_registrations.each do |promo_registration| 
+              - promo_registration_aggregate_stats = promo_registration.aggregate_stats
+              tr
+                td = check_box_tag "referral_codes[]", "#{promo_registration.referral_code}", 1
+                td = promo_registration.referral_code
+                td = promo_registration.promo_campaign&.name
+                td = promo_registration.active ? "active" : "paused"
+                td = promo_registration_aggregate_stats[PromoRegistration::RETRIEVALS] || 0
+                td = promo_registration_aggregate_stats[PromoRegistration::FIRST_RUNS] || 0
+                td = promo_registration_aggregate_stats[PromoRegistration::FINALIZED] || 0
+        .row
+          .unattached-referral-code-form--submissions
             .panel.panel--color-offset
-              .panel--sub-panel-header = "Report generation"
+              .panel--sub-panel-header = "Assign codes to campaign"
+              hr
+              .row.flex-one
+                .flex-one = select_tag :promo_campaign_target, options_for_select(@campaigns)
+                = hidden_field_tag :filter, params[:filter]
+                = submit_tag "Assign", id: "assign-to-campaign", class: "btn btn-primary"
+            .panel.panel--color-offset
+              .panel--sub-panel-header = "Update code statuses"
               hr
               .row
-                .flex-one
-                  . = label_tag "Report period start"
-                  . = date_select :referral_code_statement_period, :start
-                .flex-one
-                  . = label_tag "Report period end"
-                  . = date_select :referral_code_statement_period, :end
-                .flex-one
-                  . = label_tag "Reporting interval"
-                  . = select_tag :reporting_interval, options_for_select([["By day","by_day"], ["By week","by_week"], ["By month","by_month"], ["cumulative", "cumulative"]])
-                .flex-one
-                  . style="font-weight: bold" = label_tag = "Event types"
-                  .
-                    = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
-                    = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
-                  .
-                    = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
-                    = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
-                  .
-                    = check_box_tag "event_types[]", PromoRegistration::FINALIZED
-                    = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
-              .flex-one.download-button
-                = submit_tag "Download", id: "download-referral-statements", class: "btn btn-primary", data: { disable_with: false }
+                .flex-one = select_tag :referral_code_status, options_for_select([["Active", "active"], ["Paused", "paused"]])
+                = hidden_field_tag :filter, params[:filter]
+                = submit_tag "Update", id: "update-referral-code-statuses", class: "btn btn-primary"
+        .row
+          .panel.panel--color-offset
+            .panel--sub-panel-header = "Report generation"
+            hr
+            .row
+              .flex-one
+                . = label_tag "Report period start"
+                . = date_select :referral_code_report_period, :start
+              .flex-one
+                . = label_tag "Report period end"
+                . = date_select :referral_code_report_period, :end
+              .flex-one
+                . = label_tag "Reporting interval"
+                . = select_tag :reporting_interval, options_for_select([["By day","by_day"], ["By week","by_week"], ["By month","by_month"], ["cumulative", "cumulative"]])
+              .flex-one
+                . style="font-weight: bold" = label_tag = "Event types"
+                .
+                  = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
+                  = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
+                .
+                  = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
+                  = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
+                .
+                  = check_box_tag "event_types[]", PromoRegistration::FINALIZED
+                  = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
+            .flex-one.download-button
+              = submit_tag "Download", id: "download-referral-reports", class: "btn btn-primary", data: { disable_with: false }

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -1,15 +1,19 @@
 .unattached-promo-registrations
   h1 Referral Promo
-  
+
   hr
 
   = form_tag admin_unattached_promo_registrations_path, id: "create-referral-codes" do
-    = number_field_tag "number_of_codes_to_create", nil, placeholder: "1"
-    = submit_tag "Create referral codes", class: "btn btn-info"
+    = label_tag "Create referral codes"
+    .
+      = number_field_tag "number_of_codes_to_create", nil, placeholder: "# codes"
+      = submit_tag "+ Referral codes", class: "btn btn-info"
 
   = form_tag admin_promo_campaigns_path, id: "create-promo-campaign" do
-    = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
-    = submit_tag "Create campaign", class: "btn btn-info"
+    = label_tag "Initialize a campaign"
+    .
+      = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
+      = submit_tag "+ Campaign", class: "btn btn-info"
 
   hr
 
@@ -17,15 +21,34 @@
     = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
     = submit_tag "Filter by campaign", class: "btn btn-success"
   = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
-    table.display.table.table-bordered.table-striped.dynamic-table id="dynamic-table"
+    table.table.table-bordered.table-striped
       tr
         th 
-        th Code
-        th Campaign
-        th Status
-        th Downloads
-        th Installs
-        th Confirmed
+        th = "Code"
+        th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
+        th
+          = "Status"
+          span.tf-tooltip
+            span.icon= render "icon_help"
+            span.tf-tooltip-content
+              span.tf-tooltip-content-heading= "Status"
+              span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
+        th = "Downloads"
+        th 
+          = "Installs"
+          span.tf-tooltip
+            span.icon= render "icon_help"
+            span.tf-tooltip-content
+              span.tf-tooltip-content-heading= "Installs"
+              span.tf-tooltip-content-content== "An install is counted when a user downloads the browser and opens it the first time."
+
+        th
+          = "Confirmed"
+          span.tf-tooltip
+            span.icon= render "icon_help"
+            span.tf-tooltip-content
+              span.tf-tooltip-content-heading= "Confirmed"
+              span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens, then opens it again at least 30 days later."
       tbody
         - @promo_registrations.each do |promo_registration| 
           - promo_registration_aggregate_stats = promo_registration.aggregate_stats

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -20,11 +20,11 @@
   .row
     .panel.panel--single
       .panel--header = "Manage"
+      span style="color: darkgrey; font-size: 14px;" = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in reports are always up-to-date."
       hr
       = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
         = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
         = submit_tag "Filter by campaign", class: "btn btn-success"
-        = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in reports are always up-to-date."
       = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
         table.table
           tr
@@ -86,16 +86,16 @@
             .panel--sub-panel-header = "Report generation"
             hr
             .row
-              .flex-one
+              .flex-three.align-self-flex-center
                 . = label_tag "Report period start"
                 . = date_select :referral_code_report_period, :start
-              .flex-one
+              .flex-three.align-self-flex-center
                 . = label_tag "Report period end"
                 . = date_select :referral_code_report_period, :end
-              .flex-one
+              .flex-three.align-self-flex-center
                 . = label_tag "Reporting interval"
                 . = select_tag :reporting_interval, options_for_select([["Daily",PromoRegistration::DAILY], ["Weekly",PromoRegistration::WEEKLY], ["Monthly",PromoRegistration::MONTHLY], ["Running total", PromoRegistration::RUNNING_TOTAL]])
-              .flex-one
+              .flex-one.align-self-flex-center
                 . style="font-weight: bold" = label_tag = "Event types"
                 .
                   = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
@@ -106,5 +106,5 @@
                 .
                   = check_box_tag "event_types[]", PromoRegistration::FINALIZED
                   = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
-            .flex-one.download-button
-              = submit_tag "Download", id: "download-referral-reports", class: "btn btn-primary", data: { disable_with: false }
+              .flex-one.align-self-flex-end
+                = submit_tag "Download", id: "download-referral-reports", class: "btn btn-primary", data: { disable_with: false }

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -48,7 +48,7 @@
             span.icon= render "icon_help"
             span.tf-tooltip-content
               span.tf-tooltip-content-heading= "Confirmed"
-              span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens, then opens it again at least 30 days later."
+              span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens it, then opens it again at least 30 days later."
       tbody
         - @promo_registrations.each do |promo_registration| 
           - promo_registration_aggregate_stats = promo_registration.aggregate_stats
@@ -57,9 +57,9 @@
             td = promo_registration.referral_code
             td = promo_registration.promo_campaign&.name
             td = promo_registration.active ? "active" : "paused"
-            td = promo_registration_aggregate_stats["retrievals"] || 0
-            td = promo_registration_aggregate_stats["first_runs"] || 0
-            td = promo_registration_aggregate_stats["finalized"] || 0
+            td = promo_registration_aggregate_stats[PromoRegistration::RETRIEVALS] || 0
+            td = promo_registration_aggregate_stats[PromoRegistration::FIRST_RUNS] || 0
+            td = promo_registration_aggregate_stats[PromoRegistration::FINALIZED] || 0
     .unattached-referral-code-form--submissions
       .unattached-referral-code-form--submission
         .unattached-referral-code-form--submission--element
@@ -88,13 +88,13 @@
         .unattached-referral-code-form--submission--element
           . style="font-weight: bold" = label_tag = "Event types"
           .
-            = label_tag = event_type_column_header("retrievals") + " "
-            = check_box_tag "event_types[]", "retrievals"
+            = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
+            = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
           .
-            = label_tag = event_type_column_header("first_runs") + " "
-            = check_box_tag "event_types[]", "first_runs"
+            = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
+            = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
           .
-            = label_tag = event_type_column_header("finalized") + " "
-            = check_box_tag "event_types[]", "finalized"
+            = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
+            = check_box_tag "event_types[]", PromoRegistration::FINALIZED
         .unattached-referral-code-form--submission--submit
           = submit_tag "Download statement", id: "download-referral-statements", class: "btn btn-primary", data: { disable_with: false }

--- a/app/views/admin/unattached_promo_registrations/report.html.slim
+++ b/app/views/admin/unattached_promo_registrations/report.html.slim
@@ -2,12 +2,12 @@ scss:
   th {
     padding: 10px;
   }
-.promo-statement
-  .promo-statement--header
+.promo-report
+  .promo-report--header
     h2 style="margin-bottom: 5px;" = "Brave Referral Statement"
     h4 style="margin-top: 5px" = "#{@start_date} - #{@end_date}"
-  .promo-statement--contents
-    - @statement_contents.each do |referral_code, events|
+  .promo-report--contents
+    - @report_contents.each do |referral_code, events|
       table style="text-align:center; margin-bottom: 15px;"
         caption style="font-weight: bold;"= referral_code
         tr

--- a/app/views/admin/unattached_promo_registrations/report.html.slim
+++ b/app/views/admin/unattached_promo_registrations/report.html.slim
@@ -4,7 +4,7 @@ scss:
   }
 .promo-report
   .promo-report--header
-    h2 style="margin-bottom: 5px;" = "Brave Referral Statement"
+    h2 style="margin-bottom: 5px;" = "Brave Referral Report"
     h4 style="margin-top: 5px" = "#{@start_date} - #{@end_date}"
   .promo-report--contents
     - @report_contents.each do |referral_code, events|

--- a/app/views/admin/unattached_promo_registrations/report.html.slim
+++ b/app/views/admin/unattached_promo_registrations/report.html.slim
@@ -11,14 +11,14 @@ scss:
       table style="text-align:center; margin-bottom: 15px;"
         caption style="font-weight: bold;"= referral_code
         tr
-          - if @reporting_interval != "cumulative"
+          - if @reporting_interval != PromoRegistration::RUNNING_TOTAL
             th = reporting_interval_column_header(@reporting_interval)
           - @event_types.each do |event_type|
             th = event_type_column_header(event_type)
         tbody
           - events.each do |event|
             tr
-              - if @reporting_interval != "cumulative"
+              - if @reporting_interval != PromoRegistration::RUNNING_TOTAL
                 td = event.first
               - @event_types.each do |event_type|
                 td = event.second[event_type]

--- a/app/views/admin/unattached_promo_registrations/statement.html.slim
+++ b/app/views/admin/unattached_promo_registrations/statement.html.slim
@@ -1,0 +1,24 @@
+scss:
+  th {
+    padding: 10px;
+  }
+.promo-statement
+  .promo-statement--header
+    h2 style="margin-bottom: 5px;" = "Brave Referral Statement"
+    h4 style="margin-top: 5px" = "#{@start_date} - #{@end_date}"
+  .promo-statement--contents
+    - @statement_contents.each do |referral_code, events|
+      table style="text-align:center; margin-bottom: 15px;"
+        caption style="font-weight: bold;"= referral_code
+        tr
+          - if @reporting_interval != "cumulative"
+            th = reporting_interval_column_header(@reporting_interval)
+          - @event_types.each do |event_type|
+            th = event_type_column_header(event_type)
+        tbody
+          - events.each do |event|
+            tr
+              - if @reporting_interval != "cumulative"
+                td = event.first
+              - @event_types.each do |event_type|
+                td = event.second[event_type]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
     end
     resources :unattached_promo_registrations, only: %i(index create) do
       collection do
-        get :statement
+        get :report
         patch :update_statuses
         patch :assign
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,7 +122,14 @@ Rails.application.routes.draw do
       end
       resources :publisher_status_updates, controller: 'publishers/publisher_status_updates'
     end
-
+    resources :unattached_promo_registrations, only: %i(index create) do
+      collection do
+        get :statement
+        patch :update_statuses
+        patch :assign
+      end
+    end
+    resources :promo_campaigns, only: %i(create)
     root to: "dashboard#index" # <--- Root route
   end
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -91,7 +91,6 @@ default: &default
 
 development:
   <<: *default
-  api_promo_base_uri: "" # http://127.0.0.1:8194
   active_promo_id: "free-bats-2018q1"
   base_referral_url: "brave.com"
   internal_email: brave-publishers@localhost.local

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,6 +27,10 @@
     cron: "15 3 * * *"
     description: "For Publishers who have enabled a promo, sync their referral stats with the promo server once a day."
     queue: scheduler
+  SyncAdminPromoStatsJob:
+    cron: "0 */12 * * *"
+    description: "Syncs referral stats for unattached codes every 12 hours."
+    queue: low
   SyncChannelStatsJob:
     cron: "0 1 * * *"
     description: "Syncs the channel stats via youtube and twitch apis"

--- a/db/migrate/20181012194114_add_kind_to_promo_registration.rb
+++ b/db/migrate/20181012194114_add_kind_to_promo_registration.rb
@@ -1,0 +1,5 @@
+class AddKindToPromoRegistration < ActiveRecord::Migration[5.2]
+  def change
+    add_column :promo_registrations, :kind, :text, null: false
+  end
+end

--- a/db/migrate/20181012195619_allow_blank_channel_ids_on_promo_registration.rb
+++ b/db/migrate/20181012195619_allow_blank_channel_ids_on_promo_registration.rb
@@ -1,0 +1,5 @@
+class AllowBlankChannelIdsOnPromoRegistration < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :promo_registrations, :channel_id, true
+  end
+end

--- a/db/migrate/20181015014453_add_stats_to_promo_registration.rb
+++ b/db/migrate/20181015014453_add_stats_to_promo_registration.rb
@@ -1,0 +1,5 @@
+class AddStatsToPromoRegistration < ActiveRecord::Migration[5.2]
+  def change
+    add_column :promo_registrations, :stats, :jsonb, default: '{}'
+  end
+end

--- a/db/migrate/20181015023430_create_promo_campaigns.rb
+++ b/db/migrate/20181015023430_create_promo_campaigns.rb
@@ -1,0 +1,9 @@
+class CreatePromoCampaigns < ActiveRecord::Migration[5.2]
+  def change
+    create_table :promo_campaigns, id: :uuid,default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+      t.string :name
+      t.timestamps
+    end
+    add_index :promo_campaigns, :name, unique: true
+  end
+end

--- a/db/migrate/20181015132025_add_campaign_to_promo_registration.rb
+++ b/db/migrate/20181015132025_add_campaign_to_promo_registration.rb
@@ -1,0 +1,7 @@
+class AddCampaignToPromoRegistration < ActiveRecord::Migration[5.2]
+  def change
+    change_table :promo_registrations do |t|
+      t.references :promo_campaign, type: :uuid, index: true, null: true, unique: true
+    end
+  end
+end

--- a/db/migrate/20181016134245_add_active_to_promo_registration.rb
+++ b/db/migrate/20181016134245_add_active_to_promo_registration.rb
@@ -1,0 +1,5 @@
+class AddActiveToPromoRegistration < ActiveRecord::Migration[5.2]
+  def change
+    add_column :promo_registrations, :active, :bool, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_24_152716) do
+ActiveRecord::Schema.define(version: 2018_10_16_134245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -193,13 +193,25 @@ ActiveRecord::Schema.define(version: 2018_09_24_152716) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "promo_campaigns", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_promo_campaigns_on_name", unique: true
+  end
+
   create_table "promo_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.uuid "channel_id", null: false
+    t.uuid "channel_id"
     t.string "promo_id", null: false
     t.string "referral_code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "kind", null: false
+    t.jsonb "stats", default: "{}"
+    t.uuid "promo_campaign_id"
+    t.boolean "active", default: true, null: false
     t.index ["channel_id"], name: "index_promo_registrations_on_channel_id"
+    t.index ["promo_campaign_id"], name: "index_promo_registrations_on_promo_campaign_id"
     t.index ["promo_id", "referral_code"], name: "index_promo_registrations_on_promo_id_and_referral_code", unique: true
   end
 

--- a/lib/tasks/database_updates/set_default_promo_registration_kind.rb
+++ b/lib/tasks/database_updates/set_default_promo_registration_kind.rb
@@ -1,0 +1,6 @@
+namespace :database_updates do
+  task :set_default_promo_registration_kind => [:environment] do
+    registrations = PromoRegistration.where.not(channel_id: nil).where(kind: nil)
+    registrations.update_all!(kind: "channel")
+  end
+end

--- a/test/cassettes/test_can_add_multiple_contacts_to_a_list.yml
+++ b/test/cassettes/test_can_add_multiple_contacts_to_a_list.yml
@@ -125,4 +125,58 @@ http_interactions:
       string: ''
     http_version: 
   recorded_at: Thu, 07 Jun 2018 18:09:06 GMT
+- request:
+    method: patch
+    uri: https://api.sendgrid.com/v3/contactdb/recipients
+    body:
+      encoding: UTF-8
+      string: '[{"email":"aliceTwitch@spud.com","name":"Alice the Twitcher","phone":"+14159001420"},{"email":"alice@completed.org","name":"Alice
+        the Completed","phone":"+14159001421"}]'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - sendgrid/5.2.0;ruby
+      Authorization:
+      - Bearer <ENCODED API KEY>
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 403
+      message: FORBIDDEN
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 24 Oct 2018 13:42:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '56'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - HEAD, GET, PUT, POST, DELETE, OPTIONS, PATCH
+      Access-Control-Max-Age:
+      - '21600'
+      Access-Control-Expose-Headers:
+      - Link, Location
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - AUTHORIZATION, Content-Type, On-behalf-of, x-sg-elas-acl, X-Recaptcha
+      Content-Security-Policy:
+      - default-src https://api.sendgrid.com; frame-src 'none'; object-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"field":null,"message":"access forbidden"}]}'
+    http_version: 
+  recorded_at: Wed, 24 Oct 2018 13:42:00 GMT
 recorded_with: VCR 4.0.0

--- a/test/controllers/admin/promo_campaigns_controller_test.rb
+++ b/test/controllers/admin/promo_campaigns_controller_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+require "webmock/minitest"
+
+class Admin::PromoCampaignsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "#creates a promo campaign" do
+    admin = publishers(:admin)
+    sign_in admin
+    post(admin_promo_campaigns_path, params: {campaign_name: "Campaign 1"})
+    assert_equal PromoCampaign.order("created_at").last.name, "Campaign 1"
+  end
+end

--- a/test/controllers/admin/unattached_promo_registrations_controller_test.rb
+++ b/test/controllers/admin/unattached_promo_registrations_controller_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+require "webmock/minitest"
+
+
+class Admin::UnattachedPromoRegistrationsControllerTest < ActionDispatch::IntegrationTest
+  include PromosHelper 
+  include Devise::Test::IntegrationHelpers
+
+  before(:example) do
+    @prev_offline = Rails.application.secrets[:api_promo_base_uri] # Presence of this envar means we use external requiests
+  end
+
+  after(:example) do
+    Rails.application.secrets[:api_promo_base_uri] = @prev_offline
+  end
+
+  test "#create creates codes" do
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194" # Turn on external requests
+    admin = publishers(:admin)
+    sign_in admin
+
+    stub_request(:put, "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral_code/unattached?number=1")
+      .to_return(status: 200, body: [{"referral_code":"NDF915","ts":"2018-10-12T20:06:50.125Z","type":"unattached","owner_id":"","channel_id":"","status":"active"}].to_json)
+
+    assert_difference -> { PromoRegistration.count }, 1 do
+      post(admin_unattached_promo_registrations_path, params: {number_of_codes_to_create: "1"})
+    end
+
+    assert_equal PromoRegistration.order("created_at").last.kind, "unattached"
+  end
+
+  test "#update_statuses updates the status of codes" do
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
+    admin = publishers(:admin)
+    sign_in admin
+
+    promo_registration = PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", active: true, promo_id: active_promo_id)
+
+    stub_request(:patch, "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral?referral_code=ABC123").
+      with(body: {status: "paused"}.to_json).
+      to_return(status: 200)
+
+    patch(update_statuses_admin_unattached_promo_registrations_path, params: {referral_codes: ["ABC123"], referral_code_status: "paused"})
+
+    refute promo_registration.reload.active
+  end
+
+  test "#statement downloads a statement" do
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
+    admin = publishers(:admin)
+    sign_in admin
+
+    PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: active_promo_id)
+    PromoRegistration.create!(referral_code: "DEF456", kind: "unattached", promo_id: active_promo_id)
+
+    stubbed_response_body = [{"referral_code"=>"ABC123",
+      "ymd"=>"2018-04-29",
+      "retrievals"=>0,
+      "first_runs"=>1,
+      "finalized"=>1},
+     {"referral_code"=>"ABC123",
+      "ymd"=>"2018-05-12",
+      "retrievals"=>0,
+      "first_runs"=>1,
+      "finalized"=>0},
+     {"referral_code"=>"DEF456",
+      "ymd"=>"2018-06-17",
+      "retrievals"=>0,
+      "first_runs"=>1,
+      "finalized"=>0}].to_json
+
+    stub_request(:get, "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/statsByReferralCode?referral_code=ABC123&referral_code=DEF456").
+      to_return(status: 200, body: stubbed_response_body)
+
+    get(statement_admin_unattached_promo_registrations_path,
+        params: { referral_codes: ["ABC123", "DEF456"],
+                  event_types: ["retrievals", "first_runs", "finalized"],
+                  referral_code_statement_period: {"start(1i)"=>"2017",
+                                                  "start(2i)"=>"10",
+                                                  "start(3i)"=>"22",
+                                                  "end(1i)"=>"2018",
+                                                  "end(2i)"=>"10",
+                                                  "end(3i)"=>"22"},
+                  reporting_interval: "by_week"
+
+                 })
+
+    assert_equal response.status, 200
+    assert_equal response.header["Content-Type"], "application/html"
+    assert_match "DEF456", response.body
+    assert_match "ABC123", response.body
+  end
+
+  test "#assign assigns codes to a campaign" do
+    admin = publishers(:admin)
+    sign_in admin
+
+    promo_registration_1 = PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: active_promo_id)
+    promo_registration_2 = PromoRegistration.create!(referral_code: "DEF456", kind: "unattached", promo_id: active_promo_id)
+    PromoCampaign.create!(name: "October 2018")
+
+    patch(assign_admin_unattached_promo_registrations_path, params: {referral_codes: ["ABC123", "DEF456"], promo_campaign_target: "October 2018"})
+
+    campaign = PromoCampaign.where(name: "October 2018").first
+    
+    assert_equal campaign.promo_registrations.count, 2
+    assert campaign.promo_registrations.include?(promo_registration_1)
+    assert campaign.promo_registrations.include?(promo_registration_2)
+  end
+end

--- a/test/controllers/admin/unattached_promo_registrations_controller_test.rb
+++ b/test/controllers/admin/unattached_promo_registrations_controller_test.rb
@@ -74,7 +74,7 @@ class Admin::UnattachedPromoRegistrationsControllerTest < ActionDispatch::Integr
 
     get(statement_admin_unattached_promo_registrations_path,
         params: { referral_codes: ["ABC123", "DEF456"],
-                  event_types: ["retrievals", "first_runs", "finalized"],
+                  event_types: [PromoRegistration::RETRIEVALS, PromoRegistration::FIRST_RUNS, PromoRegistration::FINALIZED],
                   referral_code_statement_period: {"start(1i)"=>"2017",
                                                   "start(2i)"=>"10",
                                                   "start(3i)"=>"22",

--- a/test/controllers/admin/unattached_promo_registrations_controller_test.rb
+++ b/test/controllers/admin/unattached_promo_registrations_controller_test.rb
@@ -81,7 +81,7 @@ class Admin::UnattachedPromoRegistrationsControllerTest < ActionDispatch::Integr
                                                   "end(1i)"=>"2018",
                                                   "end(2i)"=>"10",
                                                   "end(3i)"=>"22"},
-                  reporting_interval: "by_week"
+                  reporting_interval: PromoRegistration::WEEKLY
 
                  })
 

--- a/test/controllers/admin/unattached_promo_registrations_controller_test.rb
+++ b/test/controllers/admin/unattached_promo_registrations_controller_test.rb
@@ -45,7 +45,7 @@ class Admin::UnattachedPromoRegistrationsControllerTest < ActionDispatch::Integr
     refute promo_registration.reload.active
   end
 
-  test "#statement downloads a statement" do
+  test "#report downloads a report" do
     Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
     admin = publishers(:admin)
     sign_in admin
@@ -72,10 +72,10 @@ class Admin::UnattachedPromoRegistrationsControllerTest < ActionDispatch::Integr
     stub_request(:get, "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/statsByReferralCode?referral_code=ABC123&referral_code=DEF456").
       to_return(status: 200, body: stubbed_response_body)
 
-    get(statement_admin_unattached_promo_registrations_path,
+    get(report_admin_unattached_promo_registrations_path,
         params: { referral_codes: ["ABC123", "DEF456"],
                   event_types: [PromoRegistration::RETRIEVALS, PromoRegistration::FIRST_RUNS, PromoRegistration::FINALIZED],
-                  referral_code_statement_period: {"start(1i)"=>"2017",
+                  referral_code_report_period: {"start(1i)"=>"2017",
                                                   "start(2i)"=>"10",
                                                   "start(3i)"=>"22",
                                                   "end(1i)"=>"2018",

--- a/test/mailers/promo_mailer_test.rb
+++ b/test/mailers/promo_mailer_test.rb
@@ -32,7 +32,7 @@ class PromoMailerTest < ActionMailer::TestCase
     channel = publisher.channels.first
 
     referral_code = "BATS-321"
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "free-bats-2018q1", referral_code: referral_code)
+    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "free-bats-2018q1", kind: "channel", referral_code: referral_code)
     promo_registration.save!
     promo_enabled_channels = publisher.channels.joins(:promo_registration)
 
@@ -69,7 +69,7 @@ class PromoMailerTest < ActionMailer::TestCase
     channel = publisher.channels.first
 
     referral_code = "BATS-321"
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "free-bats-2018q1", referral_code: referral_code)
+    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "free-bats-2018q1", kind: "channel", referral_code: referral_code)
     promo_registration.save!
 
     email = PromoMailer.new_channel_registered_2018q1(publisher, channel)

--- a/test/models/promo_campaign_test.rb
+++ b/test/models/promo_campaign_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class PromoCampaignTest < ActiveSupport::TestCase
+  test "cannot create two campaigns with the same name" do
+    campaign_1 = PromoCampaign.new(name: "Campaign 1")
+    campaign_1.save!
+
+    campaign_2 = PromoCampaign.new(name: "Campaign 1")
+    refute campaign_2.valid?
+  end
+end

--- a/test/models/promo_registration_test.rb
+++ b/test/models/promo_registration_test.rb
@@ -4,21 +4,39 @@ class PromoRegistrationTest < ActiveSupport::TestCase
   PROMO_ID = "2018q1"
   REFERRAL_CODE = "BATS-123"
 
-  test "promo registration must have an associated channel" do
+  test "promo registration doesn't need an associated channel_id if the kind is unattached" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: nil, promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: nil, promo_id: PROMO_ID, kind: "unattached", referral_code: REFERRAL_CODE)
+    assert promo_registration.valid?
+  end
 
-    # verify validation fails if no associated channel
-    assert !promo_registration.valid?
+  test "promo registration must have be kind channel if channel_id is present" do
+    channel = channels(:verified)
+    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
 
-    # verify validation passes with associated channel
+    # verify validation fails if no kind is present
+    refute promo_registration.valid?
+
+    # verify validation passes is kind is set to channel
+    promo_registration.kind = "channel"
+    assert promo_registration.valid?
+  end
+
+  test "promo registration must have a channel_id if kind is channel" do
+    channel = channels(:verified)
+    promo_registration = PromoRegistration.new(kind: "channel", promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+
+    # verify validation fails if no channel_id
+    refute promo_registration.valid?
+
+    # verify validation passes is kind is set to channel
     promo_registration.channel_id = channel.id
     assert promo_registration.valid?
   end
 
   test "promo registration must have a promo id" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "", referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "", kind: "channel", referral_code: REFERRAL_CODE)
 
     # verify validation fails if no associated promo_id
     assert !promo_registration.valid?
@@ -30,7 +48,7 @@ class PromoRegistrationTest < ActiveSupport::TestCase
 
   test "promo registration must have a referral code" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, referral_code: nil)
+    promo_registration = PromoRegistration.new(channel_id: channel.id, kind: "channel", promo_id: PROMO_ID, referral_code: nil)
 
     # verify validation fails is no associated referral code
     assert !promo_registration.valid?
@@ -43,11 +61,11 @@ class PromoRegistrationTest < ActiveSupport::TestCase
   test "promo registration must have a unique referral code " do
     channel_verified = channels(:verified)
     channel_completed = channels(:completed)
-    promo_registration = PromoRegistration.new(channel_id: channel_verified.id, promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel_verified.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
     promo_registration.save!
 
     # verify validation fails with non unique referall code
-    promo_registration_invalid = PromoRegistration.new(channel_id: channel_completed.id, promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+    promo_registration_invalid = PromoRegistration.new(channel_id: channel_completed.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
     assert !promo_registration_invalid.valid?
 
     # verify validation passes with unique referral code
@@ -58,9 +76,9 @@ class PromoRegistrationTest < ActiveSupport::TestCase
   # This might be better suited for ChannelTest
   test "channel can only have one promo registration" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
     promo_registration.save!
-    promo_registration_invalid = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, referral_code: "BATS-321")
+    promo_registration_invalid = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, kind: "channel", referral_code: "BATS-321")
     promo_registration.save!
 
     # verify channel has only the first promo detail
@@ -70,7 +88,7 @@ class PromoRegistrationTest < ActiveSupport::TestCase
 
   test "if promo registration deleted, associated channel shouldn't be deleted" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
     promo_registration.save!
 
     assert_equal channel.promo_registration, promo_registration
@@ -79,7 +97,34 @@ class PromoRegistrationTest < ActiveSupport::TestCase
     assert Channel.exists?(channel.id)
   end
 
-  test "if promo registration deleted, associated publisher shouldn't be deleted" do
-    # TO DO
+  test "aggregate_stats aggregates stats" do
+    stats = [{"referral_code"=>"GHI789",
+              "ymd"=>"2018-02-24",
+              "retrievals"=>0,
+              "first_runs"=>3,
+              "finalized"=>0},
+             {"referral_code"=>"GHI789",
+              "ymd"=>"2018-02-25",
+              "retrievals"=>0,
+              "first_runs"=>3,
+              "finalized"=>0},
+             {"referral_code"=>"GHI789",
+              "ymd"=>"2018-02-25",
+              "retrievals"=>0,
+              "first_runs"=>1,
+              "finalized"=>1},
+             {"referral_code"=>"GHI789",
+              "ymd"=>"2018-02-25",
+              "retrievals"=>0,
+              "first_runs"=>1,
+              "finalized"=>1}].to_json
+
+    PromoRegistration.create!(referral_code: "GHI789", kind: "unattached", promo_id: PROMO_ID, stats: stats)
+
+    promo_registration = PromoRegistration.find_by_referral_code("GHI789")
+
+    assert_equal promo_registration.aggregate_stats["retrievals"], 0
+    assert_equal promo_registration.aggregate_stats["first_runs"], 8
+    assert_equal promo_registration.aggregate_stats["finalized"], 2   
   end
 end

--- a/test/models/promo_registration_test.rb
+++ b/test/models/promo_registration_test.rb
@@ -127,4 +127,13 @@ class PromoRegistrationTest < ActiveSupport::TestCase
     assert_equal promo_registration.aggregate_stats["first_runs"], 8
     assert_equal promo_registration.aggregate_stats["finalized"], 2   
   end
+
+  test "unattached scope returns only unattached promo registrations" do
+    promo_registration = PromoRegistration.create!(referral_code: "ABC123", promo_id: PROMO_ID, kind: "unattached")
+    channel = channels(:verified)
+    PromoRegistration.create!(referral_code: "DEF456", promo_id: PROMO_ID, kind: "channel", channel: channel)
+
+    assert_equal PromoRegistration.unattached.count, 1
+    assert_equal PromoRegistration.unattached.first, promo_registration
+  end
 end

--- a/test/services/admin_promo_stats_fetcher_test.rb
+++ b/test/services/admin_promo_stats_fetcher_test.rb
@@ -17,8 +17,8 @@ class AdminPromoStatsFetcherTest < ActiveJob::TestCase
     Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
 
     # create two registrations
-    PromoRegistration.create(promo_id: active_promo_id, referral_code: "ABC123", kind: "unattached")
-    PromoRegistration.create(promo_id: active_promo_id, referral_code: "DEF456", kind: "unattached")
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "ABC123", kind: PromoRegistration::UNATTACHED)
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "DEF456", kind: PromoRegistration::UNATTACHED)
 
     # stub the response body
     stubbed_response_body = [{
@@ -45,7 +45,7 @@ class AdminPromoStatsFetcherTest < ActiveJob::TestCase
     promo_registrations = PromoRegistration.where(referral_code: ["ABC123", "DEF456"])
     AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
 
-    assert_equal 2, PromoRegistration.find_by_referral_code("ABC123").aggregate_stats["first_runs"]
-    assert_equal 1, PromoRegistration.find_by_referral_code("DEF456").aggregate_stats["first_runs"]
+    assert_equal 2, PromoRegistration.find_by_referral_code("ABC123").aggregate_stats[PromoRegistration::FIRST_RUNS]
+    assert_equal 1, PromoRegistration.find_by_referral_code("DEF456").aggregate_stats[PromoRegistration::FIRST_RUNS]
   end
 end

--- a/test/services/admin_promo_stats_fetcher_test.rb
+++ b/test/services/admin_promo_stats_fetcher_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+require "webmock/minitest"
+
+class AdminPromoStatsFetcherTest < ActiveJob::TestCase
+  include PromosHelper
+
+  before(:example) do
+    @prev_promo_api_uri = Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  after(:example) do
+    Rails.application.secrets[:api_promo_base_uri] = @prev_promo_api_uri
+  end
+
+  test "saves the stats" do
+    # ensure an external request is attempted to be stubbed by turning on promo
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
+
+    # create two registrations
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "ABC123", kind: "unattached")
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "DEF456", kind: "unattached")
+
+    # stub the response body
+    stubbed_response_body = [{
+      "referral_code"=>"ABC123",
+      "ymd"=>"2018-04-29",
+      "retrievals"=>0,
+      "first_runs"=>1,
+      "finalized"=>1},
+     {"referral_code"=>"ABC123",
+      "ymd"=>"2018-05-12",
+      "retrievals"=>0,
+      "first_runs"=>1,
+      "finalized"=>0},
+     {"referral_code"=>"DEF456",
+      "ymd"=>"2018-06-17",
+      "retrievals"=>0,
+      "first_runs"=>1,
+      "finalized"=>0}].to_json
+
+    request_url = "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/statsByReferralCode?referral_code=ABC123&referral_code=DEF456"
+    stub_request(:get, request_url)
+      .to_return(status: 200, body: stubbed_response_body)
+
+    promo_registrations = PromoRegistration.where(referral_code: ["ABC123", "DEF456"])
+    AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+
+    assert_equal 2, PromoRegistration.find_by_referral_code("ABC123").aggregate_stats["first_runs"]
+    assert_equal 1, PromoRegistration.find_by_referral_code("DEF456").aggregate_stats["first_runs"]
+  end
+end

--- a/test/services/promo_registrar_unattached_test.rb
+++ b/test/services/promo_registrar_unattached_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PromoRegistrarUnattachedTest < ActiveJob::TestCase
+  before(:example) do
+    @prev_promo_api_uri = Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  after(:example) do
+    Rails.application.secrets[:api_promo_base_uri] = @prev_promo_api_uri
+  end
+
+  test "creates a unattached promo registration" do
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
+    prev_promo_registration_count = PromoRegistration.count
+
+    stub_request(:put, "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral_code/unattached?number=1")
+      .to_return(status: 200, body: [{"referral_code":"NDF915","ts":"2018-10-12T20:06:50.125Z","type":"unattached","owner_id":"","channel_id":"","status":"active"}].to_json)
+    PromoRegistrarUnattached.new(number: 1).perform
+
+    current_promo_registration_count = PromoRegistration.count
+
+    # verify one more promo registration was created
+    assert_equal 1, (current_promo_registration_count - prev_promo_registration_count)
+
+    created_promo_registration = PromoRegistration.order("created_at").first
+
+    # verify the new promo registration is created correctly
+    assert_equal created_promo_registration.referral_code, "NDF915"
+    assert_nil created_promo_registration.channel_id
+    assert_equal created_promo_registration.kind, "unattached"
+  end
+
+  test "returns nil if number is <= 0" do
+    result = PromoRegistrarUnattached.new(number: 0).perform
+    assert_nil result
+  end
+end

--- a/test/services/promo_report_generator_test.rb
+++ b/test/services/promo_report_generator_test.rb
@@ -32,7 +32,7 @@ class PromoReportGeneratorTest < ActiveJob::TestCase
     statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-10-22".to_date,
                                 end_date: "2018-10-22".to_date,
-                                reporting_interval: "by_day").perform
+                                reporting_interval: PromoRegistration::DAILY).perform
 
     assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{PromoRegistration::RETRIEVALS=>0, PromoRegistration::FIRST_RUNS=>0, PromoRegistration::FINALIZED=>0}}}
   end
@@ -42,7 +42,7 @@ class PromoReportGeneratorTest < ActiveJob::TestCase
     statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-10-22".to_date,
                                 end_date: "2018-10-22".to_date,
-                                reporting_interval: "cumulative").perform
+                                reporting_interval: PromoRegistration::RUNNING_TOTAL).perform
 
     assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{PromoRegistration::RETRIEVALS=>0, PromoRegistration::FIRST_RUNS=>0, PromoRegistration::FINALIZED=>0}}}
   end
@@ -52,7 +52,7 @@ class PromoReportGeneratorTest < ActiveJob::TestCase
     statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-9-01".to_date,
                                 end_date: "2018-10-29".to_date,
-                                reporting_interval: "by_day").perform
+                                reporting_interval: PromoRegistration::DAILY).perform
 
     assert_equal statement["contents"].count, 1
     assert_equal statement["contents"]["ABC123"].count, 59
@@ -72,7 +72,7 @@ class PromoReportGeneratorTest < ActiveJob::TestCase
     statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-9-01".to_date,
                                 end_date: "2018-10-29".to_date,
-                                reporting_interval: "by_week").perform
+                                reporting_interval: PromoRegistration::WEEKLY).perform
 
     assert_equal statement["contents"].count, 1
     assert_equal statement["contents"]["ABC123"].count, 10
@@ -92,7 +92,7 @@ class PromoReportGeneratorTest < ActiveJob::TestCase
     statement = PromoReportGenerator.new(referral_codes: ["ABC123", "DEF456"],
                                 start_date: "2018-9-01".to_date,
                                 end_date: "2018-10-29".to_date,
-                                reporting_interval: "by_week").perform
+                                reporting_interval: PromoRegistration::WEEKLY).perform
 
     assert_equal statement["contents"].count, 2
     assert_equal statement["contents"]["ABC123"].count, 10

--- a/test/services/promo_report_generator_test.rb
+++ b/test/services/promo_report_generator_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PromoStatementGeneratorTest < ActiveJob::TestCase
+class PromoReportGeneratorTest < ActiveJob::TestCase
 
   STATS = [{"ymd"=>"2018-09-01",
             "retrievals"=>1,
@@ -29,7 +29,7 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
 
   test "with no stats, generates an empty statement by day" do
     PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1")
-    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+    statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-10-22".to_date,
                                 end_date: "2018-10-22".to_date,
                                 reporting_interval: "by_day").perform
@@ -39,7 +39,7 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
 
   test "with no stats, generates an empty statement with cumulative reporting interval" do
     PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1")
-    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+    statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-10-22".to_date,
                                 end_date: "2018-10-22".to_date,
                                 reporting_interval: "cumulative").perform
@@ -49,7 +49,7 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
 
   test "generates a statement with a 'by day' reporting interval" do
     PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
-    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+    statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-9-01".to_date,
                                 end_date: "2018-10-29".to_date,
                                 reporting_interval: "by_day").perform
@@ -69,7 +69,7 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
 
   test "generates a statement with a 'by week' reporting interval" do
     PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
-    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+    statement = PromoReportGenerator.new(referral_codes: ["ABC123"],
                                 start_date: "2018-9-01".to_date,
                                 end_date: "2018-10-29".to_date,
                                 reporting_interval: "by_week").perform
@@ -89,7 +89,7 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
   test "generates a statement for two codes" do
     PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
     PromoRegistration.create!(referral_code: "DEF456", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
-    statement = PromoStatementGenerator.new(referral_codes: ["ABC123", "DEF456"],
+    statement = PromoReportGenerator.new(referral_codes: ["ABC123", "DEF456"],
                                 start_date: "2018-9-01".to_date,
                                 end_date: "2018-10-29".to_date,
                                 reporting_interval: "by_week").perform

--- a/test/services/promo_statement_generator_test.rb
+++ b/test/services/promo_statement_generator_test.rb
@@ -34,7 +34,7 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
                                 end_date: "2018-10-22".to_date,
                                 reporting_interval: "by_day").perform
 
-    assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{"retrievals"=>0, "first_runs"=>0, "finalized"=>0}}}
+    assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{PromoRegistration::RETRIEVALS=>0, PromoRegistration::FIRST_RUNS=>0, PromoRegistration::FINALIZED=>0}}}
   end
 
   test "with no stats, generates an empty statement with cumulative reporting interval" do
@@ -44,7 +44,7 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
                                 end_date: "2018-10-22".to_date,
                                 reporting_interval: "cumulative").perform
 
-    assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{"retrievals"=>0, "first_runs"=>0, "finalized"=>0}}}
+    assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{PromoRegistration::RETRIEVALS=>0, PromoRegistration::FIRST_RUNS=>0, PromoRegistration::FINALIZED=>0}}}
   end
 
   test "generates a statement with a 'by day' reporting interval" do
@@ -57,14 +57,14 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
     assert_equal statement["contents"].count, 1
     assert_equal statement["contents"]["ABC123"].count, 59
 
-    checksums = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0}
+    checksums = {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, PromoRegistration::FINALIZED => 0}
     statement["contents"]["ABC123"].each do |event|
-      checksums["retrievals"] += event.second["retrievals"]
-      checksums["first_runs"] += event.second["first_runs"]
-      checksums["finalized"] += event.second["finalized"]
+      checksums[PromoRegistration::RETRIEVALS] += event.second[PromoRegistration::RETRIEVALS]
+      checksums[PromoRegistration::FIRST_RUNS] += event.second[PromoRegistration::FIRST_RUNS]
+      checksums[PromoRegistration::FINALIZED] += event.second[PromoRegistration::FINALIZED]
     end
     
-    assert_equal checksums, {"retrievals" => 6, "first_runs" => 6, "finalized" => 6}
+    assert_equal checksums, {PromoRegistration::RETRIEVALS => 6, PromoRegistration::FIRST_RUNS => 6, PromoRegistration::FINALIZED => 6}
   end
 
   test "generates a statement with a 'by week' reporting interval" do
@@ -76,14 +76,14 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
 
     assert_equal statement["contents"].count, 1
     assert_equal statement["contents"]["ABC123"].count, 10
-    checksums = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0}
+    checksums = {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, PromoRegistration::FINALIZED => 0}
     statement["contents"]["ABC123"].each do |event|
-      checksums["retrievals"] += event.second["retrievals"]
-      checksums["first_runs"] += event.second["first_runs"]
-      checksums["finalized"] += event.second["finalized"]
+      checksums[PromoRegistration::RETRIEVALS] += event.second[PromoRegistration::RETRIEVALS]
+      checksums[PromoRegistration::FIRST_RUNS] += event.second[PromoRegistration::FIRST_RUNS]
+      checksums[PromoRegistration::FINALIZED] += event.second[PromoRegistration::FINALIZED]
     end
 
-    assert_equal checksums, {"retrievals" => 6, "first_runs" => 6, "finalized" => 6}
+    assert_equal checksums, {PromoRegistration::RETRIEVALS => 6, PromoRegistration::FIRST_RUNS => 6, PromoRegistration::FINALIZED => 6}
   end
 
   test "generates a statement for two codes" do
@@ -99,13 +99,13 @@ class PromoStatementGeneratorTest < ActiveJob::TestCase
     assert_equal statement["contents"]["DEF456"].count, 10
 
     ["ABC123", "DEF456"].each do |code|
-      checksums = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0}
+      checksums = {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, PromoRegistration::FINALIZED => 0}
       statement["contents"][code].each do |event|
-        checksums["retrievals"] += event.second["retrievals"]
-        checksums["first_runs"] += event.second["first_runs"]
-        checksums["finalized"] += event.second["finalized"]
+        checksums[PromoRegistration::RETRIEVALS] += event.second[PromoRegistration::RETRIEVALS]
+        checksums[PromoRegistration::FIRST_RUNS] += event.second[PromoRegistration::FIRST_RUNS]
+        checksums[PromoRegistration::FINALIZED] += event.second[PromoRegistration::FINALIZED]
       end
-      assert_equal checksums, {"retrievals" => 6, "first_runs" => 6, "finalized" => 6}
+      assert_equal checksums, {PromoRegistration::RETRIEVALS => 6, PromoRegistration::FIRST_RUNS => 6, PromoRegistration::FINALIZED => 6}
     end
   end
 end

--- a/test/services/promo_statement_generator_test.rb
+++ b/test/services/promo_statement_generator_test.rb
@@ -1,0 +1,111 @@
+require "test_helper"
+
+class PromoStatementGeneratorTest < ActiveJob::TestCase
+
+  STATS = [{"ymd"=>"2018-09-01",
+            "retrievals"=>1,
+            "first_runs"=>1,
+            "finalized"=>1},
+            {"ymd"=>"2018-09-03",
+            "retrievals"=>1,
+            "first_runs"=>1,
+            "finalized"=>1},
+            {"ymd"=>"2018-09-08",
+            "retrievals"=>1,
+            "first_runs"=>1,
+            "finalized"=>1},
+            {"ymd"=>"2018-10-15",
+            "retrievals"=>1,
+            "first_runs"=>1,
+            "finalized"=>1},
+            {"ymd"=>"2018-10-20",
+            "retrievals"=>1,
+            "first_runs"=>1,
+            "finalized"=>1},
+            {"ymd"=>"2018-10-29",
+            "retrievals"=>1,
+            "first_runs"=>1,
+            "finalized"=>1}].to_json
+
+  test "with no stats, generates an empty statement by day" do
+    PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1")
+    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+                                start_date: "2018-10-22".to_date,
+                                end_date: "2018-10-22".to_date,
+                                reporting_interval: "by_day").perform
+
+    assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{"retrievals"=>0, "first_runs"=>0, "finalized"=>0}}}
+  end
+
+  test "with no stats, generates an empty statement with cumulative reporting interval" do
+    PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1")
+    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+                                start_date: "2018-10-22".to_date,
+                                end_date: "2018-10-22".to_date,
+                                reporting_interval: "cumulative").perform
+
+    assert_equal statement["contents"], {"ABC123"=>{"2018-10-22".to_date=>{"retrievals"=>0, "first_runs"=>0, "finalized"=>0}}}
+  end
+
+  test "generates a statement with a 'by day' reporting interval" do
+    PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
+    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+                                start_date: "2018-9-01".to_date,
+                                end_date: "2018-10-29".to_date,
+                                reporting_interval: "by_day").perform
+
+    assert_equal statement["contents"].count, 1
+    assert_equal statement["contents"]["ABC123"].count, 59
+
+    checksums = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0}
+    statement["contents"]["ABC123"].each do |event|
+      checksums["retrievals"] += event.second["retrievals"]
+      checksums["first_runs"] += event.second["first_runs"]
+      checksums["finalized"] += event.second["finalized"]
+    end
+    
+    assert_equal checksums, {"retrievals" => 6, "first_runs" => 6, "finalized" => 6}
+  end
+
+  test "generates a statement with a 'by week' reporting interval" do
+    PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
+    statement = PromoStatementGenerator.new(referral_codes: ["ABC123"],
+                                start_date: "2018-9-01".to_date,
+                                end_date: "2018-10-29".to_date,
+                                reporting_interval: "by_week").perform
+
+    assert_equal statement["contents"].count, 1
+    assert_equal statement["contents"]["ABC123"].count, 10
+    checksums = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0}
+    statement["contents"]["ABC123"].each do |event|
+      checksums["retrievals"] += event.second["retrievals"]
+      checksums["first_runs"] += event.second["first_runs"]
+      checksums["finalized"] += event.second["finalized"]
+    end
+
+    assert_equal checksums, {"retrievals" => 6, "first_runs" => 6, "finalized" => 6}
+  end
+
+  test "generates a statement for two codes" do
+    PromoRegistration.create!(referral_code: "ABC123", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
+    PromoRegistration.create!(referral_code: "DEF456", kind: "unattached", promo_id: "free-bats-2018q1", stats: STATS)
+    statement = PromoStatementGenerator.new(referral_codes: ["ABC123", "DEF456"],
+                                start_date: "2018-9-01".to_date,
+                                end_date: "2018-10-29".to_date,
+                                reporting_interval: "by_week").perform
+
+    assert_equal statement["contents"].count, 2
+    assert_equal statement["contents"]["ABC123"].count, 10
+    assert_equal statement["contents"]["DEF456"].count, 10
+
+    ["ABC123", "DEF456"].each do |code|
+      checksums = {"retrievals" => 0, "first_runs" => 0, "finalized" => 0}
+      statement["contents"][code].each do |event|
+        checksums["retrievals"] += event.second["retrievals"]
+        checksums["first_runs"] += event.second["first_runs"]
+        checksums["finalized"] += event.second["finalized"]
+      end
+      assert_equal checksums, {"retrievals" => 6, "first_runs" => 6, "finalized" => 6}
+    end
+  end
+end

--- a/test/services/promo_unattached_status_updater_test.rb
+++ b/test/services/promo_unattached_status_updater_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "webmock/minitest"
+
+class PromoUnattachedStatusUpdaterTest < ActiveJob::TestCase
+  include PromosHelper
+
+  before(:example) do
+    @prev_promo_api_uri = Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  after(:example) do
+    Rails.application.secrets[:api_promo_base_uri] = @prev_promo_api_uri
+  end
+
+  test "has the correct request format" do
+    # ensure an external request is attempted to be stubbed by turning on promo
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
+
+    # create two registrations
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "ABC123", kind: "unattached")
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "DEF456", kind: "unattached")
+
+    request_url = "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral?referral_code=ABC123&referral_code=DEF456"
+    request_body = {status: "paused"}.to_json
+    stub_request(:patch, request_url)
+      .with(body: request_body)
+      .to_return(status: 200)
+    response = PromoUnattachedStatusUpdater.new(promo_registrations: PromoRegistration.all, status: "paused").perform
+    assert_equal response.status, 200 
+  end
+end

--- a/test/tasks/launch_promo_test.rb
+++ b/test/tasks/launch_promo_test.rb
@@ -8,21 +8,6 @@ class LaunchPromoTest < ActiveJob::TestCase
     Rails.application.load_tasks
   end
 
-  # test "incorrect active_promo_id does not launch the promo" do
-  #   # TO DO
-
-  #   # ?.any_instance.stubs(:active_promo_id).returns("invalid-promo-id")
-
-  #   # We can't stub this method, maybe we should consider moving rake task logic
-  #   # into a service/lib/job and call it from within the task
-
-  #   # assert_difference("Publisher.where.not(promo_token_2018q1: nil).count", 0) do
-  #   #   assert_difference("ActionMailer::Base.deliveries.count" , 0) do
-  #   #     Rake::Task["promo:launch_promo"].invoke
-  #   #   end
-  #   # end
-  # end
-
   test "generates a promo token and sends email to each publisher" do
     assert_difference("Publisher.where.not(promo_token_2018q1: nil).count", Publisher.where.not(email: nil).count) do
       assert_enqueued_jobs(Publisher.where.not(email: nil).count) do


### PR DESCRIPTION
Resolves https://github.com/brave-intl/publishers/issues/1113

The set_default_promo_registration_kind rake task should be run as soon as the code is merged.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
