### PR TITLE
Create organization permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn-error.log
 /node_modules
 .env
 docker-compose.override.yml
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ yarn-error.log
 /node_modules
 .env
 docker-compose.override.yml
-coverage

--- a/Gemfile
+++ b/Gemfile
@@ -181,7 +181,6 @@ group :development, :test do
   gem 'rubyzip'
   gem "capybara-selenium"
   gem "chromedriver-helper"
-  gem 'simplecov', require: false, group: :test
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -181,6 +181,7 @@ group :development, :test do
   gem 'rubyzip'
   gem "capybara-selenium"
   gem "chromedriver-helper"
+  gem 'simplecov', require: false, group: :test
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,6 @@ GEM
       responders
       warden (~> 1.2.3)
     dnsruby (1.60.2)
-    docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     easy_translate (0.5.1)
@@ -400,11 +399,6 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
-    simplecov (0.16.1)
-      docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -531,7 +525,6 @@ DEPENDENCIES
   sentry-raven (~> 2.1)
   sidekiq
   sidekiq-scheduler (~> 2.2.2)
-  simplecov
   sinatra (~> 2.0.2)
   slim-rails (~> 3.1)
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       responders
       warden (~> 1.2.3)
     dnsruby (1.60.2)
+    docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     easy_translate (0.5.1)
@@ -399,6 +400,11 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -525,6 +531,7 @@ DEPENDENCIES
   sentry-raven (~> 2.1)
   sidekiq
   sidekiq-scheduler (~> 2.2.2)
+  simplecov
   sinatra (~> 2.0.2)
   slim-rails (~> 3.1)
   tzinfo-data

--- a/app/assets/stylesheets/admin/pages/organization.scss
+++ b/app/assets/stylesheets/admin/pages/organization.scss
@@ -1,0 +1,12 @@
+.organization-container {
+  h4 {
+    display: inline-block;
+  }
+  .btn {
+    margin-top: -0.5rem;
+    float: right;
+  }
+  .add-partner {
+    margin-left: 1rem;
+  }
+}

--- a/app/assets/stylesheets/admin/pages/partner.scss
+++ b/app/assets/stylesheets/admin/pages/partner.scss
@@ -2,7 +2,7 @@
   h4 {
     display: inline-block;
   }
