### PR TITLE
Request referral code stats in batches of 1000

### DIFF
--- a/app/services/promo_registrations_stats_fetcher.rb
+++ b/app/services/promo_registrations_stats_fetcher.rb
@@ -10,20 +10,24 @@ class PromoRegistrationsStatsFetcher < BaseApiClient
 
   def perform
     return perform_offline if Rails.application.secrets[:api_promo_base_uri].blank?
-    response = connection.get do |request|
-      request.options.params_encoder = Faraday::FlatParamsEncoder
-      request.headers["Authorization"] = api_authorization_header
-      request.headers["Content-Type"] = "application/json"
-      request.url("/api/2/promo/statsByReferralCode#{query_string}")
-    end
-    referral_code_events_date_list = JSON.parse(response.body)
+    @referral_codes.each_slice(1000).to_a.each do |referral_code_batch|
+      query_string = query_string(referral_code_batch)
+      response = connection.get do |request|
+        request.options.params_encoder = Faraday::FlatParamsEncoder
+        request.headers["Authorization"] = api_authorization_header
+        request.headers["Content-Type"] = "application/json"
+        request.url("/api/2/promo/statsByReferralCode#{query_string}")
+      end
 
-    @referral_codes.each do |referral_code|
-      promo_registration = PromoRegistration.find_by_referral_code(referral_code)
-      promo_registration.stats = referral_code_events_date_list.select {|referral_code_event_date|
-        referral_code_event_date["referral_code"] == referral_code
-      }.to_json
-      promo_registration.save!
+      referral_code_events_by_date = JSON.parse(response.body)
+
+      referral_code_batch.each do |referral_code|
+        promo_registration = PromoRegistration.find_by_referral_code(referral_code)
+        promo_registration.stats = referral_code_events_by_date.select {|referral_code_event_date|
+          referral_code_event_date["referral_code"] == referral_code
+        }.to_json
+        promo_registration.save!
+      end
     end
   end
 
@@ -41,9 +45,9 @@ class PromoRegistrationsStatsFetcher < BaseApiClient
     "Bearer #{Rails.application.secrets[:api_promo_key]}"
   end
 
-  def query_string
+  def query_string(referral_codes)
     query_string = "?"
-    @referral_codes.each do |referral_code|
+    referral_codes.each do |referral_code|
       query_string = "#{query_string}referral_code=#{referral_code}&"
     end
     query_string.chomp("&") # Remove the final ampersand

--- a/test/services/promo_registrations_stats_fetcher_test.rb
+++ b/test/services/promo_registrations_stats_fetcher_test.rb
@@ -12,6 +12,15 @@ class PromoRegistrationsStatsFetcherTest < ActiveJob::TestCase
     Rails.application.secrets[:api_promo_base_uri] = @prev_promo_api_uri
   end
 
+  def query_string(referral_codes)
+    query_string = "?"
+    referral_codes.each do |referral_code|
+      query_string = "#{query_string}referral_code=#{referral_code}&"
+    end
+    query_string.chomp("&") # Remove the final ampersand
+  end
+
+
   test "saves the stats" do
     # ensure an external request is attempted to be stubbed by turning on promo
     Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
@@ -47,5 +56,64 @@ class PromoRegistrationsStatsFetcherTest < ActiveJob::TestCase
 
     assert_equal 2, PromoRegistration.find_by_referral_code("ABC123").aggregate_stats[PromoRegistration::FIRST_RUNS]
     assert_equal 1, PromoRegistration.find_by_referral_code("DEF456").aggregate_stats[PromoRegistration::FIRST_RUNS]
