### PR TITLE
Fix promo flappy test and add offline mode for unattached codes

### DIFF
--- a/app/services/promo/unattached_registrar.rb
+++ b/app/services/promo/unattached_registrar.rb
@@ -10,7 +10,7 @@ class Promo::UnattachedRegistrar < BaseApiClient
 
   def perform
     return if @number <= 0
-    return register_unattached_offline if perform_promo_offline?
+    return perform_offline if perform_promo_offline?
     response = connection.put do |request|
       request.headers["Authorization"] = api_authorization_header
       request.headers["Content-Type"] = "application/json"
@@ -25,9 +25,12 @@ class Promo::UnattachedRegistrar < BaseApiClient
     end
   end
 
-  def register_unattached_offline
-    Rails.logger.info("Promo::PublisherChannelsRegistrar #register_channel offline.")
-    offline_referral_code
+  def perform_offline
+    @number.times do
+      PromoRegistration.create!(referral_code: offline_referral_code,
+                                promo_id: active_promo_id,
+                                kind: PromoRegistration::UNATTACHED)
+    end
   end
 
   private

--- a/app/services/promo/unattached_registration_status_updater.rb
+++ b/app/services/promo/unattached_registration_status_updater.rb
@@ -14,7 +14,7 @@ class Promo::UnattachedRegistrationStatusUpdater < BaseApiClient
 
   def perform
     return if @referral_codes.count <= 0
-    return true if perform_promo_offline?
+    return perform_offline if perform_promo_offline?
     response = connection.patch do |request|
       request.options.params_encoder = Faraday::FlatParamsEncoder
       request.headers["Authorization"] = api_authorization_header
@@ -23,11 +23,13 @@ class Promo::UnattachedRegistrationStatusUpdater < BaseApiClient
       request.body = {status: @status}.to_json
     end
 
-    if response.status == 200
-      @status == "active" ? @promo_registrations.update_all(active: true) : @promo_registrations.update_all(active: false)
-    end
+    @status == "active" ? @promo_registrations.update_all(active: true) : @promo_registrations.update_all(active: false)
 
     response
+  end
+
+  def perform_offline
+    @status == "active" ? @promo_registrations.update_all(active: true) : @promo_registrations.update_all(active: false)
   end
 
   private

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -120,7 +120,7 @@ test:
   api_promo_base_uri: "" # http://127.0.0.1:8194
   active_promo_id: "free-bats-2018q1"
   api_auth_token: "fake_api_auth_token"
-  api_eyeshade_base_uri: http://127.0.0.1:8194
+  api_eyeshade_base_uri: http://127.0.0.1:3001
   api_eyeshade_offline: true
   host_inspector_offline: true
   api_eyeshade_key: fakeapikey123

--- a/test/services/promo/unattached_registration_status_updater_test.rb
+++ b/test/services/promo/unattached_registration_status_updater_test.rb
@@ -17,15 +17,16 @@ class Promo::UnattachedRegistrationStatusUpdaterTest < ActiveJob::TestCase
     Rails.application.secrets[:api_promo_base_uri] = "http://127.0.0.1:8194"
 
     # create two registrations
-    PromoRegistration.create(promo_id: active_promo_id, referral_code: "ABC123", kind: "unattached")
-    PromoRegistration.create(promo_id: active_promo_id, referral_code: "DEF456", kind: "unattached")
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "NIC123", kind: "unattached")
+    PromoRegistration.create(promo_id: active_promo_id, referral_code: "NIC456", kind: "unattached")
 
     request_url = "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral?referral_code=ABC123&referral_code=DEF456"
     request_body = {status: "paused"}.to_json
     stub_request(:patch, request_url)
       .with(body: request_body)
       .to_return(status: 200)
-    response = Promo::UnattachedRegistrationStatusUpdater.new(promo_registrations: PromoRegistration.all, status: "paused").perform
+    response = Promo::UnattachedRegistrationStatusUpdater.new(promo_registrations: PromoRegistration.where(referral_code: ["NIC123", "NIC456"]),
+                                                              status: "paused").perform
     assert_equal response.status, 200 
   end
 end


### PR DESCRIPTION
Resolves #1393 

Fixed a flappy test, and also makes the unattached codes have an offline mode when no promo server is attached.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
