### PR TITLE
Update docker compose set up to work with bat-ratios

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -21,6 +21,8 @@ services:
       - BASIC_AUTH_PASSWORD
       - BASIC_AUTH_USER
       - BAT_MEDIUM_URL
+      - BAT_RATIOS_URL
+      - BAT_RATIOS_TOKEN
       - BAT_REDDIT_URL
       - BAT_ROCKETCHAT_URL
       - BAT_TWITTER_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - UPHOLD_CLIENT_SECRET
       - UPHOLD_ENVIRONMENT
       - DATABASE_URL=postgres://eyeshade:password@eyeshade-postgres/eyeshade
+      - BAT_RATIOS_TOKEN
     depends_on:
       - mongo
       - redis
@@ -75,6 +76,7 @@ services:
       - UPHOLD_CLIENT_SECRET
       - UPHOLD_ENVIRONMENT
       - DATABASE_URL=postgres://eyeshade:password@eyeshade-postgres/eyeshade
+      - BAT_RATIOS_TOKEN
     depends_on:
       - mongo
       - redis


### PR DESCRIPTION
Sometime recently the rates service within the bat-ledger repo was moved to it's own service, but we haven't yet updated our docker-compose implementation which depends on these rates.  You might get an error "config.currency.access_token: undefined" as a result.

This PR adds those environment variables into the docker-compose setup.  Since bat-ratios has not been dockerized, we need to use the staging url for development.  This will require environment variables that you will need to get from another dev.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