+  end
+
+  test "makes the request in batches if > 1000 codes" do
+    Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
+
+    number_of_codes_needed = 2000 - PromoRegistration.count
+
+    # Insert ~2000 referral codes
+    sql_values = ""
+    number_of_codes_needed.times do
+      sql_values += "('#{SecureRandom.hex(8)}', '#{active_promo_id}', '#{PromoRegistration::UNATTACHED}','#{Time.now}', '#{Time.now}'),"
+    end
+    sql_values = sql_values.chomp(",")
+
+    sql = "INSERT into promo_registrations (referral_code, promo_id, kind, created_at, updated_at) values #{sql_values}"
+    ActiveRecord::Base.connection.execute(sql)
+
+    assert_equal PromoRegistration.count, 2000
+
+    # stub response for first 1000
+    first_1000_ref_codes = PromoRegistration.all.map { |promo_registration| promo_registration.referral_code }.each_slice(1000).to_a.first
+    first_1000_ref_codes_query_string = query_string(first_1000_ref_codes)
+    first_1000_ref_codes_response = []
+    first_1000_ref_codes.each do |referral_code|
+      first_1000_ref_codes_response.push({"referral_code"=>"#{referral_code}",
+                                          "ymd"=>"2018-04-29",
+                                          "retrievals"=>1,
+                                          "first_runs"=>0,
+                                          "finalized"=>0})
+    end
+    first_1000_ref_codes_response = first_1000_ref_codes_response.to_json
+    request_url = "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/statsByReferralCode#{first_1000_ref_codes_query_string}"
+    stub_request(:get, request_url).to_return(status: 200, body: first_1000_ref_codes_response)
+
+    # stub response for second 1000
+    second_1000_ref_codes = PromoRegistration.all.map { |promo_registration| promo_registration.referral_code }.each_slice(1000).to_a.second
+    second_1000_ref_codes_query_string = query_string(second_1000_ref_codes)
+    second_1000_ref_codes_response = []
+    second_1000_ref_codes.each do |referral_code|
+      second_1000_ref_codes_response.push({"referral_code"=>"#{referral_code}",
+                                          "ymd"=>"2018-04-29",
+                                          "retrievals"=>3,
+                                          "first_runs"=>0,
+                                          "finalized"=>0})
+    end
+    second_1000_ref_codes_response = second_1000_ref_codes_response.to_json
+    request_url = "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/statsByReferralCode#{second_1000_ref_codes_query_string}"
+    stub_request(:get, request_url).to_return(status: 200, body: second_1000_ref_codes_response)
+
+    # ensure two requests were made
+    PromoRegistrationsStatsFetcher.new(promo_registrations: PromoRegistration.all).perform
+
+    first_1000_ref_codes.each do |referral_code|
+      assert_equal PromoRegistration.find_by_referral_code(referral_code).aggregate_stats[PromoRegistration::RETRIEVALS], 1
+    end
+
+    second_1000_ref_codes.each do |referral_code|
+      assert_equal PromoRegistration.find_by_referral_code(referral_code).aggregate_stats[PromoRegistration::RETRIEVALS], 3
+    end
   end
 end


### PR DESCRIPTION
**NOTE** This PR is directly against master.

We are unable to successfully request/save the stats from the promo server because the request URI is too long.  It's too long because each referral code is supplied as a query string parameter,  e.g.

```
GET /api/2/promo/statsByReferralCode?referral_code=PRO123&referral_code=PRO456
```

This PR updates the PromoRegistrationsStatsFetcher to make the request in batches of 1000, so each URI is ~31 kb.  According to [stack overflow](https://stackoverflow.com/questions/32763165/node-js-http-get-url-length-limitation) the limit is 80kb, so we should be well under.

This PR is directly against master since https://github.com/brave-intl/publishers/pull/1350 was merged in to staging.  Since that was merged in to staging, we can't merge `master <- staging` without changing the source of publisher stats from the publishers table to the promo registrations table.  We can't do that since the stats won't be there (since the uri was too long).

We could make this against staging, but there could be some downtime (I think maybe a few minutes) for referral stats.  I think in this case it makes sense to merge into master, then `master -> staging`, but am open to other approaches.

## Tests

The tests insert 2000 new referral codes in the test db with raw sql in order to make a single query instead of 2000 queries for performance.  Unfortunately, this test still takes ~10 seconds to complete because of the subsequent queries at the end of the test and in the PromoRegistrationsStatsFetcher.

I have a couple ideas for ways to speed it up further, but want to hear your thoughts.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
