### PR TITLE
Re-create versions table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem "omniauth-twitch"
 gem "omniauth-twitter"
 
 # Model record auditing
-gem "paper_trail", "~> 9.2.0"
+gem "paper_trail", "~> 10.1.0"
 
 # postgresql as database for Active Record
 gem "pg", "~> 0.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,11 +278,9 @@ GEM
       omniauth-oauth (~> 1.1)
       rack
     orm_adapter (0.5.0)
-    paper_trail (9.2.0)
-      activerecord (>= 4.2, < 5.3)
-      paper_trail-association_tracking (< 2)
+    paper_trail (10.1.0)
+      activerecord (>= 4.2, < 6.0)
       request_store (~> 1.1)
-    paper_trail-association_tracking (1.0.0)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -520,7 +518,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 0.5.2)
   omniauth-twitch
   omniauth-twitter
-  paper_trail (~> 9.2.0)
+  paper_trail (~> 10.1.0)
   pg (~> 0.18)
   phony_rails (~> 0.14)
   premailer-rails (~> 1.9.4)

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,0 @@
-PaperTrail.config.track_associations = false

--- a/db/migrate/20181231152108_drop_versions_table.rb
+++ b/db/migrate/20181231152108_drop_versions_table.rb
@@ -1,0 +1,9 @@
+class DropVersionsTable < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :versions
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20181231154124_recreate_versions.rb
+++ b/db/migrate/20181231154124_recreate_versions.rb
@@ -1,0 +1,36 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class RecreateVersions < ActiveRecord::Migration[5.2]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, {:null=>false}
+      t.uuid     :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_14_002051) do
+ActiveRecord::Schema.define(version: 2018_12_31_154124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -404,14 +404,13 @@ ActiveRecord::Schema.define(version: 2018_12_14_002051) do
     t.index ["publisher_id"], name: "index_u2f_registrations_on_publisher_id"
   end
 
-  create_table "versions", id: :serial, force: :cascade do |t|
+  create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
-    t.integer "item_id", null: false
+    t.uuid "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"
     t.datetime "created_at"
-    t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
PaperTrail was using a `Integer` id as a the type of `item_id`. Almost all of our tables have a UUID as the primary key. This was preventing versioning from working correctly.

With this PR I upgraded to PaperTrail 10 which extracted the associations gem which means we can remove our initializer.

Closes #1421