### PR TITLE
Display total payout report stats in BAT not probi

### DIFF
--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -29,8 +29,8 @@ table.display.table.table-bordered.table-striped.dynamic-table id="dynamic-table
   tbody
       tr.gradeX
         td = PayoutReport.total_payments
-        td = "#{'%.2f' % (PayoutReport.total_amount)} BAT"
-        td = "#{'%.2f' % (PayoutReport.total_fees)} BAT"
+        td = "#{'%.2f' % (PayoutReport.total_amount / 1E18)  } BAT"
+        td = "#{'%.2f' % (PayoutReport.total_fees / 1E18) } BAT"
 
 hr
 


### PR DESCRIPTION
UI says the unit is BAT but the unit is probi.  Changing to display in BAT rounded to two decimal places.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
