### PR TITLE
Update promo registration flow for channels that have previously registered

### DIFF
--- a/app/services/promo_registration_getter.rb
+++ b/app/services/promo_registration_getter.rb
@@ -1,4 +1,4 @@
-# Gets the referral code associated with a channel + publisher combo
+# Gets the referral code associated with a channel_id
 class PromoRegistrationGetter < BaseApiClient
   include PromosHelper
 
@@ -18,42 +18,17 @@ class PromoRegistrationGetter < BaseApiClient
     response = connection.get do |request|
       request.headers["Authorization"] = api_authorization_header
       request.headers["Content-Type"] = "application/json"
-      request.url("/api/1/promo/publishers?channel=#{@channel.channel_id}")
+      request.url("/api/2/promo/referral_code/channel/#{@channel.channel_id}")
     end
-    registrations =  JSON.parse(response.body)
-    referral_code = referral_code_for_promo_id(registrations)
-    
-    if should_update_channel_owner_on_promo_server(registrations)
-      PromoChannelOwnerUpdater.new(publisher_id: @publisher.id, referral_code: referral_code).perform
-    end
-    
-    referral_code
+    JSON.parse(response.body)
   end
 
   def perform_offline
     Rails.logger.info("PromoRegistrationGetter offline.")
-
-    registrations =
-    [
-      {
-      "referral_code" => offline_referral_code,
-      "promo" => "#{@promo_id}",
-      "publisher" => "#{@channel.channel_id}",
-      "name" => "#{@channel.publication_title}",
-      },
-      {
-      "referral_code" => offline_referral_code,
-      "promo" => "free-bats-2018q2",
-      "publisher" => "#{@channel.channel_id}",
-      "name" => "#{@channel.publication_title}",
-      }
-    ]
-    referral_code = referral_code_for_promo_id(registrations)
+    {}.to_json
   end
 
   class PublisherChannelMismatchError < RuntimeError; end
-
-  class NoReferralCodeError < RuntimeError; end
 
   private
 
@@ -67,23 +42,5 @@ class PromoRegistrationGetter < BaseApiClient
 
   def publisher_owners_channel
     @publisher.channels.include?(@channel)
-  end
-
-  def should_update_channel_owner_on_promo_server(registrations)
-    owner_on_promo_server = registrations[0]["owner_id"]
-    if owner_on_promo_server != @publisher.id
-      return true
-    else
-      return false
-    end
-  end
-
-  def referral_code_for_promo_id(registrations)
-    registrations.each do |registration|
-      if registration["promo"] == active_promo_id
-        return registration["referral_code"]
-      end
-      raise NoReferralCodeError.new("No referral_code has been registered for channel #{@channel.id} for promo #{@promo_id}")
-    end
   end
 end

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -219,14 +219,13 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
                 .channel-details
                   .added-date
                     = t ".channel.added", date: channel.created_at.to_date.iso8601
-                  / TODO Uncommment when promo is correctly updated of changes in channel owner
-                  / span.separator
-                  /   = ' | '
-                  / a.remove-channel href="#" data-channel-id=(channel.id)
-                  /   = t ".channel.remove_verified"
-                  / script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
-                  /   = render "publishers/remove_channel_modal", channel: channel
-                  / = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
+                  span.separator
+                    = ' | '
+                  a.remove-channel href="#" data-channel-id=(channel.id)
+                    = t ".channel.remove_verified"
+                  script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)
+                    = render "publishers/remove_channel_modal", channel: channel
+                  = form_for(channel, html: {id: "remove_channel_#{channel.id}"}) do |f|
             - elsif channel.verification_failed?
               .channel-status.float-right
                 .verification-failed

--- a/test/services/promo_registrar_test.rb
+++ b/test/services/promo_registrar_test.rb
@@ -43,12 +43,6 @@ class PromoRegistrarTest < ActiveJob::TestCase
     end
   end
 
