### PR TITLE
Give EnqueuePublishersForPayoutJob default arguments

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bundle exec puma -C config/puma.rb -e ${RACK_ENV:-development}
 worker: bundle exec sidekiq -C config/sidekiq.yml -e ${RACK_ENV:-development}
+heavyworker: bundle exec sidekiq -C config/heavy_sidekiq.yml -e ${RACK_ENV:-development}
 webpacker: ./bin/webpack-dev-server

--- a/app/jobs/enqueue_publishers_for_payout_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_job.rb
@@ -2,7 +2,7 @@
 class EnqueuePublishersForPayoutJob < ApplicationJob
   queue_as :scheduler
 
-  def perform(should_send_notifications:, final:, payout_report_id: "", publisher_ids: [])
+  def perform(should_send_notifications: true, final: true, payout_report_id: "", publisher_ids: [])
     Rails.logger.info("Enqueuing publishers for payment.")
 
     if payout_report_id.present?


### PR DESCRIPTION
This way the job can be run on the time schedule set in sidekiq.yml.

Also add the heavy worker to the dev Procfile.

Resolves https://sentry.io/brave-software/publishers-production-t2/issues/827898110/?query=is%3Aunresolved

I tested this locally and ensured that payout reports set off manually do not send notifications if the `should_send_notifications` box isn't checked.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
