### PR TITLE
Ensure empty events and real events are sorted by date

### DIFF
--- a/app/services/promo/registration_stats_report_generator.rb
+++ b/app/services/promo/registration_stats_report_generator.rb
@@ -37,7 +37,8 @@ class Promo::RegistrationStatsReportGenerator < BaseService
               csv << [
                 combined["referral_code"],
                 combined[PromoRegistration::COUNTRY],
-                combined["ymd"], combined[PromoRegistration::RETRIEVALS],
+                combined["ymd"],
+                combined[PromoRegistration::RETRIEVALS],
                 combined[PromoRegistration::FIRST_RUNS],
                 combined[PromoRegistration::FINALIZED]
               ]
@@ -57,7 +58,8 @@ class Promo::RegistrationStatsReportGenerator < BaseService
             combined = combine_events(events_for_referral_code_for_interval, referral_code, nil, date)
             csv << [
               combined["referral_code"],
-              combined["ymd"], combined[PromoRegistration::RETRIEVALS],
+              combined["ymd"],
+              combined[PromoRegistration::RETRIEVALS],
               combined[PromoRegistration::FIRST_RUNS],
               combined[PromoRegistration::FINALIZED]
             ]
@@ -87,19 +89,24 @@ class Promo::RegistrationStatsReportGenerator < BaseService
       combined[PromoRegistration::FIRST_RUNS] += event[PromoRegistration::FIRST_RUNS]
       combined[PromoRegistration::FINALIZED] += event[PromoRegistration::FINALIZED]
     end
+
     combined
   end
 
   def group_events_by_country(events)
-     events.group_by { |event|
+    events.sort_by { |event|
+      event["country"]
+    }.group_by { |event|
       event[PromoRegistration::COUNTRY]
     }
   end
 
   def group_events_by_referral_code(events)
-    events.group_by do |event|
+    events.sort_by { |event| 
       event["referral_code"]
-    end
+    }.group_by { |event|
+      event["referral_code"]
+    }
   end
 
   def fetch_stats
@@ -117,6 +124,7 @@ class Promo::RegistrationStatsReportGenerator < BaseService
   end
 
   def group_events_by_date(events)
+    events = events.sort_by { |event| event["ymd"].to_date }
     events_by_interval = events.group_by do |event|
       case @reporting_interval
       when PromoRegistration::DAILY
@@ -163,7 +171,6 @@ class Promo::RegistrationStatsReportGenerator < BaseService
         end
       end
     end
-
     events + events_with_no_activity
   end
 end

--- a/test/services/promo/registration_stats_report_generator_test.rb
+++ b/test/services/promo/registration_stats_report_generator_test.rb
@@ -265,10 +265,10 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
         event_type_column_header(PromoRegistration::RETRIEVALS),
                           event_type_column_header(PromoRegistration::FIRST_RUNS),
                           event_type_column_header(PromoRegistration::FINALIZED)],
-      ["ABC123", "United States", "2018-12-01", "6", "6", "6"],
       ["ABC123", "Mexico", "2018-12-01", "6", "6", "6"],
+      ["ABC123", "United States", "2018-12-01", "6", "6", "6"],
+      ["DEF456", "Mexico", "2018-12-01", "6", "6", "6"],
       ["DEF456", "United States", "2018-12-01", "6", "6", "6"],
-      ["DEF456", "Mexico", "2018-12-01", "6", "6", "6"]
     ]
 
     assert_equal expected, CSV.parse(csv)
@@ -294,18 +294,18 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
         event_type_column_header(PromoRegistration::RETRIEVALS),
                           event_type_column_header(PromoRegistration::FIRST_RUNS),
                           event_type_column_header(PromoRegistration::FINALIZED)],
-      ["ABC123", "United States", "2018-10-29", "1", "1", "1",],
-      ["ABC123", "United States", "2018-11-05", "1", "1", "1",],
-      ["ABC123", "United States", "2018-11-12", "1", "1", "1",],
       ["ABC123", "Mexico", "2018-10-29", "1", "1", "1",],
       ["ABC123", "Mexico", "2018-11-05", "1", "1", "1",],
       ["ABC123", "Mexico", "2018-11-12", "1", "1", "1",],
-      ["DEF456", "United States", "2018-10-29", "1", "1", "1",],
-      ["DEF456", "United States", "2018-11-05", "1", "1", "1",],
-      ["DEF456", "United States", "2018-11-12", "1", "1", "1",],
+      ["ABC123", "United States", "2018-10-29", "1", "1", "1",],
+      ["ABC123", "United States", "2018-11-05", "1", "1", "1",],
+      ["ABC123", "United States", "2018-11-12", "1", "1", "1",],
       ["DEF456", "Mexico", "2018-10-29", "1", "1", "1",],
       ["DEF456", "Mexico", "2018-11-05", "1", "1", "1",],
       ["DEF456", "Mexico", "2018-11-12", "1", "1", "1",],
+      ["DEF456", "United States", "2018-10-29", "1", "1", "1",],
+      ["DEF456", "United States", "2018-11-05", "1", "1", "1",],
+      ["DEF456", "United States", "2018-11-12", "1", "1", "1",],
     ]
 
     assert_equal expected, CSV.parse(csv)


### PR DESCRIPTION
This is a small change that ensures empty events and real events, when combined, are still sorted by date.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
