### PR TITLE
Update referral messaging on dashboard and on activate screen

### DIFF
--- a/app/assets/stylesheets/pages/home.scss
+++ b/app/assets/stylesheets/pages/home.scss
@@ -158,7 +158,7 @@
         color: #006192;
         font-weight: 700;
       }
-      #promo-title {
+      #promo-header {
         color: white;
         font-weight: 600;
         margin-bottom: 0px;
@@ -173,12 +173,12 @@
       }
       #activate-promo-dashboard-button {
         background: white;
-        color: #006192;
+        color: #4C54D2;
         border: none;
         &:hover, &focus {
           background: #bcf0f7;
         }
-        font-size: 11px;
+        font-size: 12px;
         font-weight: 600;
         font-weight: 700;
       }

--- a/app/views/promo_registrations/_activate.html.slim
+++ b/app/views/promo_registrations/_activate.html.slim
@@ -1,7 +1,7 @@
 .single-panel--wrapper.single-panel--wrapper--small.promo--panel.promo--panel-activate.text-center
-  h4.promo--subtitle = t("promo.activate.limited_time_offer")
-  .promo--title data-test="promo-activate"= t("promo.activate.title")
-  h4.promo--subtitle-alternative = t("promo.activate.for_referring_your_fans")
+  h4.promo--subtitle = t("promo.activate.sub_header_one")
+  .promo--title data-test="promo-activate"= t("promo.activate.header")
+  h4.promo--subtitle-alternative = t("promo.activate.sub_header_two")
   .promo--activate-body-container
     p.promo--body-text-alternative= t("promo.activate.description")
     #referral-reward = t("promo.activate.referral_reward")

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -49,9 +49,9 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
           .promo-panel
             - if current_publisher.promo_status(promo_running?) == :inactive
               .promo-panel-item.promo-panel-item-info
-                #promo-limited-time= t("promo.activate.limited_time_promo")
-                h3#promo-title= t("promo.activate.title")
-                #promo-referring-fans= t("promo.activate.for_referring_your_fans")
+                #promo-limited-time= t("promo.activate.sub_header_one")
+                h3#promo-header= t("promo.activate.header")
+                #promo-referring-fans= t("promo.activate.sub_header_two")
               .promo-panel-item.promo-panel-item-button
                 = form_for current_publisher, { method: :get, url: promo_registrations_path } do |f|
                   = f.submit(t("promo.activate.button-dashboard").upcase, class: "btn btn-primary", id: "activate-promo-dashboard-button" )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,15 +490,14 @@ en:
   promo:
     publisher_not_found: "No publisher found for this promo, please contact support+publishers@basicattentiontoken.org."
     activate:
-      title: "Free Tokens"
+      header: "Refer Your Fans"
       limited_time_offer: "Limited Time Offer"
-      limited_time_promo: "Limited Time Promo"
-      free_tokens: "Free Tokens"
-      for_referring_your_fans: "for Referring Your Fans!"
+      sub_header_one: "Referral Promo"
+      sub_header_two: "and Earn Tokens"      
       description: "Bring your fans to the Brave browser and grow your revenue!"
       referral_reward: "1 referral = about 5 USD in tokens"
       button: "Activate Promo"
-      button-dashboard: "Learn More"
+      button-dashboard: "Get Started"
     activated:
       title: "Congrats!"
       subtitle: "Your promo is activated."


### PR DESCRIPTION
Resolves #1215 

Remove references to 'limited time promo' and update button colors and text.  I did not update the polygon image in the background, but can figure that out if we believe it's important or high priority.

Dashboard promo panel:
![image](https://user-images.githubusercontent.com/12549658/48073078-f15f1e00-e1ab-11e8-8ba9-7ba10fcb1e33.png)

Activate promo screen:
![image](https://user-images.githubusercontent.com/12549658/48073127-0a67cf00-e1ac-11e8-8309-fe587d5eaf3a.png)



Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
