### PR TITLE
Do not update payout report json when downloading payout reports

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -10,7 +10,6 @@ class Admin::PayoutReportsController < AdminController
 
   def download    
     @payout_report = PayoutReport.find(params[:id])
-    @payout_report.update_report_contents
     contents = assign_authority(@payout_report.contents)
     send_data contents,
       filename: "payout-#{@payout_report.created_at.strftime("%FT%H-%M-%S")}",

--- a/test/controllers/admin/payout_reports_controller_test.rb
+++ b/test/controllers/admin/payout_reports_controller_test.rb
@@ -116,6 +116,7 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
 
     # Ensure authority is the admin's email when the file is downloaded
     payout_report = PayoutReport.all.order(created_at: :desc).first
+    payout_report.update_report_contents
     get download_admin_payout_report_path(payout_report)
     JSON.parse(response.body).each { |channel| assert_equal channel["authority"], admin.email}
   end


### PR DESCRIPTION
Refreshing the payout report json is a long process that likely to time out.  This should be done via the 'refresh payout report json' button on the admin dashboard.

When https://github.com/brave-intl/publishers/pull/1409/files was implemented, I forgot to remove this line.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
