### PR TITLE
Include URL in payout report json

### DIFF
--- a/app/models/json_builders/payout_report_json_builder.rb
+++ b/app/models/json_builders/payout_report_json_builder.rb
@@ -29,6 +29,7 @@ class JsonBuilders::PayoutReportJsonBuilder
           "transactionId" => "#{potential_payment.payout_report_id}",
           "owner" => "#{Publisher.find(potential_payment.publisher_id).owner_identifier}",
           "type" => PotentialPayment::CONTRIBUTION,
+          "URL" => "#{Channel.find(potential_payment.channel_id).details.url}",
           "address" => "#{potential_payment.address}"
         })
       end

--- a/test/models/potential_payment_test.rb
+++ b/test/models/potential_payment_test.rb
@@ -32,4 +32,13 @@ class PotentialPaymentTest < ActiveSupport::TestCase
     potential_payment.channel_id = channels(:verified).id
     refute potential_payment.valid?
   end
+
+  test "potential payments are not deleted when their channel or publisher is destroyed" do
+     publisher = publishers(:potentially_paid)
+     publisher.channels.each {|c| c.destroy!}
+     publisher.destroy!
+
+     potential_payment = potential_payments(:publisher).reload
+     assert_equal PotentialPayment.count, 3
+   end
 end


### PR DESCRIPTION
Noticed this was missing on staging as well.

This also includes an unrelated test to ensure potential payments are not deleted when their corresponding publisher or channel's are destroyed.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
