### PR TITLE
Ensure publisher isn't nil when requesting new auth

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -266,9 +266,7 @@ class PublishersController < ApplicationController
     @should_throttle = should_throttle_create_auth_token?
     throttle_legit = @should_throttle ? verify_recaptcha(model: @publisher) : true
     if !throttle_legit
-      @publisher = Publisher.new
-      render(:new_auth_token)
-      return
+      return redirect_to :new_auth_token_publishers, alert: t(".access_throttled")
     end
 
     @publisher = Publisher.where(email: @publisher_email).take

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -266,6 +266,7 @@ class PublishersController < ApplicationController
     @should_throttle = should_throttle_create_auth_token?
     throttle_legit = @should_throttle ? verify_recaptcha(model: @publisher) : true
     if !throttle_legit
+      @publisher = Publisher.new
       render(:new_auth_token)
       return
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -360,6 +360,8 @@ en:
       invalid_email: There was an unexpected error creating your account. Please make sure you have provided a full email address.
       email_already_active: The email address you entered "%{email}" is an active account. We've emailed you a login link.
       access_throttled: You've attempted to sign up too many times and your access had been throttled. Try again later.
+    create_auth_token:
+      access_throttled: You've attempted to sign in too many times and your access had been throttled. Try again later.
     emailed_auth_token:
       missing_email: We seem to be missing some info. Please make sure you provided an email address.
       unfound_alert_html: |
@@ -493,7 +495,7 @@ en:
       header: "Refer Your Fans"
       limited_time_offer: "Limited Time Offer"
       sub_header_one: "Referral Promo"
-      sub_header_two: "and Earn Tokens"      
+      sub_header_two: "and Earn Tokens"
       description: "Bring your fans to the Brave browser and grow your revenue!"
       referral_reward: "1 referral = about 5 USD in tokens"
       button: "Activate Promo"


### PR DESCRIPTION
Our form was raising a 500 in production when the `@publisher` was nil.