### PR TITLE
Separate publisher notification from payout report generation

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -22,10 +22,13 @@ class Admin::PayoutReportsController < AdminController
   end
 
   def create
-    EnqueuePublishersForPayoutJob.perform_later(final: params[:final].present?,
-                                                should_send_notifications: params[:should_send_notifications].present?)
-    
+    EnqueuePublishersForPayoutJob.perform_later(final: params[:final].present?)
     redirect_to admin_payout_reports_path, flash: { notice: "Your payout report is being generated, check back soon." }
+  end
+
+  def notify
+    EnqueuePublishersForPayoutNotificationJob.perform_later
+    redirect_to admin_payout_reports_path, flash: { notice: "Sending notifications to publishers with disconnected wallets." }
   end
 
   private

--- a/app/jobs/enqueue_publishers_for_payout_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_job.rb
@@ -2,7 +2,7 @@
 class EnqueuePublishersForPayoutJob < ApplicationJob
   queue_as :scheduler
 
-  def perform(should_send_notifications: true, final: true, payout_report_id: "", publisher_ids: [])
+  def perform(should_send_notifications: false, final: true, payout_report_id: "", publisher_ids: [])
     Rails.logger.info("Enqueuing publishers for payment.")
 
     if payout_report_id.present?

--- a/app/jobs/enqueue_publishers_for_payout_notification_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_notification_job.rb
@@ -1,0 +1,20 @@
+class EnqueuePublishersForPayoutNotificationJob < ApplicationJob
+  queue_as :scheduler
+
+  def perform(publisher_ids: [])
+    Rails.logger.info("Enqueuing publishers for payment notifications.")
+
+    if publisher_ids.present?
+      publishers = Publisher.where(id: publisher_ids)
+    else
+      publishers = Publisher.with_verified_channel.not_suspended
+    end
+    
+    publishers.find_each do |publisher|
+      IncludePublisherInPayoutReportJob.perform_later(payout_report_id: nil,
+                                                      publisher_id: publisher.id,
+                                                      should_send_notifications: true)
+    end
+    Rails.logger.info("Enuqueued #{publishers.count} publishers for payment notifications.")
+  end
+end

--- a/app/jobs/include_publisher_in_payout_report_job.rb
+++ b/app/jobs/include_publisher_in_payout_report_job.rb
@@ -2,7 +2,15 @@ class IncludePublisherInPayoutReportJob < ApplicationJob
   queue_as :scheduler
   
   def perform(payout_report_id:, publisher_id:, should_send_notifications:)
