### PR TITLE
Move no-channels edge case logic from UI to server

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -423,7 +423,7 @@ class PublishersController < ApplicationController
   end
 
   def get_site_banner_data
-    prepare_site_banner_data()
+    prepare_site_banner_data
     default_site_banner_mode = current_publisher.default_site_banner_mode
     default_site_banner = {:id => current_publisher.default_site_banner_id, :name => "Default", :type => "Default"}
     channel_banners = current_publisher.channels.map { |channel| {id: channel.site_banner.id, name: channel.publication_title, type: channel.details_type} }
@@ -446,13 +446,12 @@ class PublishersController < ApplicationController
       default_site_banner = SiteBanner.new_helper(current_publisher.id, nil)
       current_publisher.update(default_site_banner_id: default_site_banner.id)
     end
-    current_publisher.channels.each do |channel|
-      if channel.site_banner.nil?
-        channel.site_banner = SiteBanner.new_helper(current_publisher.id, channel.id)
-      end
-    end
     if current_publisher.channels.length.zero?
       current_publisher.update(default_site_banner_mode: true)
+    else
+      current_publisher.channels.each do |channel|
+        channel.site_banner = SiteBanner.new_helper(current_publisher.id, channel.id) if channel.site_banner.nil?
+      end
     end
   end
 

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -423,7 +423,7 @@ class PublishersController < ApplicationController
   end
 
   def get_site_banner_data
-    create_site_banners()
+    prepare_site_banner_data()
     default_site_banner_mode = current_publisher.default_site_banner_mode
     default_site_banner = {:id => current_publisher.default_site_banner_id, :name => "Default", :type => "Default"}
     channel_banners = current_publisher.channels.map { |channel| {id: channel.site_banner.id, name: channel.publication_title, type: channel.details_type} }
@@ -441,7 +441,7 @@ class PublishersController < ApplicationController
     end
   end
 
-  def create_site_banners
+  def prepare_site_banner_data
     if current_publisher.default_site_banner_id.nil?
       default_site_banner = SiteBanner.new_helper(current_publisher.id, nil)
       current_publisher.update(default_site_banner_id: default_site_banner.id)
@@ -450,6 +450,9 @@ class PublishersController < ApplicationController
       if channel.site_banner.nil?
         channel.site_banner = SiteBanner.new_helper(current_publisher.id, channel.id)
       end
+    end
+    if current_publisher.channels.length.zero?
+      current_publisher.update(default_site_banner_mode: true)
     end
   end
 

--- a/app/javascript/packs/banner_editor.jsx
+++ b/app/javascript/packs/banner_editor.jsx
@@ -28,14 +28,6 @@ export default class BannerEditor extends React.Component {
   constructor(props) {
     super(props);
 
-    let defaultSiteBannerMode;
-    if(this.props.channelBanners.length === 0){
-      defaultSiteBannerMode = true;
-    }
-    else{
-      defaultSiteBannerMode = this.props.defaultSiteBannerMode
-    }
-
     this.state = {
       loading: true,
       title: 'Brave Rewards',
@@ -45,7 +37,7 @@ export default class BannerEditor extends React.Component {
       channelIndex: 0,
       channelBanners: this.props.channelBanners,
       defaultSiteBanner: this.props.defaultSiteBanner,
-      defaultSiteBannerMode: defaultSiteBannerMode,
+      defaultSiteBannerMode: this.props.defaultSiteBannerMode,
       scale: 1,
       linkSelection: false,
       linkOption: 'Youtube',


### PR DESCRIPTION
Improves the flow for users in the case where they have:

`Not added any channels but created a default banner`
`Then have added their first channels`

