### PR TITLE
Refresh payout report contents in the worker process

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -17,6 +17,11 @@ class Admin::PayoutReportsController < AdminController
       type: :json
   end
 
+  def refresh
+    UpdatePayoutReportContentsJob.perform_later(payout_report_ids: params[:id])
+    redirect_to admin_payout_reports_path, flash: { notice: "Refreshing report JSON.  Please try downloading in a couple minutes." }
+  end
+
   def create
     EnqueuePublishersForPayoutJob.perform_later(final: params[:final].present?,
                                                 should_send_notifications: params[:should_send_notifications].present?)

--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -18,7 +18,7 @@ class Admin::PayoutReportsController < AdminController
   end
 
   def refresh
-    UpdatePayoutReportContentsJob.perform_later(payout_report_ids: params[:id])
+    UpdatePayoutReportContentsJob.perform_later(payout_report_ids: [params[:id]])
     redirect_to admin_payout_reports_path, flash: { notice: "Refreshing report JSON.  Please try downloading in a couple minutes." }
   end
 

--- a/app/jobs/update_payout_report_contents_job.rb
+++ b/app/jobs/update_payout_report_contents_job.rb
@@ -1,0 +1,15 @@
+class UpdatePayoutReportContentsJob < ApplicationJob
+  queue_as :scheduler
+
+  def perform(payout_report_ids: [])
+    if payout_report_ids.present?
+      payout_reports = PayoutReport.where(id: payout_report_ids)
+    else
+      payout_reports = PayoutReport.all
+    end
+
+    payout_reports.each do |payout_report|
+      payout_report.update_report_contents
+    end
+  end
+end

--- a/app/models/payout_report.rb
+++ b/app/models/payout_report.rb
@@ -32,8 +32,8 @@ class PayoutReport < ApplicationRecord
   def update_report_contents
     # Do not update json contents for legacy reports
     return if created_at <= LEGACY_PAYOUT_REPORT_TRANSITION_DATE
-    payout_report_json = JsonBuilders::PayoutReportJsonBuilder.new(payout_report: self).build
-    self.contents = payout_report_json.to_json
+    payout_report_hash = JsonBuilders::PayoutReportJsonBuilder.new(payout_report: self).build
+    self.contents = payout_report_hash.to_json
     save!
   end
 

--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -9,6 +9,7 @@ table.display.table.table-bordered.table-striped
     th # Payments
     th Amount
     th Fees
+    th Refresh JSON
     th Download
   tbody
     - @payout_reports.each do |report| 
@@ -19,7 +20,9 @@ table.display.table.table-bordered.table-striped
         td = report.num_payments
         td = "#{'%.2f' % (report.amount.to_d / 1E18)} BAT"
         td = "#{'%.2f' % (report.fees.to_d / 1E18)} BAT"
-        td = link_to "download", download_admin_payout_report_path(report.id)
+        td = form_tag refresh_admin_payout_report_path(report.id), method: :patch do
+             = submit_tag "refresh", class: "btn btn-info"
+        td = link_to "download", download_admin_payout_report_path(report.id), class: "btn btn-primary"
 
 table.display.table.table-bordered.table-striped.dynamic-table id="dynamic-table"
   tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -125,6 +125,7 @@ Rails.application.routes.draw do
     resources :payout_reports, only: %i(index show create) do
       member do
         get :download
+        patch :refresh
       end
     end
     resources :publishers do

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -55,4 +55,8 @@
     cron: "0 0 1 * *"
     description: "Generates the list of unsettled transactions on the first of every month"
     queue: scheduler
+  UpdatePayoutReportContentsJob:
+    cron: "0 3 1 * *"
+    description: "Refreshes the json version of the report that's built from the potential payments table on the first of every month."
+    queue: scheduler
 :verbose: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2018_11_28_143110) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"

--- a/test/controllers/admin/payout_reports_controller_test.rb
+++ b/test/controllers/admin/payout_reports_controller_test.rb
@@ -166,4 +166,14 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test "#refresh refreshes report contents" do
+    admin = publishers(:admin)
+    sign_in admin
+    payout_report = payout_reports(:one)
+
+    assert_enqueued_with(job: UpdatePayoutReportContentsJob) do
+      patch refresh_admin_payout_report_path(payout_report.id)
+    end
+  end
 end

--- a/test/jobs/update_payout_report_contents_job_test.rb
+++ b/test/jobs/update_payout_report_contents_job_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class UpdatePayoutReportContentsJobTest < ActiveJob::TestCase
+  test "updates payout report contents for single report" do
+    payout_report = payout_reports(:one)
+    UpdatePayoutReportContentsJob.perform_now(payout_report_ids: payout_report.id)
+    payout_report.reload
+    assert_not_nil payout_report.contents
+  end
+
+  test "updates payout report contents for all reports" do
+    payout_report = payout_reports(:one)
+    UpdatePayoutReportContentsJob.perform_now
+    payout_report.reload
+    assert_not_nil payout_report.contents
+  end
+end

--- a/test/tasks/backfill_potential_payments_test.rb
+++ b/test/tasks/backfill_potential_payments_test.rb
@@ -5,7 +5,6 @@ class BackfillPotentialPaymentsTest < ActiveJob::TestCase
     prev_num_potential_payments = PotentialPayment.count
     completed = publishers(:completed)
     uphold_connected = publishers(:uphold_connected)
-
     old_payout_contents = [{"name"=>completed.name,
                             "altcurrency"=>"BAT",
                             "probi"=>"39136205383556598598",
@@ -26,8 +25,9 @@ class BackfillPotentialPaymentsTest < ActiveJob::TestCase
                             "type"=>"contribution",
                             "URL"=>"#{uphold_connected.channels.first.details.url}",
                             "address"=>"f290b714-a587-4bfc-8821-028469709669"}]
-    
-    PayoutReport.create(final: true, contents: old_payout_contents.to_json)
+
+    payout_report_created_at = PayoutReport::LEGACY_PAYOUT_REPORT_TRANSITION_DATE.to_time - 1.minute
+    PayoutReport.create(created_at: payout_report_created_at, final: true, contents: old_payout_contents.to_json)
 
     Rake::Task["database_updates:backfill_potential_payments"].invoke
     assert_equal PotentialPayment.count, prev_num_potential_payments + 2


### PR DESCRIPTION
Resolves #1408 

This adds a UpdatePayoutReportContentsJob that refreshes the payout report contents.  Admins now can trigger this job via the admin dashboard.

![image](https://user-images.githubusercontent.com/12549658/49457140-552f3380-f7b8-11e8-9d04-f8e8be14f3a3.png)


This also makes some changes to the backfill_potential_payments script.  Namely we do not backfill for non-legacy reports, and we do not terminate the script if a potential payment is.  The values on the dashboard are advisory only, as the accounting is Eyeshade's responsibility.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
