### PR TITLE
Allow publishers to own referral codes, do not display publisher#promo_stats_2018q1

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -364,9 +364,6 @@ class PublishersController < ApplicationController
 
   # Domain verified. See balance and submit payment info.
   def home
-    if current_publisher.promo_stats_status == :update
-      Sync::PublisherPromoStatsJob.perform_later(publisher_id: current_publisher.id)
-    end
     # ensure the wallet has been fetched, which will check if Uphold needs to be re-authorized
     # ToDo: rework this process?
     @wallet = current_publisher.wallet

--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -20,26 +20,13 @@ module PromosHelper
     {"times"=>[Time.now.to_s], "series"=>{"name"=>"downloads", "values"=>[rand(0..1000)]}, "aggregate"=> {"downloads"=> 200, "finalized"=> 30}}
   end
 
-  def total_referral_downloads(publisher)
-    stats = publisher.promo_stats_2018q1
-    if publisher.promo_stats_2018q1.blank?
-      return 0
-    elsif stats["aggregate"]["downloads"].nil?
-      return 0
-    else
-      return stats["aggregate"]["downloads"]
-    end
-  end
+  def publisher_referral_totals(publisher)
+    aggregate_stats = PromoRegistration.aggregate_stats(publisher.promo_registrations)
 
-  def confirmed_referral_downloads(publisher)
-    stats = publisher.promo_stats_2018q1
-    if publisher.promo_stats_2018q1.blank?
-      return 0
-    elsif stats["aggregate"]["finalized"].nil?
-      return 0
-    else
-      return stats["aggregate"]["finalized"]
-    end
+    {
+      PromoRegistration::RETRIEVALS => aggregate_stats[PromoRegistration::RETRIEVALS],
+      PromoRegistration::FINALIZED => aggregate_stats[PromoRegistration::FINALIZED]
+    }
   end
 
   def referral_url(referral_code)

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -4,17 +4,17 @@ class PromoRegistration < ApplicationRecord
   # A promo registration can belong to a channel,
   # a publisher, or be unattached.  Unattached codes
   # are created by admins.
-
-  # Constants
   CHANNEL = "channel".freeze
   OWNER = "owner".freeze
   UNATTACHED ="unattached".freeze
   KINDS = [CHANNEL, OWNER, UNATTACHED].freeze
 
+  # Event types
   RETRIEVALS = "retrievals" # Aliased as 'Downloads'
   FIRST_RUNS = "first_runs" # Aliased as 'Installs'
   FINALIZED = "finalized" # Aliased as 'Confirmed'
 
+  # Reporting intervals
   DAILY = "daily"
   WEEKLY = "weekly"
   MONTHLY = "monthly"
@@ -22,8 +22,11 @@ class PromoRegistration < ApplicationRecord
   
   belongs_to :channel, validate: true, autosave: true
   belongs_to :promo_campaign
+  belongs_to :publisher, dependent: :destroy
 
-  validates :channel_id, presence: true, if: -> { kind == CHANNEL}
+  validates :channel_id, presence: true, if: -> { kind == CHANNEL }
+  validates :publisher_id, presence: true, if: -> { kind != UNATTACHED }
+  
   validates :promo_id, presence: true
   validates :kind, presence: true
   validates :kind, inclusion: { in: KINDS, message: "%{value} is not a valid kind of promo registration." }
@@ -32,6 +35,8 @@ class PromoRegistration < ApplicationRecord
   scope :unattached_only, -> { where(kind: UNATTACHED) }
   scope :channels_only, -> { where(kind: CHANNEL) }
 
