### PR TITLE
Use correct referral codes for stubbed uri

### DIFF
--- a/test/services/promo/unattached_registration_status_updater_test.rb
+++ b/test/services/promo/unattached_registration_status_updater_test.rb
@@ -20,7 +20,7 @@ class Promo::UnattachedRegistrationStatusUpdaterTest < ActiveJob::TestCase
     PromoRegistration.create(promo_id: active_promo_id, referral_code: "NIC123", kind: "unattached")
     PromoRegistration.create(promo_id: active_promo_id, referral_code: "NIC456", kind: "unattached")
 
-    request_url = "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral?referral_code=ABC123&referral_code=DEF456"
+    request_url = "#{Rails.application.secrets[:api_promo_base_uri]}/api/2/promo/referral?referral_code=NIC123&referral_code=NIC456"
     request_body = {status: "paused"}.to_json
     stub_request(:patch, request_url)
       .with(body: request_body)


### PR DESCRIPTION
Continues https://github.com/brave-intl/publishers/pull/1394 

Actually resolves #1393

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