-  .btn-partner {
+  .btn {
     margin-top: -0.5rem;
     float: right;
   }

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -40,9 +40,9 @@ module Admin
     end
 
     def permissions(organization_permissions)
-      organization_permissions.uphold_wallet = params[:uphold] == "1"
-      organization_permissions.referral_codes = params[:referral_codes] == "1"
-      organization_permissions.offline_reporting = params[:offline_reporting] == "1"
+      organization_permissions.uphold_wallet = params[:uphold].present?
+      organization_permissions.referral_codes = params[:referral_codes].present?
+      organization_permissions.offline_reporting = params[:offline_reporting].present?
 
       organization_permissions
     end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -4,8 +4,50 @@ module Admin
       @organizations = Organization.paginate(page: params[:page])
     end
 
+    def new
+      @organization = Organization.new
+    end
+
+    def create
+      @organization = Organization.new(organization_params)
+      @organization.permissions = permissions(OrganizationPermission.new)
+
+      if @organization.save
+        redirect_to admin_organization_path(@organization.id)
+      else
+        render :new
+      end
+    end
+
     def show
-      @organization = Organization.find_by(id: params[:id])
+      @organization = Organization.find(params[:id])
+    end
+
+    def edit
+      @organization = Organization.find(params[:id])
+    end
+
+    def update
+      @organization = Organization.find(params[:id])
+      @organization.permissions = permissions(@organization.permissions)
+
+      if @organization.update(organization_params)
+        redirect_to admin_organization_path(@organization.id)
+      else
+        render :edit
+      end
+    end
+
+    def permissions(organization_permissions)
+      organization_permissions.upload_offline_billing = params[:billing] == "1"
+      organization_permissions.upload_offline_invoice = params[:invoice] == "1"
+      organization_permissions.upload_referral_codes = params[:referral] == "1"
+
+      organization_permissions
+    end
+
+    def organization_params
+      params.require(:organization).permit(:name)
     end
   end
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -6,6 +6,7 @@ module Admin
 
     def new
       @organization = Organization.new
+      @organization.permissions = OrganizationPermission.new
     end
 
     def create
@@ -39,9 +40,9 @@ module Admin
     end
 
     def permissions(organization_permissions)
-      organization_permissions.upload_offline_billing = params[:billing] == "1"
-      organization_permissions.upload_offline_invoice = params[:invoice] == "1"
-      organization_permissions.upload_referral_codes = params[:referral] == "1"
+      organization_permissions.uphold_wallet = params[:uphold] == "1"
+      organization_permissions.referral_codes = params[:referral_codes] == "1"
+      organization_permissions.offline_reporting = params[:offline_reporting] == "1"
 
       organization_permissions
     end

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -38,7 +38,7 @@ module Admin
         @partner.organization = organization
         @partner.save
         MailerServices::PartnerLoginLinkEmailer.new(partner: @partner).perform
-        redirect_to admin_publisher_path(@partner.id), flash: { notice: "Email sent" }
+        redirect_to admin_organization_path(@organization.id), flash: { notice: "Email sent" }
       end
     end
 

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -27,8 +27,7 @@ module Admin
       @organization = organization
 
       if @partner.persisted? && (@partner.partner? || @partner.admin?)
-        flash.now[:alert] = "Email is already a partner"
-        render :new
+        redirect_to new_admin_partner_path(organization: organization_name), flash: { alert: "Email is already a partner"}
       elsif @organization.blank?
         flash.now[:alert] = "The organization specified does not exist"
         render :new
@@ -77,7 +76,7 @@ module Admin
                  .or(Publisher.by_email_case_insensitive(email_params))
                  .first
 
-      existing_publisher || Partner.new(email: email_params)
+      existing_publisher&.becomes(Partner) || Partner.new(email: email_params)
     end
 
     def organization

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -31,16 +31,6 @@ class Admin::PublishersController < AdminController
     redirect_to admin_publisher_path(@publisher)
   end
 
-  def make_partner
-    return unless @publisher.publisher?
-
-    @publisher.created_by = current_user
-    @publisher.update(role: Publisher::PARTNER)
-    MailerServices::PartnerLoginLinkEmailer.new(partner: @publisher).perform
-    flash[:notice] = "Successfully made partner"
-    redirect_to admin_publisher_path(@publisher)
-  end
-
   def statement
     statement_period = params[:statement_period]
     @transactions = PublisherStatementGetter.new(publisher: @publisher, statement_period: statement_period).perform

--- a/app/helpers/admin/organization_helper.rb
+++ b/app/helpers/admin/organization_helper.rb
@@ -1,0 +1,9 @@
+module Admin::OrganizationHelper
+  def boolean_to_image(value)
+    if value
+      image_tag("verified-icon@1x.png", alt: t(".https"), class: "https-check-icon", width: 11.5, height: 14)
+    else
+      image_tag("x.png", alt: t(".no_https_alt"), class: "https-check-icon", width: 12, height: 12)
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,13 @@
 class Organization < ActiveRecord::Base
   has_many :memberships
+  has_one :organization_permission
+
+  alias_attribute :permissions, :organization_permission
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :organization_permission, presence: true
+
+  def to_s
+    name
+  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,5 +1,6 @@
 class Organization < ActiveRecord::Base
   has_many :memberships
+  has_many :members, through: :memberships
   has_one :organization_permission
 
   alias_attribute :permissions, :organization_permission

--- a/app/models/organization_permission.rb
+++ b/app/models/organization_permission.rb
@@ -1,0 +1,2 @@
+class OrganizationPermission < ActiveRecord::Base
+end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -6,7 +6,6 @@ class Partner < Publisher
 
   after_initialize :ensure_role
 
-
   # Ensure that the role is always Partner
   def ensure_role
     self.role = 'partner'

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -2,8 +2,10 @@ class Partner < Publisher
   default_scope { where(role: PARTNER) }
   validates :created_by, presence: true
   has_one :membership, dependent: :destroy, foreign_key: :user_id
+  has_one :organization, through: :membership
 
   after_initialize :ensure_role
+
 
   # Ensure that the role is always Partner
   def ensure_role

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -151,7 +151,7 @@ class Publisher < ApplicationRecord
   end
 
   def to_s
-    name
+    name || email
   end
 
   def prepare_uphold_state_token

--- a/app/views/admin/organizations/_form.html.slim
+++ b/app/views/admin/organizations/_form.html.slim
@@ -1,0 +1,29 @@
+- if @organization.errors.any?
+  - @organization.errors.full_messages.each do |msg|
+    .alert.alert-warning.flash=msg
+= form_with model: [:admin, @organization] do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name,
+        autofocus: true,
+        class: "form-control",
+        placeholder: "Organization Name",
+        required: true
+  .form-group
+    label
+      strong Permissions
+    br
+    label
+      = check_box_tag('referral', 1, params[:uphold].present?, class: 'checkbox')
+      = " Referral Codes"
+    br
+    label
+      = check_box_tag('billing', 1, params[:statement].present?, class: 'checkbox')
+      = " Offline billing statement"
+    br
+    label
+      = check_box_tag('invoice', 1, params[:invoice].present?, class: 'checkbox')
+      = " Offline invoice"
+
+  = submit_tag "Save", class: "btn btn-block btn-primary"
+

--- a/app/views/admin/organizations/_form.html.slim
+++ b/app/views/admin/organizations/_form.html.slim
@@ -14,16 +14,16 @@
       strong Permissions
     br
     label
-      = check_box_tag('referral', 1, params[:uphold].present?, class: 'checkbox')
-      = " Referral Codes"
+      = check_box_tag('uphold', 1, @organization.permissions.uphold_wallet, class: 'checkbox')
+      = " Uphold wallet"
     br
     label
-      = check_box_tag('billing', 1, params[:statement].present?, class: 'checkbox')
-      = " Offline billing statement"
+      = check_box_tag('referral_codes', 1, @organization.permissions.referral_codes, class: 'checkbox')
+      = " Referral code creation"
     br
     label
-      = check_box_tag('invoice', 1, params[:invoice].present?, class: 'checkbox')
-      = " Offline invoice"
+      = check_box_tag('offline_reporting', 1, @organization.permissions.offline_reporting, class: 'checkbox')
+      = " Offline reporting and billing"
 
   = submit_tag "Save", class: "btn btn-block btn-primary"
 

--- a/app/views/admin/organizations/edit.html.slim
+++ b/app/views/admin/organizations/edit.html.slim
@@ -1,0 +1,6 @@
+div.row
+  div.col-sm-12
+    section.panel
+      header.panel-heading.organization-container
+        h4 Edit Organization
+    = render partial: 'form'

--- a/app/views/admin/organizations/index.html.slim
+++ b/app/views/admin/organizations/index.html.slim
@@ -3,6 +3,7 @@ div.row
     section.panel
       header.panel-heading.organization-container
         h4 Organizations
+        = link_to "New Organization", new_admin_organization_path, class: "btn btn-primary"
       br
       div.panel-body
         div.adv-table
@@ -10,9 +11,11 @@ div.row
             tr
               th ID
               th Name
+              th Members
             tbody
               - @organizations.each do |organization|
                 tr.gradeX
                   td = link_to organization.id, admin_organization_path(organization.id)
                   td = organization.name
+                  td = organization.memberships.length
           = will_paginate @organizations

--- a/app/views/admin/organizations/new.html.slim
+++ b/app/views/admin/organizations/new.html.slim
@@ -1,0 +1,6 @@
+div.row
+  div.col-sm-12
+    section.panel
+      header.panel-heading.organization-container
+        h4 Create Organization
+        = render partial: 'form'

--- a/app/views/admin/organizations/show.html.slim
+++ b/app/views/admin/organizations/show.html.slim
@@ -15,7 +15,7 @@ div.row
         = " Referral code creation"
         br
         = boolean_to_image(@organization.permissions.offline_reporting)
-        = " upload_referral_codes "
+        = " Offline reporting and billing"
 
       br
       h5 Partners

--- a/app/views/admin/organizations/show.html.slim
+++ b/app/views/admin/organizations/show.html.slim
@@ -3,7 +3,32 @@ div.row
     section.panel
       header.panel-heading.organization-container
         h4 Organization: #{@organization.name}
+        = link_to "Add Partner", new_admin_partner_path(organization: @organization.name), class: "btn add-partner btn-primary"
+        = link_to "Edit Organization", edit_admin_organization_path(@organization), class: "btn btn-primary"
       br
+      section.panel
+        h5 Permissions
+        = boolean_to_image(@organization.permissions.upload_offline_invoice)
+        = " upload_offline_invoice "
+        br
+        = boolean_to_image(@organization.permissions.upload_offline_billing)
+        = " upload_offline_billing "
+        br
+        = boolean_to_image(@organization.permissions.upload_referral_codes)
+        = " upload_referral_codes "
+
+      / table.display.table.table-bordered
+      /   tr
+      /     td= boolean_to_image(@organization.permissions.upload_offline_invoice)
+      /     td = "upload_offline_invoice "
+      /   tr
+      /     td= boolean_to_image(@organization.permissions.upload_offline_billing)
+      /     td= "upload_offline_billing "
+      /   tr
+      /     td= boolean_to_image(@organization.permissions.upload_referral_codes)
+      /     td= "upload_referral_codes "
+      br
+      h5 Partners
       div.panel-body
         div.adv-table
           table.display.table.table-bordered.table-striped.dynamic-table id="dynamic-table"

--- a/app/views/admin/organizations/show.html.slim
+++ b/app/views/admin/organizations/show.html.slim
@@ -8,25 +8,15 @@ div.row
       br
       section.panel
         h5 Permissions
-        = boolean_to_image(@organization.permissions.upload_offline_invoice)
-        = " upload_offline_invoice "
+        = boolean_to_image(@organization.permissions.uphold_wallet)
+        = " Uphold wallet"
         br
-        = boolean_to_image(@organization.permissions.upload_offline_billing)
-        = " upload_offline_billing "
+        = boolean_to_image(@organization.permissions.referral_codes)
+        = " Referral code creation"
         br
-        = boolean_to_image(@organization.permissions.upload_referral_codes)
+        = boolean_to_image(@organization.permissions.offline_reporting)
         = " upload_referral_codes "
 
-      / table.display.table.table-bordered
-      /   tr
-      /     td= boolean_to_image(@organization.permissions.upload_offline_invoice)
-      /     td = "upload_offline_invoice "
-      /   tr
-      /     td= boolean_to_image(@organization.permissions.upload_offline_billing)
-      /     td= "upload_offline_billing "
-      /   tr
-      /     td= boolean_to_image(@organization.permissions.upload_referral_codes)
-      /     td= "upload_referral_codes "
       br
       h5 Partners
       div.panel-body
@@ -35,8 +25,10 @@ div.row
             tr
               th ID
               th Email
+              th Status
             tbody
-              - @organization.memberships.joins(:member).each do |membership|
+              - @organization.members.each do |member|
                 tr.gradeX
-                  td = link_to membership.user_id, admin_publisher_path(membership.user_id)
-                  td = membership.member.email
+                  td = link_to member.id, admin_publisher_path(member.id)
+                  td = member.email
+                  td = member.last_status_update.status

--- a/app/views/admin/partners/edit.html.slim
+++ b/app/views/admin/partners/edit.html.slim
@@ -3,7 +3,7 @@
     .notifications
         .alert.alert-warning.flash = msg
 
-h1 Make partner 🤠
+h1 Make partner
 
 = form_with model: [:admin, @partner], url: admin_partner_path(@partner) do |f|
   .form-group

--- a/app/views/admin/partners/edit.html.slim
+++ b/app/views/admin/partners/edit.html.slim
@@ -3,17 +3,14 @@
     .notifications
         .alert.alert-warning.flash = msg
 
-h1 Add a new partner
+h1 Make partner 🤠
 
-= form_with url: admin_partners_path, method: :post do |f|
+= form_with model: [:admin, @partner], url: admin_partner_path(@partner) do |f|
   .form-group
     label
-      = "Email"
-    = f.email_field :email,
-        autofocus: true,
-        class: "form-control",
-        placeholder: "Enter Partner email",
-        required: true
+      strong= "Email"
+      br
+      = @partner.email
   .form-group
     label
       = "Organization"
@@ -22,4 +19,4 @@ h1 Add a new partner
         class: "form-control",
         placeholder: "Enter Organization Name",
         required: true
-  = submit_tag "Create Partner", class: "btn btn-block btn-primary"
+  = submit_tag "Make Partner", class: "btn btn-block btn-primary"

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -10,9 +10,10 @@
           .db-field = "Role:"
           .db-value = @publisher.role
         - if @publisher.partner?
+          - partner = @publisher.becomes(Partner)
           .db-info-row
             .db-field = "Organization:"
-            .db-value = @publisher&.becomes(Partner).organization
+            .db-value = link_to partner.organization, admin_organization_path(partner.organization)
         .db-info-row
           .db-field = "Status:"
           .db-value = link_to(@publisher.last_status_update.present? ? @publisher.last_status_update.status : "active", admin_publisher_publisher_status_updates_path(@publisher), class: "btn btn-primary")

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -9,6 +9,10 @@
         .db-info-row
           .db-field = "Role:"
           .db-value = @publisher.role
+        - if @publisher.partner?
+          .db-info-row
+            .db-field = "Organization:"
+            .db-value = @publisher&.becomes(Partner).organization
         .db-info-row
           .db-field = "Status:"
           .db-value = link_to(@publisher.last_status_update.present? ? @publisher.last_status_update.status : "active", admin_publisher_publisher_status_updates_path(@publisher), class: "btn btn-primary")
@@ -49,8 +53,7 @@
   hr
     = link_to("Edit Settings", edit_admin_publisher_path(@publisher), class: "btn btn-primary")
     = link_to("Make partner",
-          admin_publisher_make_partner_path(@publisher),
-          method: :post,
+          edit_admin_partner_path(@publisher),
           class: "btn btn-primary partner-button #{@publisher.publisher? ? '' : 'disabled'}")
     = csrf_meta_tag
   hr

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,10 @@ module Publishers
 
     config.time_zone = "Pacific Time (US & Canada)"
     config.active_record.default_timezone = :local
+
+    # Let's ensure that our generators make a UUID as default
+    config.generators do |generator|
+      generator.orm :active_record, primary_key_type: :uuid
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,12 +134,11 @@ Rails.application.routes.draw do
         get :statement
         post :create_note
       end
-      post :make_partner
       resources :publisher_status_updates, controller: 'publishers/publisher_status_updates'
     end
 
-    resources :organizations, only: [:index, :show]
-    resources :partners, only: [:index, :new, :create]
+    resources :organizations, except: [:destroy]
+    resources :partners, except: [:destroy]
 
     namespace :stats do
       resources :contributions, only: [:index]

--- a/db/migrate/20181204201916_create_organization_permissions.rb
+++ b/db/migrate/20181204201916_create_organization_permissions.rb
@@ -2,9 +2,9 @@ class CreateOrganizationPermissions < ActiveRecord::Migration[5.2]
   def change
     create_table :organization_permissions do |t|
       t.uuid :organization_id
-      t.boolean :upload_offline_billing
-      t.boolean :upload_offline_invoice
-      t.boolean :upload_referral_codes
+      t.boolean :uphold_wallet
+      t.boolean :offline_reporting
+      t.boolean :referral_codes
     end
   end
 end

--- a/db/migrate/20181204201916_create_organization_permissions.rb
+++ b/db/migrate/20181204201916_create_organization_permissions.rb
@@ -1,6 +1,6 @@
 class CreateOrganizationPermissions < ActiveRecord::Migration[5.2]
   def change
-    create_table :organization_permissions do |t|
+    create_table :organization_permissions, id: :uuid, default: -> { "uuid_generate_v4()" } do |t|
       t.uuid :organization_id
       t.boolean :uphold_wallet, default: false, null: false
       t.boolean :offline_reporting, default: false, null: false

--- a/db/migrate/20181204201916_create_organization_permissions.rb
+++ b/db/migrate/20181204201916_create_organization_permissions.rb
@@ -6,7 +6,7 @@ class CreateOrganizationPermissions < ActiveRecord::Migration[5.2]
       t.boolean :offline_reporting, default: false, null: false
       t.boolean :referral_codes, default: false, null: false
 
-      t.index :organization_id
+      t.index :organization_id, unique: true
     end
   end
 end

--- a/db/migrate/20181204201916_create_organization_permissions.rb
+++ b/db/migrate/20181204201916_create_organization_permissions.rb
@@ -2,9 +2,11 @@ class CreateOrganizationPermissions < ActiveRecord::Migration[5.2]
   def change
     create_table :organization_permissions do |t|
       t.uuid :organization_id
-      t.boolean :uphold_wallet
-      t.boolean :offline_reporting
-      t.boolean :referral_codes
+      t.boolean :uphold_wallet, default: false, null: false
+      t.boolean :offline_reporting, default: false, null: false
+      t.boolean :referral_codes, default: false, null: false
+
+      t.index :organization_id
     end
   end
 end

--- a/db/migrate/20181204201916_create_organization_permissions.rb
+++ b/db/migrate/20181204201916_create_organization_permissions.rb
@@ -1,0 +1,10 @@
+class CreateOrganizationPermissions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :organization_permissions do |t|
+      t.uuid :organization_id
+      t.boolean :upload_offline_billing
+      t.boolean :upload_offline_invoice
+      t.boolean :upload_referral_codes
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -194,7 +194,7 @@ ActiveRecord::Schema.define(version: 2018_12_04_201916) do
     t.boolean "uphold_wallet", default: false, null: false
     t.boolean "offline_reporting", default: false, null: false
     t.boolean "referral_codes", default: false, null: false
-    t.index ["organization_id"], name: "index_organization_permissions_on_organization_id"
+    t.index ["organization_id"], name: "index_organization_permissions_on_organization_id", unique: true
   end
 
   create_table "organizations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,9 +191,9 @@ ActiveRecord::Schema.define(version: 2018_12_04_201916) do
 
   create_table "organization_permissions", force: :cascade do |t|
     t.uuid "organization_id"
-    t.boolean "upload_offline_billing"
-    t.boolean "upload_offline_invoice"
-    t.boolean "upload_referral_codes"
+    t.boolean "uphold_wallet"
+    t.boolean "offline_reporting"
+    t.boolean "referral_codes"
   end
 
   create_table "organizations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_28_143110) do
+ActiveRecord::Schema.define(version: 2018_12_04_201916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2018_11_28_143110) do
     t.string "name"
     t.string "email"
     t.string "verification_token"
-    t.boolean "verified", default: false
+    t.boolean "verified", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sign_in_count", default: 0, null: false
@@ -187,6 +187,13 @@ ActiveRecord::Schema.define(version: 2018_11_28_143110) do
     t.datetime "updated_at", null: false
     t.index ["organization_id"], name: "index_memberships_on_organization_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
+  create_table "organization_permissions", force: :cascade do |t|
+    t.uuid "organization_id"
+    t.boolean "upload_offline_billing"
+    t.boolean "upload_offline_invoice"
+    t.boolean "upload_referral_codes"
   end
 
   create_table "organizations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -189,7 +189,7 @@ ActiveRecord::Schema.define(version: 2018_12_04_201916) do
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
-  create_table "organization_permissions", force: :cascade do |t|
+  create_table "organization_permissions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "organization_id"
     t.boolean "uphold_wallet", default: false, null: false
     t.boolean "offline_reporting", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,9 +191,10 @@ ActiveRecord::Schema.define(version: 2018_12_04_201916) do
 
   create_table "organization_permissions", force: :cascade do |t|
     t.uuid "organization_id"
-    t.boolean "uphold_wallet"
-    t.boolean "offline_reporting"
-    t.boolean "referral_codes"
+    t.boolean "uphold_wallet", default: false, null: false
+    t.boolean "offline_reporting", default: false, null: false
+    t.boolean "referral_codes", default: false, null: false
+    t.index ["organization_id"], name: "index_organization_permissions_on_organization_id"
   end
 
   create_table "organizations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/test/controllers/admin/organizations_controller_test.rb
+++ b/test/controllers/admin/organizations_controller_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+require "shared/mailer_test_helper"
+require "webmock/minitest"
+
+class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  before do
+    admin = publishers(:admin)
+    sign_in admin
+  end
+
+  describe 'index' do
+    it 'assigns @organizations' do
+      get admin_organizations_path
+      assert controller.instance_variable_get("@organizations")
+    end
+  end
+
+  describe "new" do
+    it "assigns @organization" do
+      get new_admin_organization_path
+      assert controller.instance_variable_get("@organization")
+      assert controller.instance_variable_get("@organization").permissions
+    end
+  end
+
+  describe 'create' do
+    let(:organization_params) do
+      {
+        organization: { name: 'org' },
+        uphold: '1',
+        referral_codes: '1',
+        offline_reporting: '1'
+      }
+    end
+
+    let(:subject) { post admin_organizations_path, params: organization_params }
+
+    describe 'when organization is valid' do
+      before do
+        subject
+      end
+
+      it 'assigns organizations' do
+        organization = controller.instance_variable_get("@organization")
+        assert organization
+      end
+
+      it 'assigns permissions correctly' do
+        organization = controller.instance_variable_get("@organization")
+        assert organization.permissions.uphold_wallet
+        assert organization.permissions.referral_codes
+        assert organization.permissions.offline_reporting
+      end
+
+      it 'redirects to organization when saved' do
+        organization = controller.instance_variable_get("@organization")
+        assert_redirected_to admin_organization_path(organization.id)
+      end
+    end
+
+    describe 'when test is invalid' do
+      let(:organization_params) { { organization: { name: '' } } }
+
+      before do
+        subject
+      end
+
+      it 'renders new if invalid' do
+        assert_template :new
+      end
+    end
+  end
+end

--- a/test/controllers/admin/organizations_controller_test.rb
+++ b/test/controllers/admin/organizations_controller_test.rb
@@ -9,7 +9,6 @@ class Admin::OrganizationsControllerTest < ActionDispatch::IntegrationTest
     admin = publishers(:admin)
     sign_in admin
 
-    # not created until invoked :)
     @org_name = "Cory's Great Organization"
     @org_id = "bde27753-2327-40dc-a1f8-06d3339f08cf"
   end

--- a/test/controllers/admin/partners_controller_test.rb
+++ b/test/controllers/admin/partners_controller_test.rb
@@ -6,87 +6,173 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
   include ActionMailer::TestHelper
 
+
+  before do
+    admin = publishers(:admin)
+    sign_in admin
+    @partner_id = publishers(:partner).id
+  end
+
   after do
     clear_enqueued_jobs
   end
 
-  test "admin can access partners" do
-    admin = publishers(:admin)
-    sign_in admin
-
-    get new_admin_partner_path
-    assert_response :success
-  end
-
-  test "when there's an unverified existing publisher" do
-    admin = publishers(:admin)
-    sign_in admin
-    unverified_email = 'unverified@example.com'
-
-    publisher = Publisher.find_or_create_by(pending_email: unverified_email)
-
-    # Ensure it's a publisher
-    assert_equal publisher.role, Publisher::PUBLISHER
-
-    # Make request
-    assert_enqueued_emails(1) do
-      post admin_partners_path, params: { email: unverified_email, organization_name: 'The Guardian' }
+  describe "index" do
+    describe "when users does not search" do
+      it 'assigns @partners' do
+        get admin_partners_path
+        assert controller.instance_variable_get("@partners")
+      end
     end
 
-    # We assert that only one account is created
-    assert_empty Publisher.where(email: unverified_email)
-    # We made it a partner
-    assert Publisher.find_by(pending_email: unverified_email).partner?
+    describe "when user searches" do
+      describe 'when suspended' do
+        it 'only shows suspended' do
+          get admin_partners_path, params: { suspended: '1' }
+
+          partners = controller.instance_variable_get("@partners")
+          assert partners.count
+          partners.each do |p|
+            assert p.suspended?
+          end
+        end
+      end
+
+      describe 'created by me' do
+        it 'returns the partners created by me' do
+          created_by_me  = Partner.where(created_by: publishers(:admin))
+          not_created_by_me  = Partner.where.not(created_by: publishers(:admin))
+
+          get admin_partners_path, params: { created_by_me: '1' }
+
+          partners = controller.instance_variable_get("@partners")
+          assert partners.count
+          partners.each do |p|
+            assert created_by_me.include? p
+            refute not_created_by_me.include? p
+          end
+        end
+      end
+
+      describe 'searching by a query' do
+        it 'returns results' do
+          get admin_partners_path, params: { q: 'paul' }
+
+          partners = controller.instance_variable_get("@partners")
+          assert partners.count
+          partners.each do |p|
+            assert p.name.downcase.include? 'paul'
+          end
+        end
+      end
+    end
   end
 
-  test "when there's a verified existing publisher" do
-    admin = publishers(:admin)
-    sign_in admin
-    unverified_email = 'unverified@example.com'
-
-    # ensure there are no previously existing entries in the database
-    Publisher.where(pending_email: unverified_email).destroy_all
-    publisher = Publisher.find_or_create_by(email: unverified_email)
-
-    # Ensure it's a publisher
-    assert_equal publisher.role, Publisher::PUBLISHER
-
-    # Make request
-    assert_enqueued_emails(1) do
-      post admin_partners_path, params: { email: unverified_email, organization_name: 'The Guardian' }
+  describe "new" do
+    it "allows admins to access partners" do
+      get new_admin_partner_path
+      assert controller.instance_variable_get("@partner")
+      assert_response :success
     end
-
-    # We assert that only one account is created
-    assert_empty Publisher.where(pending_email: unverified_email)
-    # We made it a partner
-    assert Publisher.find_by(email: unverified_email).partner?
   end
 
-  test "when there's a new partner" do
-    admin = publishers(:admin)
-    sign_in admin
-    partner_email = 'partner@example.com'
-
-    # Make request
-    assert_enqueued_emails(1) do
-      post admin_partners_path, params: { email: partner_email, organization_name: 'The Guardian' }
+  describe "edit" do
+    it "allows admins to access partners" do
+      get edit_admin_partner_path(@partner_id)
+      assert controller.instance_variable_get("@partner")
+      assert_response :success
     end
-
-    # We made it a partner
-    assert Partner.find_by(email: partner_email).partner?
   end
 
-  test "when the email is already a partner" do
-    admin = publishers(:admin)
-    sign_in admin
-    partner_email = "partner@completed.org"
+  describe "create" do
+    let(:unverified_email) { "unverified@example.com" }
 
-    # Make request
-    assert_enqueued_emails(0) do
-      post admin_partners_path, params: { email: partner_email, organization_name: 'The Guardian' }
+    test "when there's an unverified existing publisher" do
+      publisher = Publisher.find_or_create_by(pending_email: unverified_email)
+
+      # Ensure it's a publisher
+      assert_equal publisher.role, Publisher::PUBLISHER
+
+      # Make request
+      assert_enqueued_emails(1) do
+        post admin_partners_path, params: { email: unverified_email, organization_name: 'The Guardian' }
+      end
+
+      # We assert that only one account is created
+      assert_empty Publisher.where(email: unverified_email)
+      # We made it a partner
+      assert Publisher.find_by(pending_email: unverified_email).partner?
     end
 
-    assert_equal "Email is already a partner", flash[:alert]
-    assert_redirected_to new_admin_partner_path(organization: 'The Guardian')
+    test "when there's a verified existing publisher" do
+      # ensure there are no previously existing entries in the database
+      Publisher.where(pending_email: unverified_email).destroy_all
+      publisher = Publisher.find_or_create_by(email: unverified_email)
+
+      # Ensure it's a publisher
+      assert_equal publisher.role, Publisher::PUBLISHER
+
+      # Make request
+      assert_enqueued_emails(1) do
+        post admin_partners_path, params: { email: unverified_email, organization_name: 'The Guardian' }
+      end
+
+      # We assert that only one account is created
+      assert_empty Publisher.where(pending_email: unverified_email)
+      # We made it a partner
+      assert Publisher.find_by(email: unverified_email).partner?
+    end
+
+    test "when there's a new partner" do
+      partner_email = 'partner@example.com'
+
+      # Make request
+      assert_enqueued_emails(1) do
+        post admin_partners_path, params: { email: partner_email, organization_name: 'The Guardian' }
+      end
+
+      # We made it a partner
+      assert Partner.find_by(email: partner_email).partner?
+    end
+
+    test "when the email is already a partner" do
+      partner_email = "partner@completed.org"
+
+      # Make request
+      assert_enqueued_emails(0) do
+        post admin_partners_path, params: { email: partner_email, organization_name: 'The Guardian' }
+      end
+
+      assert_equal "Email is already a partner", flash[:alert]
+      assert_redirected_to new_admin_partner_path(organization: 'The Guardian')
+    end
+
+    test 'when the organization is invalid' do
+      post admin_partners_path, params: { email: unverified_email, organization_name: 'not found' }
+      assert_equal "The organization specified does not exist", flash[:alert]
+      assert_template :new
+    end
+  end
+
+  describe 'update' do
+    describe 'when the organization is valid' do
+      it 'updates the partner' do
+        partner_id = publishers(:completed).id
+        patch admin_partner_path(partner_id), params: { organization_name: 'The Guardian' }
+
+        updated = Partner.find(partner_id)
+        assert updated.organization.name = 'The Guardian'
+        assert updated.partner?
+      end
+
+    end
+
+    describe 'when the organization is not valid' do
+      it 'shows edit page' do
+        patch admin_partner_path(@partner_id), params: { organization_name: '' }
+        assert_template :edit
+        assert_response :success
+      end
+    end
   end
 end

--- a/test/controllers/admin/partners_controller_test.rb
+++ b/test/controllers/admin/partners_controller_test.rb
@@ -30,7 +30,7 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
 
     # Make request
     assert_enqueued_emails(1) do
-      post admin_partners_path, params: { email: unverified_email }
+      post admin_partners_path, params: { email: unverified_email, organization_name: 'The Guardian' }
     end
 
     # We assert that only one account is created
@@ -53,7 +53,7 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
 
     # Make request
     assert_enqueued_emails(1) do
-      post admin_partners_path, params: { email: unverified_email }
+      post admin_partners_path, params: { email: unverified_email, organization_name: 'The Guardian' }
     end
 
     # We assert that only one account is created
@@ -69,7 +69,7 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
 
     # Make request
     assert_enqueued_emails(1) do
-      post admin_partners_path, params: { email: partner_email }
+      post admin_partners_path, params: { email: partner_email, organization_name: 'The Guardian' }
     end
 
     # We made it a partner
@@ -83,10 +83,10 @@ class Admin::PartnersControllerTest < ActionDispatch::IntegrationTest
 
     # Make request
     assert_enqueued_emails(0) do
-      post admin_partners_path, params: { email: partner_email }
+      post admin_partners_path, params: { email: partner_email, organization_name: 'The Guardian' }
     end
 
     assert_equal "Email is already a partner", flash[:alert]
-    assert_template :new
+    assert_redirected_to new_admin_partner_path(organization: 'The Guardian')
   end
 end

--- a/test/controllers/admin/publishers_controller_test.rb
+++ b/test/controllers/admin/publishers_controller_test.rb
@@ -27,31 +27,6 @@ class Admin::PublishersControllerTest < ActionDispatch::IntegrationTest
     }
   end
 
