### PR TITLE
Use empty string for string comparison instead of nil when grouping geo reports by date

### DIFF
--- a/app/services/promo/registration_stats_report_generator.rb
+++ b/app/services/promo/registration_stats_report_generator.rb
@@ -95,7 +95,7 @@ class Promo::RegistrationStatsReportGenerator < BaseService
 
   def group_events_by_country(events)
     events.sort_by { |event|
-      event["country"]
+      event[PromoRegistration::COUNTRY] || ""
     }.group_by { |event|
       event[PromoRegistration::COUNTRY]
     }


### PR DESCRIPTION
Resolves https://sentry.io/brave-software/publishers-staging/issues/829492362/?query=is%3Aunresolved

Tested locally with copy of promo staging db.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
