### PR TITLE
Ensure emails are sent to publishers with only contributions but no wallet address

### DIFF
--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -29,11 +29,9 @@ class PayoutReportPublisherIncluder < BaseService
 
     @publisher.channels.verified.each do |channel|
       probi = wallet.channel_balances[channel.details.channel_identifier].probi # probi = balance - fee
+      publisher_has_unsettled_balance = probi.positive? ? true : publisher_has_unsettled_balance
       next unless probi.positive? && @publisher.uphold_verified? && wallet.address.present?
-
-      publisher_has_unsettled_balance = true
       fee_probi = wallet.channel_balances[channel.details.channel_identifier].fee # fee = balance - probi
-
       PotentialPayment.create(payout_report_id: @payout_report.id,
                               name: "#{channel.publication_title}",
                               amount: "#{probi}",


### PR DESCRIPTION
Fix #1510 
Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:

Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