-  test "regular users cannot make partner" do
-    publisher = publishers(:completed)
-    sign_in publisher
-
-    assert_raises(CanCan::AccessDenied) {
-      post admin_publisher_make_partner_path(publisher.id)
-    }
-  end
-
-  test "admin can make publisher a parnter" do
-    admin = publishers(:admin)
-    sign_in admin
-
-    publisher = Publisher.where(role: Publisher::PUBLISHER).first
-
-    # Make request
-    assert_enqueued_emails(1) do
-      post admin_publisher_make_partner_path(publisher.id)
-    end
-
-    publisher.reload
-
-    assert publisher.partner?
-  end
-
   test "admin can access" do
     admin = publishers(:admin)
     sign_in admin

--- a/test/fixtures/organization_permissions.yml
+++ b/test/fixtures/organization_permissions.yml
@@ -1,0 +1,7 @@
+default_permission:
+  id: 1
+  organization_id: 'bde27753-2327-40dc-a1f8-06d3339f08cf'
+  uphold_wallet: true
+  offline_reporting: true
+  referral_codes: true
+

--- a/test/fixtures/organization_permissions.yml
+++ b/test/fixtures/organization_permissions.yml
@@ -2,6 +2,6 @@ default_permission:
   id: 1
   organization_id: 'bde27753-2327-40dc-a1f8-06d3339f08cf'
   uphold_wallet: true