-  test "registrar registers > 5 channels asynchronously" do
-    # create 5 verified channels
-    # TO DO: either create a fixture that has 5 channels of find a way
-    #        to generate an arbitrary number of valid channels
-  end
-
   test "registrar requests promo code for channel if encounters duplicate error" do
     publisher = publishers(:completed)
 
@@ -62,5 +56,8 @@ class PromoRegistrarTest < ActiveJob::TestCase
     assert_difference "PromoRegistration.count", 1 do
       PromoRegistrar.new(publisher: publisher).perform
     end
+  end
+
+  test "" do
   end
 end

--- a/test/services/promo_registrar_test.rb
+++ b/test/services/promo_registrar_test.rb
@@ -3,6 +3,15 @@ require "webmock/minitest"
 
 class PromoRegistrarTest < ActiveJob::TestCase
   include PromosHelper
+
+  before(:example) do
+    @prev_offline = Rails.application.secrets[:api_promo_base_uri]
+  end
+
+  after(:example) do
+    Rails.application.secrets[:api_promo_base_uri] = @prev_offline
+  end
+
   test "registrar registers a verified channel" do
     publisher = publishers(:completed) # has one verified channel
 
@@ -44,20 +53,25 @@ class PromoRegistrarTest < ActiveJob::TestCase
   end
 
   test "registrar requests promo code for channel if encounters duplicate error" do
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
     publisher = publishers(:completed)
 
-    # Force use register_channel, not register_channel_offline
-    PromoRegistrationsController.any_instance.stubs(:perform_promo_offline?).returns(false)
-
-    # Force duplicate error    
-    stub_request(:put, "#{Rails.application.secrets[:api_promi_base_uri]}/api/1/promo/publishers")
+    # Stub Promo response saying the ref code has been taken
+    stub_request(:put, "#{Rails.application.secrets[:api_promo_base_uri]}/api/1/promo/publishers")
       .to_return(status: 409)
-    
+
+    # Stub Promo response with the referral code and current code owner
+    stub_request(:get, "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral_code/channel/completed.org")
+      .to_return(status: 200, body: {referral_code: "COM001", owner_id: "invalid"}.to_json)
+
+    # Stub Promo response when we update the owner
+    stub_request(:put, "#{Rails.application.secrets[:api_promo_base_uri]}/api/1/promo/publishers/COM001")
+      .to_return(status: 200, body: [].to_json)
+
     assert_difference "PromoRegistration.count", 1 do
       PromoRegistrar.new(publisher: publisher).perform
     end
-  end
 
-  test "" do
+    assert_equal PromoRegistration.order("created_at").last.referral_code, "COM001"
   end
 end

--- a/test/services/promo_registration_getter_test.rb
+++ b/test/services/promo_registration_getter_test.rb
@@ -12,15 +12,6 @@ class PromoRegistrationGetterTest < ActiveJob::TestCase
     end
   end
 
-  test "raises NoReferralCodeError when requesting referral_code for invalid promo_id " do
-    publisher = publishers(:completed)
-    channel = publisher.channels.first
-
-    assert_raise PromoRegistrationGetter::NoReferralCodeError do
-      PromoRegistrationGetter.new(publisher: publisher, channel: channel, promo_id: "invalid-promo-id").perform
-    end
-  end
-
   test "returns the promo code for a " do
     publisher = publishers(:completed)
     channel = publisher.channels.first


### PR DESCRIPTION
Resolves https://github.com/brave-intl/publishers/issues/1291

Blocked by https://github.com/brave-intl/vault-promo-services/pull/56
More information found in https://github.com/brave-intl/vault-promo-services/pull/56.

* Update the url used by the PromoRegistrationGetter - this ensures
  the referral code owned by the channel_id supplied is returned

* No longer update the referral server when a channel has changed
  owners via the PromoRegistrationsGetter

* Allow publishers to remove verified channels

* Remove dead tests

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
