### PR TITLE
Save referral stats for channel owned codes to the promo registrations table

### DIFF
--- a/app/controllers/admin/unattached_promo_registrations_controller.rb
+++ b/app/controllers/admin/unattached_promo_registrations_controller.rb
@@ -5,9 +5,9 @@ class Admin::UnattachedPromoRegistrationsController < AdminController
     filter = params[:filter]
     case filter
     when "All codes", nil, ""
-      @promo_registrations = PromoRegistration.unattached.order("created_at DESC")
+      @promo_registrations = PromoRegistration.unattached_only.order("created_at DESC")
     when "Not assigned"
-      @promo_registrations = PromoRegistration.unattached.where(promo_campaign_id: nil).order("created_at DESC")
+      @promo_registrations = PromoRegistration.unattached_only.where(promo_campaign_id: nil).order("created_at DESC")
     else
       @promo_registrations = PromoRegistration.joins(:promo_campaign).
                                                unattached.

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -365,7 +365,7 @@ class PublishersController < ApplicationController
   # Domain verified. See balance and submit payment info.
   def home
     if current_publisher.promo_stats_status == :update
-      SyncPublisherPromoStatsJob.perform_later(publisher_id: current_publisher.id)
+      Sync::PublisherPromoStatsJob.perform_later(publisher_id: current_publisher.id)
     end
     # ensure the wallet has been fetched, which will check if Uphold needs to be re-authorized
     # ToDo: rework this process?

--- a/app/jobs/sync/channel_promo_registrations_stats_job.rb
+++ b/app/jobs/sync/channel_promo_registrations_stats_job.rb
@@ -1,5 +1,5 @@
 # Fetches and saves the referral stats for channel owned codes
-class SyncChannelPromoRegistrationsStatsJob < ApplicationJob
+class Sync::ChannelPromoRegistrationsStatsJob < ApplicationJob
   include PromosHelper
   queue_as :scheduler
 

--- a/app/jobs/sync/channel_stats_job.rb
+++ b/app/jobs/sync/channel_stats_job.rb
@@ -1,5 +1,5 @@
 # Syncs the stats for all channels once a day
-class SyncChannelStatsJob < ApplicationJob
+class Sync::ChannelStatsJob < ApplicationJob
   queue_as :low
 
   def perform

--- a/app/jobs/sync/publisher_promo_stats_job.rb
+++ b/app/jobs/sync/publisher_promo_stats_job.rb
@@ -1,5 +1,5 @@
 # Syncs promo enabled publishers referral statisitics every 10 minutes
-class SyncPublisherPromoStatsJob < ApplicationJob
+class Sync::PublisherPromoStatsJob < ApplicationJob
   include PromosHelper
   queue_as :transactional
 

--- a/app/jobs/sync/unattached_promo_registrations_stats_job.rb
+++ b/app/jobs/sync/unattached_promo_registrations_stats_job.rb
@@ -1,5 +1,5 @@
 # Fetches and saves the referral stats for unattached codes
-class SyncUnattachedPromoRegistrationsStatsJob < ApplicationJob
+class Sync::UnattachedPromoRegistrationsStatsJob < ApplicationJob
   include PromosHelper
   queue_as :low
 

--- a/app/jobs/sync_channel_promo_registrations_stats_job.rb
+++ b/app/jobs/sync_channel_promo_registrations_stats_job.rb
@@ -1,0 +1,10 @@
+# Fetches and saves the referral stats for channel owned codes
+class SyncChannelPromoRegistrationsStatsJob < ApplicationJob
+  include PromosHelper
+  queue_as :scheduler
+
+  def perform(promo_id: active_promo_id)
+    promo_registrations = PromoRegistration.channel
+    success = PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
+  end
+end