-  offline_reporting: true
+  offline_reporting: false
   referral_codes: true
 

--- a/test/fixtures/organization_permissions.yml
+++ b/test/fixtures/organization_permissions.yml
@@ -1,5 +1,5 @@
 default_permission:
-  id: 1
+  id: 'a3854b33-afef-4411-9757-3460b9add43d'
   organization_id: 'bde27753-2327-40dc-a1f8-06d3339f08cf'
   uphold_wallet: true
   offline_reporting: false

--- a/test/fixtures/organizations.yml
+++ b/test/fixtures/organizations.yml
@@ -1,0 +1,3 @@
+default_organization:
+  id: 'bde27753-2327-40dc-a1f8-06d3339f08cf'
+  name: "The Guardian"

--- a/test/fixtures/publisher_status_updates.yml
+++ b/test/fixtures/publisher_status_updates.yml
@@ -21,3 +21,7 @@ onboarding:
 suspended:
   publisher: suspended
   status: "suspended"
+
+suspended_partner:
+  publisher: suspended_partner
+  status: "suspended"

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -62,8 +62,27 @@ completed_partner:
   two_factor_prompted_at: "<%= 1.day.ago %>"
   agreed_to_tos: "<%= 1.day.ago %>"
   visible: true
+  created_by: admin
   default_currency_confirmed_at: "<%= DateTime.now %>"
 