+  # Parses the events associated with a promo registration and returns
+  # the aggregate totals for each event type
   def aggregate_stats
     JSON.parse(stats).reduce({RETRIEVALS => 0,
                               FIRST_RUNS => 0,
@@ -41,5 +46,21 @@ class PromoRegistration < ApplicationRecord
       aggregate_stats[FINALIZED] += event[FINALIZED]
       aggregate_stats.slice(RETRIEVALS, FIRST_RUNS, FINALIZED)
     }
+  end
+
+  class << self
+    # Returns the aggregate totals for each event type given a
+    # ActiveRecord::Association of PromoRegistrations
+    def aggregate_stats(promo_registrations)
+      promo_registrations.reduce({RETRIEVALS => 0,
+                                  FIRST_RUNS => 0,
+                                  FINALIZED => 0}) { |aggregate_stats, promo_registration|
+        promo_registration_aggregate_stats = promo_registration.aggregate_stats
+        aggregate_stats[RETRIEVALS] += promo_registration_aggregate_stats[RETRIEVALS]
+        aggregate_stats[FIRST_RUNS] += promo_registration_aggregate_stats[FIRST_RUNS]
+        aggregate_stats[FINALIZED] += promo_registration_aggregate_stats[FINALIZED]
+        aggregate_stats
+      }
+    end
   end
 end

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -25,7 +25,7 @@ class PromoRegistration < ApplicationRecord
   belongs_to :publisher, dependent: :destroy
 
   validates :channel_id, presence: true, if: -> { kind == CHANNEL }
-  validates :publisher_id, presence: true, if: -> { kind != UNATTACHED }
+  validates :publisher_id, presence: true, unless: -> { kind == UNATTACHED }
   
   validates :promo_id, presence: true
   validates :kind, presence: true

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -19,6 +19,7 @@ class Publisher < ApplicationRecord
   has_many :login_activities
 
   has_many :channels, validate: true, autosave: true
+  has_many :promo_registrations, dependent: :destroy
   has_one :site_banner
   has_many :site_channel_details, through: :channels, source: :details, source_type: 'SiteChannelDetails'
   has_many :youtube_channel_details, through: :channels, source: :details, source_type: 'YoutubeChannelDetails'

--- a/app/services/promo_registrar.rb
+++ b/app/services/promo_registrar.rb
@@ -17,7 +17,7 @@ class PromoRegistrar < BaseApiClient
         if referral_code.present?
           promo_registration = PromoRegistration.new(channel_id: channel.id,
                                                      promo_id: @promo_id,
-                                                     kind: "channel",
+                                                     kind: PromoRegistration::CHANNEL,
                                                      publisher_id: @publisher.id,
                                                      referral_code: referral_code)
           success = promo_registration.save!

--- a/app/services/promo_registrar.rb
+++ b/app/services/promo_registrar.rb
@@ -15,7 +15,11 @@ class PromoRegistrar < BaseApiClient
         referral_code = result[:referral_code]
         should_update_promo_server = result[:should_update_promo_server]
         if referral_code.present?
-          promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: @promo_id, kind: "channel", referral_code: referral_code)
+          promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                                     promo_id: @promo_id,
+                                                     kind: "channel",
+                                                     publisher_id: @publisher.id,
+                                                     referral_code: referral_code)
           success = promo_registration.save!
           if success && should_update_promo_server
             PromoChannelOwnerUpdater.new(publisher_id: @publisher.id, referral_code: referral_code).perform

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -56,6 +56,7 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
                 = form_for current_publisher, { method: :get, url: promo_registrations_path } do |f|
                   = f.submit(t("promo.activate.button-dashboard").upcase, class: "btn btn-primary", id: "activate-promo-dashboard-button" )
             - elsif current_publisher.has_verified_channel?
+              - publisher_referral_totals = publisher_referral_totals(current_publisher)
               .promo-flex-col
                 .promo-flex-row.promo-flex-row-main
                   .promo-flex-col.promo-panel-title
@@ -67,12 +68,12 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
                     .promo-panel-header
                       =t("promo.dashboard.downloaded").upcase
                     .promo-panel-number
-                      = total_referral_downloads(current_publisher)
+                      = publisher_referral_totals[PromoRegistration::RETRIEVALS]
                   .promo-flex-col.promo-flex-col-confirmed
                     .promo-panel-header
                       =t("promo.dashboard.confirmed").upcase
                     .promo-panel-number
-                      = confirmed_referral_downloads(current_publisher)
+                      = publisher_referral_totals[PromoRegistration::FINALIZED]
                 .promo-flex-row.promo-flex-row-sub
                   =t("promo.dashboard.check_statement")
             - else

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -28,8 +28,8 @@
     description: "For Publishers who have enabled a promo, sync their referral stats with the promo server once a day."
     queue: scheduler
   Sync::ChannelPromoRegistrationsStatsJob:
-    cron: "15 3 * * *"
-    description: "Sync stats for channel owned referral codes with the promo server once a day."
+    cron: "0 */8 * * *"
+    description: "Sync stats for channel owned referral codes with the promo server every 8 hours."
     queue: scheduler
   Sync::UnattachedPromoRegistrationsStatsJob:
     cron: "0 */12 * * *"