--- a/app/jobs/sync_channel_promo_registrations_stats_job.rb
+++ b/app/jobs/sync_channel_promo_registrations_stats_job.rb
@@ -3,8 +3,8 @@ class SyncChannelPromoRegistrationsStatsJob < ApplicationJob
   include PromosHelper
   queue_as :scheduler
 
-  def perform(promo_id: active_promo_id)
+  def perform
     promo_registrations = PromoRegistration.channel
-    success = PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
+    PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
   end
 end

--- a/app/jobs/sync_channel_promo_registrations_stats_job.rb
+++ b/app/jobs/sync_channel_promo_registrations_stats_job.rb
@@ -4,7 +4,7 @@ class SyncChannelPromoRegistrationsStatsJob < ApplicationJob
   queue_as :scheduler
 
   def perform
-    promo_registrations = PromoRegistration.channel
+    promo_registrations = PromoRegistration.channels_only
     PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
   end
 end

--- a/app/jobs/sync_unattached_promo_registrations_stats_job.rb
+++ b/app/jobs/sync_unattached_promo_registrations_stats_job.rb
@@ -1,11 +1,11 @@
-# Fetches and saves the referral stats for admins
-class SyncAdminPromoStatsJob < ApplicationJob
+# Fetches and saves the referral stats for unattached codes
+class SyncUnattachedPromoRegistrationsStatsJob < ApplicationJob
   include PromosHelper
   queue_as :low
 
   def perform(promo_id: active_promo_id)
     promo_registrations = PromoRegistration.unattached
-    success = AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+    success = PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
 
     if success
       Rails.cache.write("unattached_promo_registration_stats_last_synced_at", Time.now)

--- a/app/jobs/sync_unattached_promo_registrations_stats_job.rb
+++ b/app/jobs/sync_unattached_promo_registrations_stats_job.rb
@@ -3,7 +3,7 @@ class SyncUnattachedPromoRegistrationsStatsJob < ApplicationJob
   include PromosHelper
   queue_as :low
 
-  def perform(promo_id: active_promo_id)
+  def perform
     promo_registrations = PromoRegistration.unattached_only
     success = PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
 

--- a/app/jobs/sync_unattached_promo_registrations_stats_job.rb
+++ b/app/jobs/sync_unattached_promo_registrations_stats_job.rb
@@ -4,7 +4,7 @@ class SyncUnattachedPromoRegistrationsStatsJob < ApplicationJob
   queue_as :low
 
   def perform(promo_id: active_promo_id)
-    promo_registrations = PromoRegistration.unattached
+    promo_registrations = PromoRegistration.unattached_only
     success = PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
 
     if success

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -29,8 +29,8 @@ class PromoRegistration < ApplicationRecord
   validates :kind, inclusion: { in: KINDS, message: "%{value} is not a valid kind of promo registration." }
   validates :referral_code, presence: true, uniqueness: { scope: :promo_id }
 
