### PR TITLE
Report first runs as downloads

### DIFF
--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -24,7 +24,7 @@ module PromosHelper
     aggregate_stats = PromoRegistration.aggregate_stats(publisher.promo_registrations)
 
     {
-      PromoRegistration::RETRIEVALS => aggregate_stats[PromoRegistration::RETRIEVALS],
+      PromoRegistration::FIRST_RUNS => aggregate_stats[PromoRegistration::FIRST_RUNS],
       PromoRegistration::FINALIZED => aggregate_stats[PromoRegistration::FINALIZED]
     }
   end

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -68,7 +68,7 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
                     .promo-panel-header
                       =t("promo.dashboard.downloaded").upcase
                     .promo-panel-number
-                      = publisher_referral_totals[PromoRegistration::RETRIEVALS]
+                      = publisher_referral_totals[PromoRegistration::FIRST_RUNS]
                   .promo-flex-col.promo-flex-col-confirmed
                     .promo-panel-header
                       =t("promo.dashboard.confirmed").upcase

--- a/lib/tasks/database_updates/add_publisher_id_to_existing_channel_promo_registrations.rake
+++ b/lib/tasks/database_updates/add_publisher_id_to_existing_channel_promo_registrations.rake
@@ -1,6 +1,6 @@
 namespace :database_updates do
   task add_publisher_id_to_existing_channel_promo_registrations: [:environment] do
-    PromoRegistration.channel_owned.find_each do |promo_registration|
+    PromoRegistration.channels_only.find_each do |promo_registration|
       promo_registration.update(publisher_id: promo_registration.channel.publisher.id)
       print "."
     end


### PR DESCRIPTION
Up until the recent infinity codes referral refactor, Publishers did not have access to downloads, and referred to a download + an open as a download.

We may want to switch to reporting actual downloads (ie PromoRegistration::RETRIEVALS), but that will change every publisher dashboard.  For the time being let's keep it same and only report first runs as downloads.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