--- a/db/migrate/20181115160802_add_publisher_to_promo_registration.rb
+++ b/db/migrate/20181115160802_add_publisher_to_promo_registration.rb
@@ -1,0 +1,5 @@
+class AddPublisherToPromoRegistration < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :promo_registrations, :publisher, type: :uuid, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20181115160802_add_publisher_to_promo_registration.rb
+++ b/db/migrate/20181115160802_add_publisher_to_promo_registration.rb
@@ -1,5 +1,5 @@
 class AddPublisherToPromoRegistration < ActiveRecord::Migration[5.2]
   def change
-    add_reference :promo_registrations, :publisher, type: :uuid, index: true, foreign_key: true
+    add_reference :promo_registrations, :publisher, type: :uuid, index: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_16_134245) do
+ActiveRecord::Schema.define(version: 2018_11_15_160802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -210,9 +210,11 @@ ActiveRecord::Schema.define(version: 2018_10_16_134245) do
     t.jsonb "stats", default: "{}"
     t.uuid "promo_campaign_id"
     t.boolean "active", default: true, null: false
+    t.uuid "publisher_id"
     t.index ["channel_id"], name: "index_promo_registrations_on_channel_id"
     t.index ["promo_campaign_id"], name: "index_promo_registrations_on_promo_campaign_id"
     t.index ["promo_id", "referral_code"], name: "index_promo_registrations_on_promo_id_and_referral_code", unique: true
+    t.index ["publisher_id"], name: "index_promo_registrations_on_publisher_id"
   end
 
   create_table "publisher_notes", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -386,5 +388,6 @@ ActiveRecord::Schema.define(version: 2018_10_16_134245) do
   end
 
   add_foreign_key "channels", "channels", column: "contested_by_channel_id"
+  add_foreign_key "promo_registrations", "publishers"
   add_foreign_key "publisher_notes", "publishers", column: "created_by_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -388,6 +388,5 @@ ActiveRecord::Schema.define(version: 2018_11_15_160802) do
   end
 
   add_foreign_key "channels", "channels", column: "contested_by_channel_id"
-  add_foreign_key "promo_registrations", "publishers"
   add_foreign_key "publisher_notes", "publishers", column: "created_by_id"
 end

--- a/lib/tasks/database_updates/add_publisher_id_to_existing_channel_promo_registrations.rake
+++ b/lib/tasks/database_updates/add_publisher_id_to_existing_channel_promo_registrations.rake
@@ -1,0 +1,8 @@
+namespace :database_updates do
+  task add_publisher_id_to_existing_channel_promo_registrations: [:environment] do
+    PromoRegistration.channel_owned.find_each do |promo_registration|
+      promo_registration.update(publisher_id: promo_registration.channel.publisher.id)
+      print "."
+    end
+  end
+end

--- a/lib/tasks/database_updates/set_default_promo_registration_kind.rake
+++ b/lib/tasks/database_updates/set_default_promo_registration_kind.rake
@@ -1,5 +1,5 @@
 namespace :database_updates do
-  task :set_default_promo_registration_kind => [:environment] do
+  task set_default_promo_registration_kind: [:environment] do
     registrations = PromoRegistration.where.not(channel_id: nil).where(kind: nil)
     registrations.update_all!(kind: "channel")
   end

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -227,3 +227,13 @@ locked_out_site:
   publisher: locked_out_verifier
   details: locked_out_site_details (SiteChannelDetails)
   verified: false
+
+promo_enabled_site:
+  publisher: promo_enabled
+  details: promo_enabled_site_details (SiteChannelDetails)
+  verified: true
+
+promo_enabled_youtube:
+  publisher: promo_enable
+  details: promo_enabled_youtube_details (YoutubeChannelDetails)
+  verified: true

--- a/test/fixtures/promo_registrations.yml
+++ b/test/fixtures/promo_registrations.yml
@@ -1,0 +1,12 @@
+site_promo_registration:
+  kind: channel
+  promo_id: 1
+  referral_code: PRO123
+  channel: promo_enabled_site
+  publisher: promo_enabled
+youtube_promo_registration:
+  kind: channel
+  promo_id: 1
+  referral_code: PRO456
+  channel: promo_enabled_youtube
+  publisher: promo_enabled

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -240,3 +240,7 @@ locked_out_verifier:
   name: "Logan the locked out"
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+
+promo_enabled:
+  email: "enabled@promo.org"
+  name: "peter promo"

--- a/test/fixtures/site_channel_details.yml
+++ b/test/fixtures/site_channel_details.yml
@@ -136,3 +136,6 @@ fraudulently_verified_site_details:
 
 locked_out_site_details:
   brave_publisher_id: "contested.com"
+
+promo_enabled_site_details:
+  brave_publisher_id: "promotion.org"

--- a/test/fixtures/youtube_channel_details.yml
+++ b/test/fixtures/youtube_channel_details.yml
@@ -59,3 +59,11 @@ lockedout_yt1_details:
   youtube_channel_id: "lo12345"
   title: "My channel"
   thumbnail_url: "https://some_image_host.com/some_image.png"
+
+promo_enabled_youtube_details:
+  auth_user_id: "promo123456"
+  auth_email: "youtube_promo@pages.plusgoogle.com"
+  auth_provider: "google_oauth2"
+  youtube_channel_id: "promo123"
+  title: "Promo"
+  thumbnail_url: "https://some_image_host.com/some_image.png"

--- a/test/helpers/promos_helper_test.rb
+++ b/test/helpers/promos_helper_test.rb
@@ -1,26 +1,3 @@
 require 'test_helper'
 class PromosHelperTest < ActionView::TestCase
-  test "returns correct number of promo stats " do
-    publisher = publishers(:completed)
-    publisher.promo_stats_2018q1 = offline_promo_stats
-    publisher.save!
-
-    total_referral_downloads = total_referral_downloads(publisher)
-    assert_equal total_referral_downloads, 200
-    
-    confirmed_referral_downloads = confirmed_referral_downloads(publisher)
-    assert_equal confirmed_referral_downloads, 30
-  end
-
-  test "if aggregate downloads or finalized is nil, display 0" do
-    publisher = publishers(:completed)
-    publisher.promo_stats_2018q1 = {"times"=>[], "series"=>{"name"=>"downloads", "values"=>[]}, "aggregate"=>{"downloads"=>nil, "finalized"=>nil}}
-    publisher.save!
-
-    total_referral_downloads = total_referral_downloads(publisher)
-    assert_equal total_referral_downloads, 0
-    
-    confirmed_referral_downloads = confirmed_referral_downloads(publisher)
-    assert_equal confirmed_referral_downloads, 0
-  end
 end

--- a/test/mailers/promo_mailer_test.rb
+++ b/test/mailers/promo_mailer_test.rb
@@ -32,7 +32,11 @@ class PromoMailerTest < ActionMailer::TestCase
     channel = publisher.channels.first
 
     referral_code = "BATS-321"
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "free-bats-2018q1", kind: "channel", referral_code: referral_code)
+    promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                               promo_id: "free-bats-2018q1",
+                                               kind: "channel",
+                                               publisher_id: publisher.id,
+                                               referral_code: referral_code)
     promo_registration.save!
     promo_enabled_channels = publisher.channels.joins(:promo_registration)
 
