### PR TITLE
Wordpress URL

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -696,10 +696,10 @@ en:
       verify_dns_record: Verify via a DNS record.
       heading: Hello. It looks like you are using WordPress!
       install_plugin_html: |
-        <p><strong><a href="https://wordpress.org/plugins/brave-rewards-verification/" class="download-link">Install the plugin</a></strong>
+        <p><strong><a href="https://wordpress.org/plugins/brave-payments-verification/" class="download-link">Install the plugin</a></strong>
         that makes the entire process a snap.</p>
-        <p class="note-text">(Plugin location: <a href="https://wordpress.org/plugins/brave-rewards-verification/">
-        https://wordpress.org/plugins/brave-rewards-verification/</a>)</p>
+        <p class="note-text">(Plugin location: <a href="https://wordpress.org/plugins/brave-payments-verification/">
+        https://wordpress.org/plugins/brave-payments-verification/</a>)</p>
       verification_token: Copy the verification code below into the plugin.
       wordpress_token: "Verification code:"
       verify: Once the code is pasted in, click verify.


### PR DESCRIPTION
This answer on Stack Overflow says that even if you rename a plugin the url will stay the same. https://stackoverflow.com/a/33139685

Until we test https://github.com/brave-intl/brave-payments-verification/pull/13 we can have the URLs be the previous ones