### PR TITLE
Release 2018-10-26 (3)

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -10,6 +10,8 @@ class Publisher < ApplicationRecord
   ROLES = [ADMIN, PUBLISHER]
   JAVASCRIPT_DETECTED_RELEASE_TIME = "2018-06-19 22:51:51".freeze
 
+  OWNER_PREFIX = "publishers#uuid:"
+
   devise :timeoutable, :trackable, :omniauthable
 
   has_many :u2f_registrations, -> { order("created_at DESC") }
@@ -205,7 +207,7 @@ class Publisher < ApplicationRecord
   end
 
   def owner_identifier
-    "publishers#uuid:#{id}"
+    "#{OWNER_PREFIX}#{id}"
   end
 
   def promo_status(promo_running)
@@ -321,6 +323,10 @@ class Publisher < ApplicationRecord
   class << self
     def encryption_key
       Rails.application.secrets[:attr_encrypted_key]
+    end
+
+    def find_by_owner_identifier(owner_identifier)
+      Publisher.find(owner_identifier.split(OWNER_PREFIX)[1])
     end
   end
 end

--- a/app/models/twitch_channel_details.rb
+++ b/app/models/twitch_channel_details.rb
@@ -7,10 +7,12 @@ class TwitchChannelDetails < BaseChannelDetails
   validates :auth_user_id, presence: true
   validates :display_name, presence: true
 
+  TWITCH_PREFIX = "twitch#author:"
+
   ## Begin methods to satisfy the Eyeshade integration
 
   def channel_identifier
-    "twitch#author:#{name}"
+    "#{TWITCH_PREFIX}#{name}"
   end
 
   def authorizer_email

--- a/app/models/twitter_channel_details.rb
+++ b/app/models/twitter_channel_details.rb
@@ -7,11 +7,12 @@ class TwitterChannelDetails < BaseChannelDetails
   validates :name, presence: true
   validates :screen_name, presence: true
 
+  TWITTER_PREFIX = "twitter#channel:"
 
   # TODO: Figure out why eyeshade needs the email and name
   ## Begin methods to satisfy the Eyeshade integration
   def channel_identifier
-    "twitter#channel:#{twitter_channel_id}"
+    "#{TWITTER_PREFIX}#{twitter_channel_id}"
   end
 
   def authorizer_email

--- a/app/models/youtube_channel_details.rb
+++ b/app/models/youtube_channel_details.rb
@@ -7,10 +7,12 @@ class YoutubeChannelDetails < BaseChannelDetails
   validates :thumbnail_url, presence: true
   validates :auth_user_id, presence: true
 
+  YOUTUBE_PREFIX = "youtube#channel:"
+
   ## Begin methods to satisfy the Eyeshade integration
 
   def channel_identifier
-    "youtube#channel:#{youtube_channel_id}"
+    "#{YOUTUBE_PREFIX}#{youtube_channel_id}"
   end
 
   def authorizer_email

--- a/app/services/publisher_statement_getter.rb
+++ b/app/services/publisher_statement_getter.rb
@@ -9,7 +9,7 @@ class PublisherStatementGetter < BaseApiClient
 
   def perform
     transactions = PublisherTransactionsGetter.new(publisher: publisher).perform
-    transactions = replace_channel_identifiers_with_channel_titles(transactions)
+    transactions = replace_account_identifiers_with_titles(transactions)
     transactions = filter_transactions_by_period(transactions, @statement_period)
     transactions
   end
@@ -35,11 +35,15 @@ class PublisherStatementGetter < BaseApiClient
     end
   end
 
-  def replace_channel_identifiers_with_channel_titles(transactions)
+  def replace_account_identifiers_with_titles(transactions)
     transactions.map { |transaction|
-      channel_identifier = transaction["channel"]
-      channel = Channel.find_by_channel_identifier(channel_identifier)
-      transaction["channel"] = channel.publication_title
+      account_identifier = transaction["channel"]
+      if account_identifier.starts_with?(Publisher::OWNER_PREFIX)
+        transaction["channel"] = "All"
+      else
+        channel = Channel.find_by_channel_identifier(account_identifier)
+        transaction["channel"] = channel.publication_title
+      end
       transaction
     }
   end

--- a/app/services/publisher_transactions_getter.rb
+++ b/app/services/publisher_transactions_getter.rb
@@ -105,7 +105,7 @@ class PublisherTransactionsGetter < BaseApiClient
         transactions.push({
           "created_at" => "#{base_date}",
           "description" => "payout for referrals",
-          "channel" => "#{channel.details.channel_identifier}",
+          "channel" => "#{channel.publisher.owner_identifier}",
           "amount" => "#{referral_settlement_amount}",
           "settlement_currency" => publisher.default_currency,
           "settlement_amount" => "18.81",

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -591,4 +591,9 @@ class PublisherTest < ActiveSupport::TestCase
     publishers = Publisher.with_verified_channel.select(:id)
     assert_equal publishers.uniq.length, publishers.length
   end
+
+  test "#find_by_owner_identifier finds by owner identifier" do
+    publisher = Publisher.first
+    assert_equal Publisher.find_by_owner_identifier(publisher.owner_identifier), publisher
+  end
 end

--- a/test/services/publisher_statement_getter_test.rb
+++ b/test/services/publisher_statement_getter_test.rb
@@ -35,7 +35,7 @@ class PublisherStatementGetterTest < ActiveJob::TestCase
     assert_equal PublisherTransactionsGetter::OFFLINE_NUMBER_OF_SETTLEMENTS, number_of_unique_settlement_dates(statement_data)
   end
 
-  test "replaces channel identifiers with channel titles" do
+  test "replaces account identifiers with channel title if channel or 'All' if publisher" do
     Rails.application.secrets[:api_eyeshade_offline] = true
     publisher = publishers(:uphold_connected)
     statement_data = PublisherStatementGetter.new(publisher: publisher, statement_period: "this_month").perform
@@ -46,6 +46,10 @@ class PublisherStatementGetterTest < ActiveJob::TestCase
       assert_nil transaction["channel"].match("twitch#channel")
       assert_nil transaction["channel"].match("twitch#author")
       assert_nil transaction["channel"].match("twitter#channel")
+
+      if transaction["description"] == "payout for referrals"
+        assert_equal transaction["channel"], "All"
+      end
     end
   end
 


### PR DESCRIPTION
* Modify PublisherStatementGetter to accept txs where the 'channel' is an owner id

* Replace account identifier with "All" if the 'channel' is an owner id

* Add the account prefixes as constants to models

* Add Publisher#find_by_owner_identifier

* Add test to ensure 'All' is in the statement

* Rename and add tests for Publisher#find_by_owner_identifier

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