@@ -69,7 +73,11 @@ class PromoMailerTest < ActionMailer::TestCase
     channel = publisher.channels.first
 
     referral_code = "BATS-321"
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "free-bats-2018q1", kind: "channel", referral_code: referral_code)
+    promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                               promo_id: "free-bats-2018q1",
+                                               kind: "channel",
+                                               publisher_id: publisher.id,
+                                               referral_code: referral_code)
     promo_registration.save!
 
     email = PromoMailer.new_channel_registered_2018q1(publisher, channel)

--- a/test/models/promo_registration_test.rb
+++ b/test/models/promo_registration_test.rb
@@ -12,31 +12,41 @@ class PromoRegistrationTest < ActiveSupport::TestCase
 
   test "promo registration must have be kind channel if channel_id is present" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                               publisher_id: channel.publisher.id,
+                                               promo_id: PROMO_ID,
+                                               referral_code: REFERRAL_CODE)
 
     # verify validation fails if no kind is present
     refute promo_registration.valid?
 
-    # verify validation passes is kind is set to channel
+    # verify validation passes if kind is set to channel
     promo_registration.kind = "channel"
     assert promo_registration.valid?
   end
 
   test "promo registration must have a channel_id if kind is channel" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(kind: "channel", promo_id: PROMO_ID, referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(kind: "channel",
+                                               publisher_id: channel.publisher.id,
+                                               promo_id: PROMO_ID,
+                                               referral_code: REFERRAL_CODE)
 
     # verify validation fails if no channel_id
     refute promo_registration.valid?
 
-    # verify validation passes is kind is set to channel
+    # verify validation passes if kind is set to channel
     promo_registration.channel_id = channel.id
     assert promo_registration.valid?
   end
 
   test "promo registration must have a promo id" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: "", kind: "channel", referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                               promo_id: "",
+                                               kind: "channel",
+                                               publisher_id: channel.publisher.id,
+                                               referral_code: REFERRAL_CODE)
 
     # verify validation fails if no associated promo_id
     assert !promo_registration.valid?