-    payout_report = PayoutReport.find(payout_report_id)
+
+    # If payout_report_id is not present, we only want to send notifications
+    # not create payments
+    if payout_report_id.present?
+      payout_report = PayoutReport.find(payout_report_id) 
+    else
+      payout_report = nil
+    end
+
     publisher = Publisher.find(publisher_id)
     PayoutReportPublisherIncluder.new(publisher: publisher,
                                       payout_report: payout_report,

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -60,7 +60,11 @@ class PayoutReportPublisherIncluder < BaseService
   end
 
   def create_payment?
-    @publisher.uphold_verified? && @publisher.wallet.address.present? && @publisher.wallet.is_a_member?
+    @publisher.uphold_verified? && @publisher.wallet.address.present? && @publisher.wallet.is_a_member? && !should_only_notify?
+  end
+
+  def should_only_notify?
+    @payout_report.nil?
   end
 end
 

--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -39,14 +39,11 @@ hr
 
 h3 Generate Payout Report
 = form_tag admin_payout_reports_path do
-  .form_group
-    = check_box_tag :should_send_notifications
-    = label_tag "Send notifications (email publishers who aren't verified with or are not connected to Uphold)"
-  .form_group
     = check_box_tag :final
     = label_tag "Final (this report will be used for settlement)"
-  .actions
     = submit_tag("Generate", class: "btn btn-primary")
 
-
+= form_tag notify_admin_payout_reports_path do
+    = label_tag "Send notifications to publishers"
+    = submit_tag("Notify publishers", class: "btn btn-primary")
 = will_paginate @payout_reports

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,9 @@ Rails.application.routes.draw do
     resources :faq_categories, except: [:show]
     resources :faqs, except: [:show]
     resources :payout_reports, only: %i(index show create) do
+      collection do
+        post :notify
+      end
       member do
         get :download
         patch :refresh

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -43,6 +43,10 @@
     cron: "50 2 * * *"
     description: "Refreshes the redis cache for eyeshade stats information"
     queue: transactional
+  EnqueuePublishersForPayoutNotification:
+    cron: "0 0 23 * *"
+    description: "Notifies publishers their wallet is disconnected on the 23rd of every month."
+    queue: scheduler
   EnqueuePublishersForPayoutJob:
     cron: "0 0 1 * *"
     description: "Generates the list of unsettled transactions on the first of every month"

--- a/test/controllers/admin/payout_reports_controller_test.rb
+++ b/test/controllers/admin/payout_reports_controller_test.rb
@@ -111,7 +111,7 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
 
     # Create the non blank payout report
     perform_enqueued_jobs do
-      post admin_payout_reports_path(final: true, should_send_notifications: true)
+      post admin_payout_reports_path(final: true)
     end
 
     # Ensure authority is the admin's email when the file is downloaded
@@ -161,9 +161,9 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
       to_return(status: 200, body: balance_response)
 
     assert_difference("PayoutReport.count", 1) do
-      assert_difference("ActionMailer::Base.deliveries.count", 1) do
+      assert_difference("ActionMailer::Base.deliveries.count", 0) do
         perform_enqueued_jobs do
-          post admin_payout_reports_path(final: true, should_send_notifications: true)
+          post admin_payout_reports_path(final: true, should_send_notifications: true) 
         end
       end
     end
@@ -176,6 +176,54 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
 
     assert_enqueued_with(job: UpdatePayoutReportContentsJob) do
       patch refresh_admin_payout_report_path(payout_report.id)
+    end
+  end
+
+  test "#notify sends emails to" do
+    Rails.application.secrets[:api_eyeshade_offline] = false
+    admin = publishers(:admin)
+    publisher = publishers(:uphold_connected)
+    delete_publishers_except([admin.id, publisher.id])
+    sign_in admin
+
+    # Stub disconnected /wallet response
+    wallet_response = {}.to_json
+
+    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+      to_return(status: 200, body: wallet_response, headers: {})
+
+    # Stub /balances response
+    balance_response = [
+      {
+        "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+        "account_type" => "owner",
+        "balance" => "20.00"
+      },
+      {
+        "account_id" => "uphold_connected.org",
+        "account_type" => "channel",
+        "balance" => "20.00"
+      },
+      {
+        "account_id" => "twitch#channel:ucTw",
+        "account_type" => "channel",
+        "balance" => "20.00"
+      },      {
+        "account_id" => "twitter#channel:def456",
+        "account_type" => "channel",
+        "balance" => "20.00"
+      }
+    ].to_json
+
+    stub_request(:get, "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23channel:ucTw&account=twitter%23channel:def456").
+      to_return(status: 200, body: balance_response)
+
+    assert_difference("PayoutReport.count", 0) do # Ensure no payout report is created
+      assert_difference("ActionMailer::Base.deliveries.count", 1) do # ensure notification is sent
+        perform_enqueued_jobs do
+          post notify_admin_payout_reports_path
+        end
+      end
     end
   end
 end

--- a/test/jobs/enqueue_publishers_for_payout_notification_job_test.rb
+++ b/test/jobs/enqueue_publishers_for_payout_notification_job_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class EnqueuePublishersForPayoutNotificationJobTest < ActiveJob::TestCase
+  test "launches 1 job per publisher" do
+    assert_difference -> { PayoutReport.count } do
+      assert_enqueued_jobs(Publisher.with_verified_channel.not_suspended.count) do
+        EnqueuePublishersForPayoutJob.perform_now()
+      end
+    end
+  end
+  
+  test "can supply a list of publisher ids" do
+    publishers = Publisher.where.not(email: "priscilla@potentiallypaid.org")
+
+    assert_enqueued_jobs(publishers.count) do
+      EnqueuePublishersForPayoutJob.perform_now(publisher_ids: publishers.pluck(:id))
+    end
+  end
+end

--- a/test/services/payout_report_publisher_includer_test.rb
+++ b/test/services/payout_report_publisher_includer_test.rb
@@ -306,4 +306,56 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
                                         should_send_notifications: true).perform
     end
   end
+
+  test "only sends notifications if payout_id is false" do
+    Rails.application.secrets[:api_eyeshade_offline] = false
+    Rails.application.secrets[:fee_rate] = 0.05
+
+    payout_report = PayoutReport.create(fee_rate: 0.05)
+
+    # Clear database
+    publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
+    delete_publishers_except([publisher.id])
+
+    # Stub disconnected /wallet response
+    wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", "isMember": false}}.to_json
+
+    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+      to_return(status: 200, body: wallet_response, headers: {})
+
+    # Stub /balances response
+    balance_response = [
+      {
+        "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+        "account_type" => "owner",
+        "balance" => "0.00"
+      },
+      {
+        "account_id" => "uphold_connected.org",
+        "account_type" => "channel",
+        "balance" => "20.00"
+      },
+      {
+        "account_id" => "twitch#author:ucTw",
+        "account_type" => "channel",
+        "balance" => "20.00"
+      },      {
+        "account_id" => "twitter#channel:def456",
+        "account_type" => "channel",
+        "balance" => "20.00"
+      }
+    ].to_json
+
+    stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
+      to_return(status: 200, body: balance_response)
+
+    # Ensure is emails sent
+    assert_difference -> { PotentialPayment.count }, 0 do
+      assert_enqueued_jobs(2) do
+        PayoutReportPublisherIncluder.new(payout_report: nil,
+                                          publisher: publisher,
+                                          should_send_notifications: true).perform
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1528 

This pr creates a new job, EnqueuePublishersForPayoutNotification, which only sends notifications and does not create potential payments.  EnqueuePublisherForPayout no longer sends notifications.

EnqueuePublishersForPayoutNotification will run on the 23rd of every month, giving publishers about a week to reconnect before the payout report is created on the 1st.

Admins can also trigger notifications manually:

![image](https://user-images.githubusercontent.com/12549658/51128084-0cc25700-17f5-11e9-8fca-330c89dcfac9.png)


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