+suspended_partner:
+  email: "suspended_partner@completed.org"
+  name: "Suspended"
+  phone: "4159001421"
+  phone_normalized: "+14159001421"
+  authentication_token_expires_at: "<%= DateTime.now + PublisherTokenGenerator::TOKEN_TTL %>"
+  encrypted_authentication_token_iv: "<%= Base64.encode64(salt) %>"
+  encrypted_authentication_token: "<%= Publisher.encrypt_authentication_token(
+    "authentication_token",
+    key: Publisher.encryption_key,
+    iv: salt
+  ) %>"
+  role: 'partner'
+  two_factor_prompted_at: "<%= 1.day.ago %>"
+  created_by: admin
+  agreed_to_tos: "<%= 1.day.ago %>"
+  visible: true
+  default_currency_confirmed_at: "<%= DateTime.now %>"
 
 admin:
   email: "hello@brave.com"

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class MembershipTest < ActiveSupport::TestCase
   test "Membership test" do
     partner = partners(:default_partner)
-    organization = Organization.create(name: "Brave")
+    organization = Organization.create(name: "Brave", permissions: OrganizationPermission.new)
     membership = Membership.create(organization: organization, member: partner)
 
     assert_equal partner.membership, membership

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -1,17 +1,19 @@
 require "test_helper"
 
 class OrganizationTest < ActiveSupport::TestCase
