### PR TITLE
Allow a promo registrations's kind to be null in postgres

### DIFF
--- a/db/migrate/20181012194114_add_kind_to_promo_registration.rb
+++ b/db/migrate/20181012194114_add_kind_to_promo_registration.rb
@@ -1,5 +1,5 @@
 class AddKindToPromoRegistration < ActiveRecord::Migration[5.2]
   def change
-    add_column :promo_registrations, :kind, :text, null: false
+    add_column :promo_registrations, :kind, :text
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -206,7 +206,7 @@ ActiveRecord::Schema.define(version: 2018_10_16_134245) do
     t.string "referral_code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "kind", null: false
+    t.text "kind"
     t.jsonb "stats", default: "{}"
     t.uuid "promo_campaign_id"
     t.boolean "active", default: true, null: false


### PR DESCRIPTION
Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
