### PR TITLE
Add 'new' badge to Tipping Banner button

### DIFF
--- a/app/assets/stylesheets/pages/banner-intro.scss
+++ b/app/assets/stylesheets/pages/banner-intro.scss
@@ -1,4 +1,4 @@
-#instant-donation-modal-selection {
+#tipping-banner-modal-selection {
   padding: 10px 30px 10px 30px;
 }
 

--- a/app/assets/stylesheets/pages/home.scss
+++ b/app/assets/stylesheets/pages/home.scss
@@ -11,6 +11,23 @@
   margin-bottom: 30px;
 }
 
+.new-badge {
+  display: inline-block;
+  height: 17px;
+  width: 35px;
+  vertical-align: text-top;
+  margin-left: -40px;
+  margin-right: 20px;
+  background-color: #fb542b;
+  border-radius: 4px;
+  font-size: 10px;
+  padding-top: 2px;
+  font-family: poppins;
+  font-weight: bold;
+  text-align: center;
+  color: white;
+}
+
 .brave-rewards-banner {
   &--background {
     &-label {

--- a/app/javascript/packs/banner_preview.jsx
+++ b/app/javascript/packs/banner_preview.jsx
@@ -53,7 +53,7 @@ export default class BannerPreview extends React.Component {
   }
 
   handleClose(){
-    let instantDonationButton = document.getElementById("instant-donation-button");
+    let instantDonationButton = document.getElementById("tipping-banner-button");
     instantDonationButton.click();
     renderBannerEditor(this.props.preferredCurrency, this.props.conversionRate, "Editor");
     setTimeout(function(){

--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -382,7 +382,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   })
 
-  let instantDonationButton = document.getElementById("instant-donation-button");
+  let tippingBannerButton = document.getElementById("tipping-banner-button");
 
   editContact.addEventListener('click', function(event) {
     updateContactName.value = showContactName.innerText;
@@ -402,7 +402,7 @@ document.addEventListener('DOMContentLoaded', function() {
     event.preventDefault();
   }, false);
 
-  instantDonationButton.addEventListener("click", function(event) {
+  tippingBannerButton.addEventListener("click", function(event) {
 
     document.getElementById("intro-container").style.padding = '50px';
     document.getElementsByClassName("modal-panel")[0].style.padding = '0px';

--- a/app/views/publishers/_tipping_banner_modal.html.slim
+++ b/app/views/publishers/_tipping_banner_modal.html.slim
@@ -1,6 +1,6 @@
 .modal id="rewards_banner_intro_modal" role="dialog" tabindex="-1"
   .modal-dialog
-    .modal-header id="instant-donation-modal-selection"
+    .modal-header id="tipping-banner-modal-selection"
       center id="intro-container"
         = image_tag "icn-donation-jar@1x.png", id: 'icn-donation-jar'
         br

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -15,7 +15,9 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
     class: 'title' \
   )
   = render partial: "choose_channel_button"
-  = link_to("#{t "shared.instant_donation"}", "#", data: { "js-confirm-with-modal": "instant-donation-modal" }, class: 'btn btn-secondary btn-highlight', id: 'instant-donation-button')
+  = link_to("#{t "shared.tipping_banner"}", "#", data: { "js-confirm-with-modal": "tipping-banner-modal" }, class: 'btn btn-secondary btn-highlight', id: 'tipping-banner-button')
+  .new-badge = t "shared.new"
+
 
 
 = hidden_field_tag 'publisher_id', current_publisher.id
@@ -356,5 +358,5 @@ javascript:
     javascriptDetected();
   });
 
-script id="instant-donation-modal" type="text/html"
-  = render "instant_donation_modal", wallet: @wallet
+script id="tipping-banner-modal" type="text/html"
+  = render "tipping_banner_modal", wallet: @wallet

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,9 +37,10 @@ en:
     download: Download
     existing_account: Already have an account?
     get_started: Get Started
-    instant_donation: Tipping Banner
+    tipping_banner: Tipping Banner
     invalid_totp: Invalid 6-digit code. Please try again.
     log_in: Log In
+    new: NEW
     remove: Remove
     terms_of_service: Terms of Service
     faqs: FAQs
@@ -479,7 +480,7 @@ en:
       saving: Saving ...
       redirecting: Redirecting to Uphold for authorization ...
       refreshing: Refreshing balances ...
-    instant_donation_modal:
+    tipping_banner_modal:
       headline: Customize Your Tipping Banner
       intro:
         html: Your fans using the Brave browser can now send you tips through your very own branded banner. This banner is presented when your fan opens the Brave Rewards panel from the URL bar and clicks the <span style="color:#7d7bdc;">Send Tip Now</span> button.


### PR DESCRIPTION
Add a `new` badge to the Tipping Banner button, this PR also cleans up some naming conventions we used previously. 

![screen shot 2018-11-26 at 2 38 58 pm](https://user-images.githubusercontent.com/4713771/49037767-1d593800-f189-11e8-8551-83d3c5e971d0.png)