@@ -48,7 +58,11 @@ class PromoRegistrationTest < ActiveSupport::TestCase
 
   test "promo registration must have a referral code" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, kind: "channel", promo_id: PROMO_ID, referral_code: nil)
+    promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                               kind: "channel",
+                                               publisher_id: channel.publisher.id,
+                                               promo_id: PROMO_ID,
+                                               referral_code: nil)
 
     # verify validation fails is no associated referral code
     assert !promo_registration.valid?
@@ -61,11 +75,19 @@ class PromoRegistrationTest < ActiveSupport::TestCase
   test "promo registration must have a unique referral code " do
     channel_verified = channels(:verified)
     channel_completed = channels(:completed)
-    promo_registration = PromoRegistration.new(channel_id: channel_verified.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel_verified.id,
+                                               promo_id: PROMO_ID,
+                                               kind: "channel",
+                                               publisher_id: channel_verified.publisher.id,
+                                               referral_code: REFERRAL_CODE)
     promo_registration.save!
 
     # verify validation fails with non unique referall code
-    promo_registration_invalid = PromoRegistration.new(channel_id: channel_completed.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
+    promo_registration_invalid = PromoRegistration.new(channel_id: channel_completed.id,
+                                                       promo_id: PROMO_ID,
+                                                       kind: "channel",
+                                                       publisher_id: channel_completed.publisher.id,
+                                                       referral_code: REFERRAL_CODE)
     assert !promo_registration_invalid.valid?
 
     # verify validation passes with unique referral code
@@ -76,9 +98,17 @@ class PromoRegistrationTest < ActiveSupport::TestCase
   # This might be better suited for ChannelTest
   test "channel can only have one promo registration" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                               promo_id: PROMO_ID,
+                                               kind: "channel",
+                                               publisher_id: channel.publisher.id,
+                                               referral_code: REFERRAL_CODE)
     promo_registration.save!
-    promo_registration_invalid = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, kind: "channel", referral_code: "BATS-321")
+    promo_registration_invalid = PromoRegistration.new(channel_id: channel.id,
+                                                       promo_id: PROMO_ID,
+                                                       kind: "channel",
+                                                       publisher_id: channel.publisher.id,
+                                                       referral_code: "BATS-321")
     promo_registration.save!
 
     # verify channel has only the first promo detail
@@ -88,7 +118,11 @@ class PromoRegistrationTest < ActiveSupport::TestCase
 
   test "if promo registration deleted, associated channel shouldn't be deleted" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.new(channel_id: channel.id, promo_id: PROMO_ID, kind: "channel", referral_code: REFERRAL_CODE)
+    promo_registration = PromoRegistration.new(channel_id: channel.id,
+                                               promo_id: PROMO_ID,
+                                               kind: "channel",
+                                               publisher_id: channel.publisher.id,
+                                               referral_code: REFERRAL_CODE)
     promo_registration.save!
 
     assert_equal channel.promo_registration, promo_registration
@@ -131,18 +165,70 @@ class PromoRegistrationTest < ActiveSupport::TestCase
   test "unattached scope returns only unattached promo registrations" do
     promo_registration = PromoRegistration.create!(referral_code: "ABC123", promo_id: PROMO_ID, kind: "unattached")
     channel = channels(:verified)
-    PromoRegistration.create!(referral_code: "DEF456", promo_id: PROMO_ID, kind: "channel", channel: channel)
+    PromoRegistration.create!(referral_code: "DEF456",
+                              promo_id: PROMO_ID,
+                              kind: "channel",
+                              publisher_id: channel.publisher.id,
+                              channel: channel)
 
     assert_equal PromoRegistration.unattached_only.count, 1
     assert_equal PromoRegistration.unattached_only.first, promo_registration
   end
 
-  test "channel scope reutrns only channel owned promo registrations" do
+  test "channel scope returns only channel owned promo registrations" do
     channel = channels(:verified)
