### PR TITLE
Resolve Dnsruby::ServFail

### DIFF
--- a/app/services/site_channel_verifier.rb
+++ b/app/services/site_channel_verifier.rb
@@ -103,6 +103,9 @@ class SiteChannelVerifier < BaseService
     Rails.logger.debug("Dnsruby::NXDomain")
     @verification_details = "domain_not_found"
     return false
+  rescue Dnsruby::ServFail
+    @verification_details = "domain_not_found"
+    false
   end
 
   def verify_site_channel_public_file


### PR DESCRIPTION
Currently there are >23,000 events in Sentry for this error. Since we're aware of it, might as well capture it and at least do something about it 

https://sentry.io/brave-software/publishers-production-t2/issues/676099431/?query=is%3Aunresolved