### PR TITLE
Prepare infinity code dashboard for release

### DIFF
--- a/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
+++ b/app/assets/stylesheets/admin/pages/unattached_promo_registrations.scss
@@ -1,7 +1,11 @@
 
 .unattached-promo-registrations {
 
-  .row {
+  hr {
+    margin: 5px 0px 10px 0px; 
+  }
+
+  .flex {
     display: flex;
   }
 
@@ -10,8 +14,12 @@
     flex: 1;
     border-width: 1px;
     border-radius: 15px;
-    margin: 15px;
+    margin: 10px;
     padding: 20px 50px 20px 50px;
+
+    &--white{
+      background: white;
+    }
 
     .panel--header {
       font-size: 20px;
@@ -22,32 +30,23 @@
       font-size: 18px;
       font-weight: bold;
     }
-
-    &--color-offset {
-      background: white;      
-    }
-
-  .download-button {
-    padding-top: 10px;
-    text-align: center;
-  }
-  }
-  .panel--double {
   }
 
   .panel--single {
+    margin: 20px;
+    border-radius: 0px;
+  }
+
+  .panel--table {
+    padding: 10px 25px 10px 25px;
   }
 
   .flex-one {
     flex: 1;
   }
 
-  .flex-one {
+  .flex-two {
     flex: 2;
-  }
-
-  .flex-three {
-    flex: 3;
   }
 
   .align-self-center {
@@ -61,22 +60,25 @@
   .btn {
     margin: 0px 5px 5px 5px;
   }
+  
   .unattached-referral-code-form--submissions {
     display: flex;
     width: 100%;
   }
-  .unattached-referral-code-form--submission {
-  }
 
-  label {
-    font-weight: bold;
-  }
-
-  .table {
+  table {
+    border: none;
     text-align: center;
-    
+    tbody {
+      border: none;
+    }
+    th {
+      border: none;
+    }
     tr {
+      border: none;
       td {
+        border: none;
         padding: 0;
       }
     }

--- a/app/controllers/admin/unattached_promo_registrations_controller.rb
+++ b/app/controllers/admin/unattached_promo_registrations_controller.rb
@@ -20,8 +20,12 @@ class Admin::UnattachedPromoRegistrationsController < AdminController
 
   def create
     number = create_params.to_i
-    PromoRegistrarUnattached.new(number: number).perform
-    redirect_to admin_unattached_promo_registrations_path, notice: "#{number} codes created."
+    if number > 50
+      redirect_to admin_unattached_promo_registrations_path, alert: "Can't create more than 50 codes at a time."
+    else
+      PromoRegistrarUnattached.new(number: number).perform
+      redirect_to admin_unattached_promo_registrations_path, notice: "#{number} codes created."
+    end
   end
 
   def report

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -9,14 +9,14 @@
         hr
         .
           = number_field_tag "number_of_codes_to_create", nil, placeholder: "# of codes"
-          = submit_tag "Create", class: "btn btn-info"
+          = submit_tag "Create", class: "btn btn-info", style: "float:right;"
     .panel.panel--double
       = form_tag admin_promo_campaigns_path, id: "create-promo-campaign" do
         .panel--header = "Create campaigns"
         hr
         .
           = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
-          = submit_tag "Create", class: "btn btn-info"
+          = submit_tag "Create", class: "btn btn-info", style: "float: right"
   .row
   .panel.panel--white.panel--table
     .panel--header = "Manage"

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -20,7 +20,11 @@
   .row
   .panel.panel--white.panel--table
     .panel--header = "Manage"
-      span style="color: darkgrey; font-size: 14px;" = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in reports are always up-to-date."
+    . style="color: darkgrey; font-size: 14px; margin-bottom: 5px;"
+      - if Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at').nil?
+        = "Stats have not been refreshed."
+      - else 
+        = "Stats last refreshed #{distance_of_time_in_words(Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in reports are always up-to-date."
     = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign" do
       = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
       = submit_tag "Filter by campaign", class: "btn btn-success"

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -40,7 +40,7 @@
               span.icon= render "icon_help"
               span.tf-tooltip-content
                 span.tf-tooltip-content-heading= "Status"
-                span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
+                span.tf-tooltip-content-content== "Downloads and installs will not be tracked when a code is 'paused'."
           th = "Downloads"
           th 
             = "Installs"

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -102,12 +102,12 @@
               . style="font-weight: bold" = label_tag = "Event types"
               .
                 = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
-                = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
+                = label_tag = " " + event_type_column_header(PromoRegistration::RETRIEVALS)
               .
                 = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
-                = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
+                = label_tag = " " + event_type_column_header(PromoRegistration::FIRST_RUNS)
               .
                 = check_box_tag "event_types[]", PromoRegistration::FINALIZED
-                = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
+                = label_tag = " " + event_type_column_header(PromoRegistration::FINALIZED)
             .flex-one.align-self-flex-end
               = submit_tag "Download", id: "download-referral-reports", class: "btn btn-primary", data: { disable_with: false }

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -1,110 +1,109 @@
 .unattached-promo-registrations
-  .row
+  .flex
     h1 Referral Promo
     hr
-  .row
+  .flex
     .panel.panel--double
       = form_tag admin_unattached_promo_registrations_path, id: "create-referral-codes" do
         .panel--header = "Create codes"
         hr
         .
-          = number_field_tag "number_of_codes_to_create", nil, placeholder: "# codes"
-          = submit_tag "+ Referral codes", class: "btn btn-info"
+          = number_field_tag "number_of_codes_to_create", nil, placeholder: "# of codes"
+          = submit_tag "Create", class: "btn btn-info"
     .panel.panel--double
       = form_tag admin_promo_campaigns_path, id: "create-promo-campaign" do
         .panel--header = "Create campaigns"
         hr
         .
           = text_field_tag "campaign_name", nil, placeholder: "Campaign name"
-          = submit_tag "+ Campaign", class: "btn btn-info"
+          = submit_tag "Create", class: "btn btn-info"
   .row
-    .panel.panel--single
-      .panel--header = "Manage"
+  .panel.panel--white.panel--table
+    .panel--header = "Manage"
       span style="color: darkgrey; font-size: 14px;" = "Stats last refreshed #{distance_of_time_in_words (Time.now - Rails.cache.fetch('unattached_promo_registration_stats_last_synced_at'))} ago. Stats in reports are always up-to-date."
-      hr
-      = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign"do
-        = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
-        = submit_tag "Filter by campaign", class: "btn btn-success"
-      = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
-        table.table
-          tr
-            th 
-            th = "Code"
-            th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
-            th
-              = "Status"
-              span.tf-tooltip
-                span.icon= render "icon_help"
-                span.tf-tooltip-content
-                  span.tf-tooltip-content-heading= "Status"
-                  span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
-            th = "Downloads"
-            th 
-              = "Installs"
-              span.tf-tooltip
-                span.icon= render "icon_help"
-                span.tf-tooltip-content
-                  span.tf-tooltip-content-heading= "Installs"
-                  span.tf-tooltip-content-content== "An install is counted when a user downloads the browser and opens it the first time."
+    = form_tag admin_unattached_promo_registrations_path, method: :get, id: "filter-by-campaign" do
+      = select_tag :filter, options_for_select(@campaigns + ["Not assigned", "All codes"], @current_campaign)
+      = submit_tag "Filter by campaign", class: "btn btn-success"
+    = form_tag admin_unattached_promo_registrations_path, method: :patch, id: "unattached-referral-code-form" do
+      table.table
+        tr
+          th 
+          th = "Code"
+          th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
+          th
+            = "Status"
+            span.tf-tooltip
+              span.icon= render "icon_help"
+              span.tf-tooltip-content
+                span.tf-tooltip-content-heading= "Status"
+                span.tf-tooltip-content-content== "A code's stats will not be tracked or updated while it's status is 'paused.'"
+          th = "Downloads"
+          th 
+            = "Installs"
+            span.tf-tooltip
+              span.icon= render "icon_help"
+              span.tf-tooltip-content
+                span.tf-tooltip-content-heading= "Installs"
+                span.tf-tooltip-content-content== "An install is counted when a user downloads the browser and opens it the first time."
 
-            th
-              = "Confirmed"
-              span.tf-tooltip
-                span.icon= render "icon_help"
-                span.tf-tooltip-content
-                  span.tf-tooltip-content-heading= "Confirmed"
-                  span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens it, then opens it again at least 30 days later."
-          tbody
-            - @promo_registrations.each do |promo_registration| 
-              - promo_registration_aggregate_stats = promo_registration.aggregate_stats
-              tr
-                td = check_box_tag "referral_codes[]", "#{promo_registration.referral_code}", 1
-                td = promo_registration.referral_code
-                td = promo_registration.promo_campaign&.name
-                td = promo_registration.active ? "active" : "paused"
-                td = promo_registration_aggregate_stats[PromoRegistration::RETRIEVALS] || 0
-                td = promo_registration_aggregate_stats[PromoRegistration::FIRST_RUNS] || 0
-                td = promo_registration_aggregate_stats[PromoRegistration::FINALIZED] || 0
-        .row
-          .unattached-referral-code-form--submissions
-            .panel.panel--color-offset
-              .panel--sub-panel-header = "Assign codes to campaign"
-              hr
-              .row.flex-one
-                .flex-one = select_tag :promo_campaign_target, options_for_select(@campaigns)
-                = hidden_field_tag :filter, params[:filter]
-                = submit_tag "Assign", id: "assign-to-campaign", class: "btn btn-primary"
-            .panel.panel--color-offset
-              .panel--sub-panel-header = "Update code statuses"
-              hr
-              .row
-                .flex-one = select_tag :referral_code_status, options_for_select([["Active", "active"], ["Paused", "paused"]])
-                = hidden_field_tag :filter, params[:filter]
-                = submit_tag "Update", id: "update-referral-code-statuses", class: "btn btn-primary"
-        .row
-          .panel.panel--color-offset
-            .panel--sub-panel-header = "Report generation"
+          th
+            = "Confirmed"
+            span.tf-tooltip
+              span.icon= render "icon_help"
+              span.tf-tooltip-content
+                span.tf-tooltip-content-heading= "Confirmed"
+                span.tf-tooltip-content-content== "A confirmation is counted when a user downloads the browser and opens it, then opens it again at least 30 days later."
+        tbody
+          - @promo_registrations.each do |promo_registration| 
+            - promo_registration_aggregate_stats = promo_registration.aggregate_stats
+            tr
+              td = check_box_tag "referral_codes[]", "#{promo_registration.referral_code}", 1
+              td = promo_registration.referral_code
+              td = promo_registration.promo_campaign&.name
+              td = promo_registration.active ? "active" : "paused"
+              td = promo_registration_aggregate_stats[PromoRegistration::RETRIEVALS] || 0
+              td = promo_registration_aggregate_stats[PromoRegistration::FIRST_RUNS] || 0
+              td = promo_registration_aggregate_stats[PromoRegistration::FINALIZED] || 0
+      .flex
+        .unattached-referral-code-form--submissions
+          .panel
+            .panel--sub-panel-header = "Assign codes to campaign"
             hr
-            .row
-              .flex-three.align-self-flex-center
-                . = label_tag "Report period start"
-                . = date_select :referral_code_report_period, :start
-              .flex-three.align-self-flex-center
-                . = label_tag "Report period end"
-                . = date_select :referral_code_report_period, :end
-              .flex-three.align-self-flex-center
-                . = label_tag "Reporting interval"
-                . = select_tag :reporting_interval, options_for_select([["Daily",PromoRegistration::DAILY], ["Weekly",PromoRegistration::WEEKLY], ["Monthly",PromoRegistration::MONTHLY], ["Running total", PromoRegistration::RUNNING_TOTAL]])
-              .flex-one.align-self-flex-center
-                . style="font-weight: bold" = label_tag = "Event types"
-                .
-                  = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
-                  = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
-                .
-                  = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
-                  = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
-                .
-                  = check_box_tag "event_types[]", PromoRegistration::FINALIZED
-                  = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
-              .flex-one.align-self-flex-end
-                = submit_tag "Download", id: "download-referral-reports", class: "btn btn-primary", data: { disable_with: false }
+            .flex.flex-one
+              .flex-one = select_tag :promo_campaign_target, options_for_select(@campaigns)
+              = hidden_field_tag :filter, params[:filter]
+              = submit_tag "Assign", id: "assign-to-campaign", class: "btn btn-primary"
+          .panel
+            .panel--sub-panel-header = "Update code statuses"
+            hr
+            .flex
+              .flex-one = select_tag :referral_code_status, options_for_select([["Active", "active"], ["Paused", "paused"]])
+              = hidden_field_tag :filter, params[:filter]
+              = submit_tag "Update", id: "update-referral-code-statuses", class: "btn btn-primary"
+      .flex
+        .panel
+          .panel--sub-panel-header = "Report generation"
+          hr
+          .flex
+            .flex-two.align-self-flex-center
+              . = label_tag "Report period start"
+              . = date_select :referral_code_report_period, :start
+            .flex-two.align-self-flex-center
+              . = label_tag "Report period end"
+              . = date_select :referral_code_report_period, :end
+            .flex-two.align-self-flex-center
+              . = label_tag "Reporting interval"
+              . = select_tag :reporting_interval, options_for_select([["Daily",PromoRegistration::DAILY], ["Weekly",PromoRegistration::WEEKLY], ["Monthly",PromoRegistration::MONTHLY], ["Running total", PromoRegistration::RUNNING_TOTAL]])
+            .flex-one.align-self-flex-center
+              . style="font-weight: bold" = label_tag = "Event types"
+              .
+                = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
+                = label_tag = event_type_column_header(PromoRegistration::RETRIEVALS) + " "
+              .
+                = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
+                = label_tag = event_type_column_header(PromoRegistration::FIRST_RUNS) + " "
+              .
+                = check_box_tag "event_types[]", PromoRegistration::FINALIZED
+                = label_tag = event_type_column_header(PromoRegistration::FINALIZED) + " "
+            .flex-one.align-self-flex-end
+              = submit_tag "Download", id: "download-referral-reports", class: "btn btn-primary", data: { disable_with: false }

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -33,7 +33,7 @@
         tr
           th 
           th = "Code"
-          th data-toggle="tooltip" data-placement="top" title="Tooltip"= "Campaign"
+          th = "Campaign"
           th
             = "Status"
             span.tf-tooltip

--- a/test/controllers/admin/unattached_promo_registrations_controller_test.rb
+++ b/test/controllers/admin/unattached_promo_registrations_controller_test.rb
@@ -107,4 +107,15 @@ class Admin::UnattachedPromoRegistrationsControllerTest < ActionDispatch::Integr
     assert campaign.promo_registrations.include?(promo_registration_1)
     assert campaign.promo_registrations.include?(promo_registration_2)
   end
+
+  test "cannot #create more than 50 codes at a time" do
+    admin = publishers(:admin)
+    sign_in admin
+
+    assert_difference -> { PromoRegistration.count }, 0 do
+      post(admin_unattached_promo_registrations_path, params: {number_of_codes_to_create: "51"})
+    end
+
+    assert_equal flash[:alert], "Can't create more than 50 codes at a time."
+  end
 end


### PR DESCRIPTION
This PR allows the dashboard to load in the case when the last stats updated was not stored in redis.  This value is only set by the AdminSyncPromoStats job, which can only complete after a code has been created.  This change will simplify deploying the code because we will not need to create a code via rails console, then run the AdminSyncPromoStats job via rails console before we can use the feature.

Also this PR restricts the number of codes that an admin can create to 50 per click.  Currently it is unbounded and thus admins have the ability to accidentally crash the system and enter huge amounts of data directly into two databases.

Lastly, this PR also iterates on the infinity codes admin dashboard frontend.  After this PR it will look like:

![image](https://user-images.githubusercontent.com/12549658/47517725-29369f00-d857-11e8-83d3-1497f4f44fab.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
