### PR TITLE
Do not attempt to backfill potential payments for an empty legacy report

### DIFF
--- a/lib/tasks/database_updates/backfill_potential_payments.rake
+++ b/lib/tasks/database_updates/backfill_potential_payments.rake
@@ -3,6 +3,7 @@ namespace :database_updates do
     PayoutReport.all.each do |payout_report|
       next if PotentialPayment.where(payout_report_id: payout_report.id).any? # For idempotence
       potential_payments = JSON.parse(payout_report.contents)
+      next if potential_payments.empty?
       potential_payments.each do |potential_payment|
         begin
           if potential_payment["type"] == "referral"


### PR DESCRIPTION
Testing on staging found this edgecase.  If a report has no payments, we don't need to create any PotentialPayments.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
