### PR TITLE
Fix webpack deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem "u2f", "~> 1.0"
 # One-time passwords for 2fa
 gem "rotp", "~> 3.3"
 
-gem 'webpacker'
+gem 'webpacker', "~> 3.5"
 
 # pagination support for models
 gem "will_paginate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,7 +548,7 @@ DEPENDENCIES
   vcr
   web-console
   webmock (~> 3.0)
-  webpacker
+  webpacker (~> 3.5)
   will_paginate
   yt
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "ts-loader": "^5.3.0",
     "typescript": "^3.1.6"
   },
-  "engines": {
-    "yarn": ">= 0.25.2"
-  },
   "devDependencies": {
     "@rails/webpacker": "3.5",
     "hoek": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "test": "NODE_ENV=test karma start --single-run --browsers ChromeHeadless karma.conf.js"
   },
   "dependencies": {
+    "@rails/webpacker": "3.5",
     "@types/react": "^16.4.7",
     "@types/react-dom": "^16.0.6",
     "babel-preset-react": "^6.24.1",
@@ -20,7 +21,6 @@
     "typescript": "^3.1.6"
   },
   "devDependencies": {
-    "@rails/webpacker": "3.5",
     "hoek": "^6.0.1",
     "karma": "^3.1.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "ts-loader": "^5.3.0",
     "typescript": "^3.1.6"
   },
+  "engines": {
+    "yarn": ">= 0.25.2"
+  },
   "devDependencies": {
     "@rails/webpacker": "3.5",
     "hoek": "^6.0.1",


### PR DESCRIPTION
The webpacker version was moved to `devDependencies` which isn't installed. 

The only problem left is that the `webpack-dev-server` doesn't work. We can fix this by downgrading to an appropriate version. Or waiting until webpack v4 comes out.

```
~/r/publishers ❯❯❯ wds                                                                                                                                                                                                                   ✘ 130 
/Users/cory/repos/publishers/node_modules/webpack-dev-server/bin/webpack-dev-server.js:363
    throw err;
    ^

TypeError: Cannot destructure property `compile` of 'undefined' or 'null'.
    at addHooks (/Users/cory/repos/publishers/node_modules/webpack-dev-server/lib/Server.js:114:49)
    at new Server (/Users/cory/repos/publishers/node_modules/webpack-dev-server/lib/Server.js:127:5)
    at startDevServer (/Users/cory/repos/publishers/node_modules/webpack-dev-server/bin/webpack-dev-server.js:355:14)
    at processOptions (/Users/cory/repos/publishers/node_modules/webpack-dev-server/bin/webpack-dev-server.js:309:5)
    at Object.<anonymous> (/Users/cory/repos/publishers/node_modules/webpack-dev-server/bin/webpack-dev-server.js:424:1)
    at Module._compile (internal/modules/cjs/loader.js:707:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:718:10)
    at Module.load (internal/modules/cjs/loader.js:605:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:544:12)
    at Function.Module._load (internal/modules/cjs/loader.js:536:3)
~/r/publishers ❯❯❯                                                 
```

We can also always just install the version locally and have our stable version not include a working webpack-dev-server. Up to you guys