-  test "must have a name and cannot be taken" do
-    organization = Organization.new(name: "Brave")
+  test "must have a name and permission and cannot be taken" do
+    permission = OrganizationPermission.new
+    organization = Organization.new(name: "Brave", permissions: permission)
     assert organization.save
     refute organization.errors.present?
 
-    organization = Organization.new(name: "Brave")
+    organization = Organization.new(name: "Brave", permissions: permission)
     refute organization.save
     assert organization.errors.present?
 
     organization = Organization.new
     refute organization.save
-    assert organization.errors.present?
+    assert organization.errors[:name].present?
+    assert organization.errors[:organization_permission].present?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,8 @@
 ENV["RAILS_ENV"] ||= "test"
+
+require 'simplecov'
+SimpleCov.start 'rails'
+
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 require "selenium/webdriver"
@@ -6,14 +10,12 @@ require "minitest/rails/capybara"
 require "webmock/minitest"
 require "chromedriver/helper"
 require 'sidekiq/testing'
-require 'simplecov'
 
 # https://github.com/rails/rails/issues/31324
 if ActionPack::VERSION::STRING >= "5.2.0"
   Minitest::Rails::TestUnit = Rails::TestUnit
 end
 
-SimpleCov.start 'rails'
 
 Sidekiq::Testing.fake!
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,11 +6,14 @@ require "minitest/rails/capybara"
 require "webmock/minitest"
 require "chromedriver/helper"
 require 'sidekiq/testing'
+require 'simplecov'
 
 # https://github.com/rails/rails/issues/31324
 if ActionPack::VERSION::STRING >= "5.2.0"
   Minitest::Rails::TestUnit = Rails::TestUnit
 end
+
+SimpleCov.start 'rails'
 
 Sidekiq::Testing.fake!
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,5 @@
 ENV["RAILS_ENV"] ||= "test"
 
-require 'simplecov'
-SimpleCov.start 'rails'
-
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 require "selenium/webdriver"


### PR DESCRIPTION
## Create Organization Permissions
An important thing to note is that this does not change anything that's on the user side. This is admin facing only. 

This additionally fleshes out the concept of an Organization by adding permissions to it.

## What was changed?

1. Added create/update workflows for organizations
1. Updated the "Make a partner" button in the publisher show page to direct to an update method on a partner. 
1. Partners now must be associated with an organization, and users can choose that relationship via drop down box.
1. Created link to organization from publishers show page
1. Added relationship to `Organization` so you don't have to type `organization.memberships.members` and now only have to type `organization.members`
1. Added relationship from Partner to organization so now you can simply type `partner.organization` to get the corresponding organization
1. Added a bunch of new tests to `partners_controller` and `organizations_controller` to increase test coverage to 100% 

Closes #1351