-    promo_registration = PromoRegistration.create!(referral_code: "DEF456", promo_id: PROMO_ID, kind: "channel", channel: channel)
+    assert_equal PromoRegistration.channels_only.count, 2
+    promo_registration = PromoRegistration.create!(referral_code: "DEF456",
+                                                   promo_id: PROMO_ID,
+                                                   kind: "channel",
+                                                   publisher_id: channel.publisher.id,
+                                                   channel: channel)
     PromoRegistration.create!(referral_code: "ABC123", promo_id: PROMO_ID, kind: "unattached")
 
-    assert_equal PromoRegistration.channels_only.count, 1
-    assert_equal PromoRegistration.channels_only.first, promo_registration
+    assert_equal PromoRegistration.channels_only.count, 3
+    assert_equal PromoRegistration.channels_only.order("created_at").last, promo_registration
+  end
+
+  test "aggregate_stats class method aggregates stats for all of a publishers's promo registrations" do
+
+    # Ensure promo registrations with default stats e.g. "{}" has correct format
+    publisher = publishers(:promo_enabled)
+    assert_equal PromoRegistration.aggregate_stats(publisher.promo_registrations), {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, PromoRegistration::FINALIZED => 0}
+
+    # Ensure promo registrations with empty stats e.g. "[]" has correct format
+    publisher.promo_registrations.first.update(stats: [].to_json)
+    assert_equal PromoRegistration.aggregate_stats(publisher.promo_registrations),
+                 {PromoRegistration::RETRIEVALS => 0, PromoRegistration::FIRST_RUNS => 0, PromoRegistration::FINALIZED => 0}
+
+    # Ensure promo registrations with stats present has correct format
+    publisher.promo_registrations.where(referral_code: "PRO123").first.update(stats: [{"referral_code"=>"PRO123",
+                                                                                   "ymd"=>"2018-10-24",
+                                                                                   "retrievals"=>1,
+                                                                                   "first_runs"=>1,
+                                                                                   "finalized"=>0},
+                                                                                {"referral_code"=>"PRO123",
+                                                                                   "ymd"=>"2018-10-24",
+                                                                                   "retrievals"=>1,
+                                                                                   "first_runs"=>1,
+                                                                                   "finalized"=>0}].to_json)
+
+    publisher.reload
+    assert_equal PromoRegistration.aggregate_stats(publisher.promo_registrations),
+                 {PromoRegistration::RETRIEVALS => 2, PromoRegistration::FIRST_RUNS => 2, PromoRegistration::FINALIZED => 0}
+
+    # Ensure we aggregate stats for multiple promo registrations
+    publisher.promo_registrations.where(referral_code: "PRO456").first.update(stats: [{"referral_code"=>"PRO456",
+                                                                                   "ymd"=>"2018-10-24",
+                                                                                   "retrievals"=>3,
+                                                                                   "first_runs"=>3,
+                                                                                   "finalized"=>2},
+                                                                                {"referral_code"=>"PRO456",
+                                                                                   "ymd"=>"2018-10-24",
+                                                                                   "retrievals"=>1,
+                                                                                   "first_runs"=>1,
+                                                                                   "finalized"=>1}].to_json)
+    publisher.reload
+    assert_equal PromoRegistration.aggregate_stats(publisher.promo_registrations),
+                 {PromoRegistration::RETRIEVALS => 6, PromoRegistration::FIRST_RUNS => 6, PromoRegistration::FINALIZED => 3}
   end
 end

--- a/test/services/promo_registrar_unattached_test.rb
+++ b/test/services/promo_registrar_unattached_test.rb
@@ -23,7 +23,7 @@ class PromoRegistrarUnattachedTest < ActiveJob::TestCase
     # verify one more promo registration was created
     assert_equal 1, (current_promo_registration_count - prev_promo_registration_count)
 
-    created_promo_registration = PromoRegistration.order("created_at").first
+    created_promo_registration = PromoRegistration.order("created_at").last
 
     # verify the new promo registration is created correctly
     assert_equal created_promo_registration.referral_code, "NDF915"


### PR DESCRIPTION
Part two of #1337.  Blocked until https://github.com/brave-intl/publishers/pull/1338 is in production for a couple days to propagate stats to PromoRegistration#stats.

This makes promo registrations polymorphic.  So a channel promo_registration now belongs to one channel and one publisher. A publisher has many promo registrations.

Now we can do things like `publisher.promo_registrations` to get all the promo registrations associated with the publisher. This allows us to easily sum the stats for all promo registrations belonging to a publisher and display them to the publisher.

Part 3 of #1337 will include removing `promo_stats_2018q1q1` from the publishers table and other clean up.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