-  scope :unattached, -> { where(kind: UNATTACHED) }
-  scope :channel, -> { where(kind: CHANNEL) }
+  scope :unattached_only, -> { where(kind: UNATTACHED) }
+  scope :channels_only, -> { where(kind: CHANNEL) }
 
   def aggregate_stats
     JSON.parse(stats).reduce({RETRIEVALS => 0,

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -30,6 +30,7 @@ class PromoRegistration < ApplicationRecord
   validates :referral_code, presence: true, uniqueness: { scope: :promo_id }
 
   scope :unattached, -> { where(kind: UNATTACHED) }
+  scope :channel, -> { where(kind: CHANNEL) }
 
   def aggregate_stats
     JSON.parse(stats).reduce({RETRIEVALS => 0,

--- a/app/services/promo_registrations_stats_fetcher.rb
+++ b/app/services/promo_registrations_stats_fetcher.rb
@@ -1,5 +1,5 @@
 # Fetches and updates the stats for unattached codes
-class AdminPromoStatsFetcher < BaseApiClient
+class PromoRegistrationsStatsFetcher < BaseApiClient
   include PromosHelper
 
   def initialize(promo_registrations:)

--- a/app/services/promo_registrations_stats_fetcher.rb
+++ b/app/services/promo_registrations_stats_fetcher.rb
@@ -1,4 +1,4 @@
-# Fetches and updates the stats for unattached codes
+# Fetches and updates the stats for all types of referral codes
 class PromoRegistrationsStatsFetcher < BaseApiClient
   include PromosHelper
 

--- a/app/services/promo_report_generator.rb
+++ b/app/services/promo_report_generator.rb
@@ -12,7 +12,7 @@ class PromoReportGenerator < BaseService
   def perform
     # Fetch the most recent stats
     promo_registrations = PromoRegistration.where(referral_code: @referral_codes)
-    AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+    PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
     promo_registrations.reload
 
     # Build the report contents

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,6 +27,10 @@
     cron: "15 3 * * *"
     description: "For Publishers who have enabled a promo, sync their referral stats with the promo server once a day."
     queue: scheduler
+  SyncChannelPromoRegistrationsStatsJob:
+    cron: "15 3 * * *"
+    description: "Sync stats for channel owned referral codes with the promo server once a day."
+    queue: scheduler
   SyncUnattachedPromoRegistrationsStatsJob:
     cron: "0 */12 * * *"
     description: "Syncs referral stats for unattached codes every 12 hours."

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,7 +27,7 @@
     cron: "15 3 * * *"
     description: "For Publishers who have enabled a promo, sync their referral stats with the promo server once a day."
     queue: scheduler
-  SyncAdminPromoStatsJob:
+  SyncUnattachedPromoRegistrationsStatsJob:
     cron: "0 */12 * * *"
     description: "Syncs referral stats for unattached codes every 12 hours."
     queue: low

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -23,19 +23,19 @@
   TransferChannelsJob:
     cron: "0 8 * * *"
     description: "Complete transfer of channels that have exceeded their timeout time without being rejected"
-  SyncPublisherPromoStatsJob:
+  Sync::PublisherPromoStatsJob:
     cron: "15 3 * * *"
     description: "For Publishers who have enabled a promo, sync their referral stats with the promo server once a day."
     queue: scheduler
-  SyncChannelPromoRegistrationsStatsJob:
+  Sync::ChannelPromoRegistrationsStatsJob:
     cron: "15 3 * * *"
     description: "Sync stats for channel owned referral codes with the promo server once a day."
     queue: scheduler
-  SyncUnattachedPromoRegistrationsStatsJob:
+  Sync::UnattachedPromoRegistrationsStatsJob:
     cron: "0 */12 * * *"
     description: "Syncs referral stats for unattached codes every 12 hours."
     queue: low
-  SyncChannelStatsJob:
+  Sync::ChannelStatsJob:
     cron: "0 1 * * *"
     description: "Syncs the channel stats via youtube and twitch apis"
     queue: low

--- a/test/jobs/sync/publisher_promo_stats_job_test.rb
+++ b/test/jobs/sync/publisher_promo_stats_job_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SyncPublisherPromoStatsJobTest < ActionDispatch::IntegrationTest
+class Sync::PublisherPromoStatsJobTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
   include ActiveJob::TestHelper
   
@@ -11,7 +11,7 @@ class SyncPublisherPromoStatsJobTest < ActionDispatch::IntegrationTest
     enable_promo_for_publisher(publisher_one)
     enable_promo_for_publisher(publisher_two)
 
-    SyncPublisherPromoStatsJob.perform_now
+    Sync::PublisherPromoStatsJob.perform_now
 
     publisher_one.reload
     publisher_two.reload
@@ -27,7 +27,7 @@ class SyncPublisherPromoStatsJobTest < ActionDispatch::IntegrationTest
     enable_promo_for_publisher(publisher_one)
     enable_promo_for_publisher(publisher_two)
 
-    SyncPublisherPromoStatsJob.perform_now(publisher_id: publisher_one.id)
+    Sync::PublisherPromoStatsJob.perform_now(publisher_id: publisher_one.id)
 
     publisher_one.reload
     publisher_two.reload

--- a/test/models/promo_registration_test.rb
+++ b/test/models/promo_registration_test.rb
@@ -133,8 +133,8 @@ class PromoRegistrationTest < ActiveSupport::TestCase
     channel = channels(:verified)
     PromoRegistration.create!(referral_code: "DEF456", promo_id: PROMO_ID, kind: "channel", channel: channel)
 
-    assert_equal PromoRegistration.unattached.count, 1
-    assert_equal PromoRegistration.unattached.first, promo_registration
+    assert_equal PromoRegistration.unattached_only.count, 1
+    assert_equal PromoRegistration.unattached_only.first, promo_registration
   end
 
   test "channel scope reutrns only channel owned promo registrations" do
@@ -142,7 +142,7 @@ class PromoRegistrationTest < ActiveSupport::TestCase
     promo_registration = PromoRegistration.create!(referral_code: "DEF456", promo_id: PROMO_ID, kind: "channel", channel: channel)
     PromoRegistration.create!(referral_code: "ABC123", promo_id: PROMO_ID, kind: "unattached")
 
-    assert_equal PromoRegistration.channel.count, 1
-    assert_equal PromoRegistration.channel.first, promo_registration
+    assert_equal PromoRegistration.channels_only.count, 1
+    assert_equal PromoRegistration.channels_only.first, promo_registration
   end
 end

--- a/test/models/promo_registration_test.rb
+++ b/test/models/promo_registration_test.rb
@@ -136,4 +136,13 @@ class PromoRegistrationTest < ActiveSupport::TestCase
     assert_equal PromoRegistration.unattached.count, 1
     assert_equal PromoRegistration.unattached.first, promo_registration
   end
+
+  test "channel scope reutrns only channel owned promo registrations" do
+    channel = channels(:verified)
+    promo_registration = PromoRegistration.create!(referral_code: "DEF456", promo_id: PROMO_ID, kind: "channel", channel: channel)
+    PromoRegistration.create!(referral_code: "ABC123", promo_id: PROMO_ID, kind: "unattached")
+
+    assert_equal PromoRegistration.channel.count, 1
+    assert_equal PromoRegistration.channel.first, promo_registration
+  end
 end

--- a/test/services/promo_registrations_stats_fetcher_test.rb
+++ b/test/services/promo_registrations_stats_fetcher_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "webmock/minitest"
 
-class AdminPromoStatsFetcherTest < ActiveJob::TestCase
+class PromoRegistrationsStatsFetcherTest < ActiveJob::TestCase
   include PromosHelper
 
   before(:example) do
@@ -43,7 +43,7 @@ class AdminPromoStatsFetcherTest < ActiveJob::TestCase
       .to_return(status: 200, body: stubbed_response_body)
 
     promo_registrations = PromoRegistration.where(referral_code: ["ABC123", "DEF456"])
-    AdminPromoStatsFetcher.new(promo_registrations: promo_registrations).perform
+    PromoRegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
 
     assert_equal 2, PromoRegistration.find_by_referral_code("ABC123").aggregate_stats[PromoRegistration::FIRST_RUNS]
     assert_equal 1, PromoRegistration.find_by_referral_code("DEF456").aggregate_stats[PromoRegistration::FIRST_RUNS]


### PR DESCRIPTION
Implements the first stage of #1337.

This PR adds a background job to save all channel referral stats to the promo registrations table.  Previously stats were saved to the publisher.  This does not change from which table the referral stats are sourced to display to the user, they will still be sourced from the `promo_stats_2018q1` column in the publishers table.  But when we do switch to the stats column in the promo_registrations table, this will ensure that the data will already be there.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:
Resolves 

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
