### PR TITLE
Partner Role

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -204,7 +204,7 @@ class PublishersController < ApplicationController
   end
 
   def protect
-    return redirect_to admin_publishers_path unless current_publisher.publisher?
+    return redirect_to admin_publishers_path unless current_publisher.publisher? || current_publisher.partner?
   end
 
   # Records default currency preference

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,7 +2,7 @@ class Ability
   include CanCan::Ability
   include PublishersHelper
 
-  ROLES = %i(admin publisher)
+  ROLES = %i(admin partner publisher)
   if Rails.application.secrets[:admin_ip_whitelist]
     ADMIN_IP_WHITELIST = Rails.application.secrets[:admin_ip_whitelist].split(",").map { |ip_cidr| IPAddr.new(ip_cidr) }.freeze
   else
@@ -28,6 +28,10 @@ class Ability
   end
 
   def publisher
+    base_role
+  end
+
+  def partner
     base_role
   end
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -6,8 +6,9 @@ class Publisher < ApplicationRecord
   UPHOLD_ACCESS_PARAMS_TIMEOUT = 2.hours
   PROMO_STATS_UPDATE_DELAY = 10.minutes
   ADMIN = "admin"
+  PARTNER = "partner"
   PUBLISHER = "publisher"
-  ROLES = [ADMIN, PUBLISHER]
+  ROLES = [ADMIN, PARTNER, PUBLISHER]
   JAVASCRIPT_DETECTED_RELEASE_TIME = "2018-06-19 22:51:51".freeze
 
   OWNER_PREFIX = "publishers#uuid:"
@@ -71,6 +72,7 @@ class Publisher < ApplicationRecord
 
   scope :email_verified, -> { where.not(email: nil) }
   scope :not_admin, -> { where.not(role: ADMIN) }
+  scope :not_partner, -> { where.not(role: PARTNER) }
   scope :suspended, -> {
     joins(:status_updates)
     .where('publisher_status_updates.created_at =
@@ -242,6 +244,10 @@ class Publisher < ApplicationRecord
 
   def admin?
     role == ADMIN
+  end
+
+  def partner?
+    role == PARTNER
   end
 
   def publisher?


### PR DESCRIPTION
Basis for the forthcoming `Partner` role as mentioned in @mandar-brave's v1.1 

Using the console `Publisher` can be set to `Partner` like so:

```ruby
record.role = "partner"
record.save
```

`partner` will not have access to admin privileges.

Closes #1327 