### PR TITLE
Log additional attributes in channel_registrar

### DIFF
--- a/app/services/promo/publisher_channels_registrar.rb
+++ b/app/services/promo/publisher_channels_registrar.rb
@@ -32,6 +32,7 @@ class Promo::PublisherChannelsRegistrar < BaseApiClient
       rescue ActiveRecord::RecordInvalid => e
         require "sentry-raven"
         Rails.logger.error("PublisherChannelsRegistrar perform: #{referral_code} channel_id: #{channel.id} exception: #{e}")
+        Raven.extra_context referral_code: referral_code
         Raven.capture_exception("Promo::PublisherChannelsRegistrar #perform error: #{e}")
       end
     end


### PR DESCRIPTION
We're currently seeing the error "Validation failed: Referral code has already been taken"

In order to determine what is occurring I propose we add a little bit more logging and capture these exceptions