### PR TITLE
Auto-select end-date for tomorrow to cover timezone issues

### DIFF
--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -103,7 +103,7 @@
               . = date_select :referral_code_report_period, :start
             .flex-two.align-self-flex-center
               . = label_tag "Report period end"
-              . = date_select :referral_code_report_period, :end, default: 1.day.from_now
+              . = date_select :referral_code_report_period, :end, default: Time.now.utc.to_date
             .flex-two.align-self-flex-center
               . = label_tag "Reporting interval"
               . = select_tag :reporting_interval, options_for_select([["Daily",PromoRegistration::DAILY], ["Weekly",PromoRegistration::WEEKLY], ["Monthly",PromoRegistration::MONTHLY], ["Running total", PromoRegistration::RUNNING_TOTAL]])

--- a/app/views/admin/unattached_promo_registrations/index.html.slim
+++ b/app/views/admin/unattached_promo_registrations/index.html.slim
@@ -103,20 +103,20 @@
               . = date_select :referral_code_report_period, :start
             .flex-two.align-self-flex-center
               . = label_tag "Report period end"
-              . = date_select :referral_code_report_period, :end
+              . = date_select :referral_code_report_period, :end, default: 1.day.from_now
             .flex-two.align-self-flex-center
               . = label_tag "Reporting interval"
               . = select_tag :reporting_interval, options_for_select([["Daily",PromoRegistration::DAILY], ["Weekly",PromoRegistration::WEEKLY], ["Monthly",PromoRegistration::MONTHLY], ["Running total", PromoRegistration::RUNNING_TOTAL]])
             .flex-one.align-self-flex-center
               . style="font-weight: bold" = label_tag = "Event types"
               .
-                = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS
+                = check_box_tag "event_types[]", PromoRegistration::RETRIEVALS, checked: true
                 = label_tag = " " + event_type_column_header(PromoRegistration::RETRIEVALS)
               .
-                = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS
+                = check_box_tag "event_types[]", PromoRegistration::FIRST_RUNS, checked: true
                 = label_tag = " " + event_type_column_header(PromoRegistration::FIRST_RUNS)
               .
-                = check_box_tag "event_types[]", PromoRegistration::FINALIZED
+                = check_box_tag "event_types[]", PromoRegistration::FINALIZED, checked: true
                 = label_tag = " " + event_type_column_header(PromoRegistration::FINALIZED)
             .flex-one.align-self-flex-end
               = submit_tag "Download", id: "download-referral-reports", class: "btn btn-primary", data: { disable_with: false }


### PR DESCRIPTION
Default checked

Closes #1395

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
