### PR TITLE
Expose Uphold Status and ID

### DIFF
--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -96,6 +96,7 @@ class Admin::PublishersController < AdminController
   end
 
   def is_a_uuid?(uuid)
+    # https://stackoverflow.com/questions/47508829/validate-uuid-string-in-ruby-rails
     uuid_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     uuid_regex.match?(uuid.to_s.downcase)
   end

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -7,12 +7,14 @@ class Admin::PublishersController < AdminController
     @publishers = if sort_column&.to_sym&.in? Publisher::ADVANCED_SORTABLE_COLUMNS
                     Publisher.advanced_sort(sort_column.to_sym, sort_direction)
                   else
-                    Publisher.order(sanitize_sql_for_order("#{sort_column} #{sort_direction}"))
+                    Publisher.order(sanitize_sql_for_order("#{sort_column} #{sort_direction} NULLS LAST"))
                   end
 
     if params[:q].present?
       # Returns an ActiveRecord::Relation of publishers for pagination
-      search_query = "%#{remove_prefix_if_necessary(params[:q])}%"
+      search_query = remove_prefix_if_necessary(params[:q])
+      search_query = "%#{search_query}%" unless is_a_uuid?(search_query)
+
       @publishers = @publishers.where(search_sql, search_query: search_query)
     end
 
@@ -91,5 +93,10 @@ class Admin::PublishersController < AdminController
 
   def sortable_columns
     [:last_sign_in_at, :created_at, Publisher::VERIFIED_CHANNEL_COUNT]
+  end
+
+  def is_a_uuid?(uuid)
+    uuid_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    uuid_regex.match?(uuid.to_s.downcase)
   end
 end

--- a/app/controllers/concerns/search.rb
+++ b/app/controllers/concerns/search.rb
@@ -51,6 +51,7 @@ module Search
         WHERE publishers.email ILIKE :search_query
               OR publishers.name ILIKE :search_query
               OR publishers.id::text = :search_query
+              OR publishers.uphold_id::text = :search_query
       )
     }
   end

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -137,6 +137,14 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
+  def uphold_member_restricted(publisher)
+    @publisher = publisher
+    mail(
+      to: @publisher.email,
+      subject: default_i18n_subject
+    )
+  end
+
   def statement_ready(publisher_statement)
     @publisher_statement = publisher_statement
     @publisher = publisher_statement.publisher

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -157,7 +157,13 @@ class Publisher < ApplicationRecord
       if self.default_currency.present? && self.default_currency != @_wallet.default_currency
         UploadDefaultCurrencyJob.perform_later(publisher_id: self.id)
       end
+
+      if @_wallet.uphold_id.present? && @_wallet.uphold_id != self.uphold_id
+        self.uphold_id = wallet.uphold_id
+        save!
+      end
     end
+
     @_wallet
   end
 

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -53,6 +53,12 @@ class PayoutReportPublisherIncluder < BaseService
         PublisherMailer.wallet_not_connected(@publisher).deliver_later
       end
 
+      # eyeshade omits the wallet address if the status is not ok
+      # means that the transaction limits have been exceeded 
+      if wallet.is_a_member? && wallet.address.blank?
+        PublisherMailer.uphold_member_restricted(@publisher).deliver_later
+      end
+
       if @publisher.uphold_verified? && wallet.not_a_member?
         Rails.logger.info("Publisher #{@publisher.owner_identifier} will not be paid for their balance because they are not a verified member on Uphold")
         PublisherMailer.uphold_kyc_incomplete(@publisher).deliver_later

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -10,7 +10,8 @@ class PayoutReportPublisherIncluder < BaseService
     publisher_has_unsettled_balance = false
 
     wallet = @publisher.wallet
-    return if wallet.nil?
+    # If the wallet has been blocked from uphold's terms of service. In this state users are unable to login or access uphold.
+    return if wallet.nil? || wallet.blocked?
 
     probi = wallet.channel_balances[@publisher.owner_identifier].probi_before_fees # probi = balance
     if probi.positive?
@@ -47,12 +48,12 @@ class PayoutReportPublisherIncluder < BaseService
 
     # Notify publishers that have money waiting, but will not will not receive funds
     if publisher_has_unsettled_balance && @should_send_notifications
-      if !@publisher.uphold_verified? || wallet.address.blank?
+      if !@publisher.uphold_verified? || wallet.status.nil?
         Rails.logger.info("Publisher #{@publisher.owner_identifier} will not be paid for their balance because they are disconnected from Uphold.")
         PublisherMailer.wallet_not_connected(@publisher).deliver_later
       end
 
-      if @publisher.uphold_verified? && wallet.address.present? && wallet.not_a_member?
+      if @publisher.uphold_verified? && wallet.not_a_member?
         Rails.logger.info("Publisher #{@publisher.owner_identifier} will not be paid for their balance because they are not a verified member on Uphold")
         PublisherMailer.uphold_kyc_incomplete(@publisher).deliver_later
       end

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -67,7 +67,7 @@ class PayoutReportPublisherIncluder < BaseService
   end
 
   def create_payment?
-    @publisher.uphold_verified? && @publisher.wallet.address.present? && @publisher.wallet.is_a_member? && !should_only_notify?
+    @publisher.uphold_verified? && @publisher.wallet.authorized? && @publisher.wallet.is_a_member? && !should_only_notify?
   end
 
   def should_only_notify?

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -54,13 +54,13 @@ class PayoutReportPublisherIncluder < BaseService
       end
 
       # eyeshade omits the wallet address if the status is not ok
-      # means that the transaction limits have been exceeded 
+      # means that the transaction limits have been exceeded
       if wallet.is_a_member? && wallet.address.blank?
         PublisherMailer.uphold_member_restricted(@publisher).deliver_later
       end
 
       # The wallet status has to exist because otherwise their wallet is just not connected
-      if @publisher.uphold_verified? && wallet.not_a_member? && wallet.status.present?
+      if @publisher.uphold_verified? && wallet.status.present? && wallet.not_a_member?
         Rails.logger.info("Publisher #{@publisher.owner_identifier} will not be paid for their balance because they are not a verified member on Uphold")
         PublisherMailer.uphold_kyc_incomplete(@publisher).deliver_later
       end

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -59,7 +59,8 @@ class PayoutReportPublisherIncluder < BaseService
         PublisherMailer.uphold_member_restricted(@publisher).deliver_later
       end
 
-      if @publisher.uphold_verified? && wallet.not_a_member?
+      # The wallet status has to exist because otherwise their wallet is just not connected
+      if @publisher.uphold_verified? && wallet.not_a_member? && wallet.status.present?
         Rails.logger.info("Publisher #{@publisher.owner_identifier} will not be paid for their balance because they are not a verified member on Uphold")
         PublisherMailer.uphold_kyc_incomplete(@publisher).deliver_later
       end

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -18,11 +18,15 @@
           .db-field = "Status:"
           .db-value = publisher_status(@publisher)
         .db-info-row
-          .db-field = "Uphold verified:"
+          .db-field = "Uphold once connected:"
           .db-value = @publisher.uphold_verified?
         .db-info-row
           .db-field = "Uphold authorized:"
           .db-value = @publisher.wallet.authorized?
+        - if @publisher.wallet.status.present?
+          .db-info-row
+            .db-field = "Uphold status:"
+            .db-value = @publisher.wallet.status
         .db-info-row
           .db-field = "Uphold widget enabled?"
           .db-value = @publisher.excluded_from_payout? ? "No" : "Yes"

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -27,6 +27,10 @@
           .db-info-row
             .db-field = "Uphold status:"
             .db-value = @publisher.wallet.status
+        -if @publisher.uphold_id.present?
+          .db-info-row
+            .db-field = "Uphold id:"
+            .db-value = link_to @publisher.uphold_id, admin_publishers_path(q: @publisher.uphold_id)
         .db-info-row
           .db-field = "Uphold widget enabled?"
           .db-value = @publisher.excluded_from_payout? ? "No" : "Yes"

--- a/app/views/publisher_mailer/uphold_member_restricted.html.slim
+++ b/app/views/publisher_mailer/uphold_member_restricted.html.slim
@@ -1,0 +1,11 @@
+p.salutation= t "publisher_mailer.shared.salutation", name: @publisher.name
+
+== t ".body_html"
+
+p= t "publisher_mailer.shared.signature"
+
+hr
+
+p.hint
+  span.attribute= "#{t("publisher_mailer.shared.contact_help")}: "
+  = mail_to(Rails.application.secrets[:support_email])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,11 +294,11 @@ en:
         <p>Your earnings will be paid out in the next payment cycle after you verify your identity with Uphold. In the meantime, your earnings will still be held safely in your account. We’re sorry for the inconvenience and delays this may cause. Thank you for being a Brave Creator and bearing with us as we improve the integrity of the payout system. Learn more about this new requirement <a href="https://support.uphold.com/hc/en-us/articles/202887565-What-are-the-benefits-of-becoming-a-verified-member-of-Uphold-">here</a>.</p>
         <p>Thank you,</p>
     uphold_member_restricted:
-      subject: Please check Uphold Accoun
+      subject: Please check Uphold Account
       body_html: |
         <p>Thank you for being a Brave creator.</p>
         <p>
-          We've noticed that your Uphold account is not able to receive funds. Plus check your Uphold account status and ensure that there are no actionable items and that you are within the transaction limit guidelines.  
+          We've noticed that your Uphold account is not able to receive funds. Please check your Uphold account status to ensure that there are no actionable items and that you are within the transaction limit guidelines.
         </p>
         <p>In the meantime, your earnings will still be held safely in your account. We’re sorry for the inconvenience and delays this may cause.</p>
         <p>Thank you,</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,6 +293,15 @@ en:
         </p>
         <p>Your earnings will be paid out in the next payment cycle after you verify your identity with Uphold. In the meantime, your earnings will still be held safely in your account. We’re sorry for the inconvenience and delays this may cause. Thank you for being a Brave Creator and bearing with us as we improve the integrity of the payout system. Learn more about this new requirement <a href="https://support.uphold.com/hc/en-us/articles/202887565-What-are-the-benefits-of-becoming-a-verified-member-of-Uphold-">here</a>.</p>
         <p>Thank you,</p>
+    uphold_member_restricted:
+      subject: Please check Uphold Accoun
+      body_html: |
+        <p>Thank you for being a Brave creator.</p>
+        <p>
+          We've noticed that your Uphold account is not able to receive funds. Plus check your Uphold account status and ensure that there are no actionable items and that you are within the transaction limit guidelines.  
+        </p>
+        <p>In the meantime, your earnings will still be held safely in your account. We’re sorry for the inconvenience and delays this may cause.</p>
+        <p>Thank you,</p>
     verification_done:
       subject: "%{publication_title} Publisher website verified"
       title: Verification complete

--- a/db/migrate/20190116001651_add_uphold_id_to_publisher.rb
+++ b/db/migrate/20190116001651_add_uphold_id_to_publisher.rb
@@ -1,0 +1,5 @@
+class AddUpholdIdToPublisher < ActiveRecord::Migration[5.2]
+  def change
+    add_column :publishers, :uphold_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_14_002051) do
+ActiveRecord::Schema.define(version: 2019_01_16_001651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -310,6 +310,7 @@ ActiveRecord::Schema.define(version: 2018_12_14_002051) do
     t.uuid "created_by_id"
     t.uuid "default_site_banner_id"
     t.boolean "default_site_banner_mode", default: false, null: false
+    t.uuid "uphold_id"
     t.index "lower((email)::text)", name: "index_publishers_on_lower_email", unique: true
     t.index ["created_at"], name: "index_publishers_on_created_at"
     t.index ["created_by_id"], name: "index_publishers_on_created_by_id"

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -12,6 +12,7 @@ module Eyeshade
                 :contribution_balance,
                 :channel_balances,
                 :rates,
+                :status,
                 :last_settlement_balance,
                 :last_settlement_date
 
@@ -25,6 +26,7 @@ module Eyeshade
       @possible_currencies = details_json["possibleCurrencies"] || []
       @address = details_json["address"] || ""
       @is_member = details_json["isMember"] || false
+      @status  = details_json["status"]
 
       status_json = wallet_json["status"] || {}
       @action = status_json["action"]
@@ -47,6 +49,10 @@ module Eyeshade
 
     def authorized?
       @authorized == true
+    end
+
+    def blocked? 
+      @status == 'blocked'
     end
 
     def is_a_member?

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -56,7 +56,7 @@ module Eyeshade
     end
 
     def is_a_member?
-      @is_member
+      @status.present? && @is_member
     end
 
     def not_a_member?

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -14,7 +14,8 @@ module Eyeshade
                 :rates,
                 :status,
                 :last_settlement_balance,
-                :last_settlement_date
+                :last_settlement_date,
+                :uphold_id
 
     def initialize(wallet_json:, channel_json:)
       details_json = wallet_json["wallet"] || {}
@@ -27,6 +28,7 @@ module Eyeshade
       @address = details_json["address"] || ""
       @is_member = details_json["isMember"] || false
       @status  = details_json["status"]
+      @uphold_id = details_json["id"]
 
       status_json = wallet_json["status"] || {}
       @action = status_json["action"]
@@ -51,7 +53,7 @@ module Eyeshade
       @authorized == true
     end
 
-    def blocked? 
+    def blocked?
       @status == 'blocked'
     end
 

--- a/test/controllers/admin/payout_reports_controller_test.rb
+++ b/test/controllers/admin/payout_reports_controller_test.rb
@@ -163,7 +163,7 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
     assert_difference("PayoutReport.count", 1) do
       assert_difference("ActionMailer::Base.deliveries.count", 0) do
         perform_enqueued_jobs do
-          post admin_payout_reports_path(final: true, should_send_notifications: true) 
+          post admin_payout_reports_path(final: true, should_send_notifications: true)
         end
       end
     end

--- a/test/services/payout_report_publisher_includer_test.rb
+++ b/test/services/payout_report_publisher_includer_test.rb
@@ -3,7 +3,8 @@ require "webmock/minitest"
 
 class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
   before do
-    ActionMailer::Base.deliveries.clear 
+    ActionMailer::Base.deliveries.clear
+    PotentialPayment.destroy_all
     @prev_offline = Rails.application.secrets[:api_eyeshade_offline]
     @prev_fee_rate = Rails.application.secrets[:fee_rate]
   end
@@ -15,31 +16,102 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
 
   api_eyeshade_base_uri = Rails.application.secrets[:api_eyeshade_base_uri]
 
-  def delete_publishers_except(publisher_ids)
-    PublisherNote.destroy_all
-    Publisher.all.each do |publisher|
-      publisher.delete unless publisher_ids.include?(publisher.id)
+  describe "when publisher does not have a verified channel" do
+    let(:publisher) { publishers(:fake1) }
+
+    let(:subject) do
+      perform_enqueued_jobs do
+        PayoutReportPublisherIncluder.new(payout_report: PayoutReport.create,
+                                          publisher: publisher,
+                                          should_send_notifications: true).perform
+      end
+    end
+
+    before { subject }
+
+    it "does not generate a report" do
+      assert_equal 0, PotentialPayment.count
     end
   end
 
-  describe 'when publisher does not have a verified channel' do
-    it 'does not generate a report' do
+  describe "when publisher is suspended" do
+    let(:publisher) { publishers(:suspended) }
 
+    let(:subject) do
+      perform_enqueued_jobs do
+        PayoutReportPublisherIncluder.new(payout_report: PayoutReport.create,
+                                          publisher: publisher,
+                                          should_send_notifications: true).perform
+      end
+    end
+
+    before { subject }
+
+    it "does not generate a report" do
+      assert_equal 0, PotentialPayment.count
     end
   end
 
-  describe 'when publisher is suspended' do
-    it 'does not generate a report' do
+  describe "when user is blocked from uphold" do
+    let(:publisher) { publishers(:uphold_connected) }
+    let(:wallet_response) do
+      { wallet: { authorized: false, status: "blocked", "isMember": false } }
+    end
+
+    let(:subject) do
+      perform_enqueued_jobs do
+        PayoutReportPublisherIncluder.new(payout_report: @payout_report,
+                                          publisher: publisher,
+                                          should_send_notifications: should_send_notifications).perform
+      end
+    end
+
+    let(:balance_response) do
+      [
+        {
+          account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+          account_type: "owner",
+          balance: "20.00"
+        },
+        {
+          account_id: "uphold_connected.org",
+          account_type: "channel",
+          balance: "20.00"
+        },
+        {
+          account_id: "twitch#author:ucTw",
+          account_type: "channel",
+          balance: "20.00"
+        }, {
+          account_id: "twitter#channel:def456",
+          account_type: "channel",
+          balance: "20.00"
+        }
+      ]
+    end
+
+    before do
+      Rails.application.secrets[:fee_rate] = 0.05
+      @payout_report = PayoutReport.create(fee_rate: 0.05)
+
+      account_ids = balance_response.map { |x| "account=#{x[:account_id]}" }.join("&")
+      stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+        .to_return(status: 200, body: wallet_response.to_json, headers: {})
+      stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}")
+        .to_return(status: 200, body: balance_response.to_json)
+    end
+
+    it "does not generate a report" do
+      assert_equal 0, PotentialPayment.count
     end
   end
 
-  describe 'publisher has a verified channel' do
+  describe "publisher has a verified channel" do
     before do
       Rails.application.secrets[:api_eyeshade_offline] = false
-      PotentialPayment.destroy_all
     end
 
-    describe 'when not uphold verified' do
+    describe "when not uphold verified" do
       let(:publisher) { publishers(:youtube_initial) }
       let(:should_send_notifications) { true }
       let(:wallet_response) { {} }
@@ -70,26 +142,26 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
       before do
         account_ids = balance_response.map { |x| "account=#{x[:account_id]}" }.join("&")
 
-        stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-          to_return(status: 200, body: wallet_response.to_json, headers: {})
+        stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+          .to_return(status: 200, body: wallet_response.to_json, headers: {})
 
-        stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{account_ids}").
-          to_return(status: 200, body: balance_response.to_json)
+        stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}")
+          .to_return(status: 200, body: balance_response.to_json)
 
         subject
       end
 
-      it 'is not included in the report' do
+      it "is not included in the report" do
         assert_equal 0, PotentialPayment.count
       end
 
-      it 'sends email to connect uphold' do
+      it "sends email to connect uphold" do
         email = ActionMailer::Base.deliveries.last
-        assert_equal email&.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
+        assert_equal email&.subject, I18n.t("publisher_mailer.wallet_not_connected.subject")
       end
     end
 
-    describe 'when uphold verified' do
+    describe "when uphold verified" do
       let(:publisher) { publishers(:uphold_connected) }
       let(:subject) do
         perform_enqueued_jobs do
@@ -99,9 +171,9 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
         end
       end
 
-        # All members should have addresses 
-      describe 'with address' do
-        describe 'with balance' do
+      # All members should have addresses
+      describe "with address" do
+        describe "with balance" do
           let(:balance_response) do
             [
               {
@@ -118,7 +190,7 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
                 account_id: "twitch#author:ucTw",
                 account_type: "channel",
                 balance: "20.00"
-              },      {
+              }, {
                 account_id: "twitter#channel:def456",
                 account_type: "channel",
                 balance: "20.00"
@@ -131,133 +203,151 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
             @payout_report = PayoutReport.create(fee_rate: 0.05)
 
             account_ids = balance_response.map { |x| "account=#{x[:account_id]}" }.join("&")
-            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}").
-              to_return(status: 200, body: balance_response.to_json)
+            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}")
+              .to_return(status: 200, body: balance_response.to_json)
           end
 
           # Edge case when user has reached uphold transaction limits
-          describe 'when is a member and restricted' do
+          describe "when is a member and restricted" do
             let(:wallet_response) do
-              { wallet: { authorized: false, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": true } }
+              { wallet: { authorized: false, status: "restricted", "isMember": true } }
             end
 
             before do
-              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-                to_return(status: 200, body: wallet_response.to_json, headers: {})
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+                .to_return(status: 200, body: wallet_response.to_json, headers: {})
             end
 
-            describe 'when should_send_notifications is false' do
+            describe "when should_send_notifications is false" do
               let(:should_send_notifications) { false }
 
               before do
                 subject
               end
-              
-              it 'does not include in report' do
+
+              it "does not include in report" do
                 assert_equal 0, PotentialPayment.count
-                assert_equal 0, payout_report.amount
+                assert_equal 0, @payout_report.amount
               end
 
-              it 'sends no emails' do
-                assert_empty ActionMailer::Base.deliveries 
+              it "sends no emails" do
+                assert_empty ActionMailer::Base.deliveries
               end
             end
 
-            describe 'when should_send_notifications is true' do
+            describe "when should_send_notifications is true" do
               let(:should_send_notifications) { true }
 
               before do
                 subject
               end
-              
-              it 'does not include in report' do
+
+              it "does not include in report" do
                 assert_equal 0, PotentialPayment.count
                 assert_equal 0, @payout_report.amount
               end
 
-              it 'sends an email notifying restricted' do
+              it "sends an email notifying restricted" do
                 assert ActionMailer::Base.deliveries.present?
               end
             end
           end
 
-          describe 'when is a member' do
+          describe "when is a member" do
             let(:wallet_response) do
               { wallet: { authorized: true, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "ok", "isMember": true } }
             end
 
-            describe 'when should_send_notifications is false' do
+            describe "when should_send_notifications is false" do
               let(:should_send_notifications) { false }
 
-              before do
-                stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-                  to_return(status: 200, body: wallet_response.to_json, headers: {})
+              describe "when payout_report exists" do
+                before do
+                  stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+                    .to_return(status: 200, body: wallet_response.to_json, headers: {})
 
-                subject
-              end
+                  subject
+                end
 
-              it 'is included in payout report' do
-                assert_equal @payout_report.num_payments, publisher.channels.count + 1
-                assert_equal @payout_report.amount, (80 * BigDecimal('1e18') - ((60 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i
-                assert_equal @payout_report.fees, (60 * BigDecimal('1e18') * @payout_report.fee_rate).to_i
-              end
+                it "is included in payout report" do
+                  assert_equal @payout_report.num_payments, publisher.channels.count + 1
+                  assert_equal @payout_report.amount, (80 * BigDecimal("1e18") - ((60 * BigDecimal("1e18")) * @payout_report.fee_rate)).to_i
+                  assert_equal @payout_report.fees, (60 * BigDecimal("1e18") * @payout_report.fee_rate).to_i
+                end
 
-              it 'has the correct content' do
-                PotentialPayment.where(payout_report_id: @payout_report.id).each do |potential_payment|
-                  assert_equal potential_payment.address, wallet_response[:wallet][:address]
-                  assert_equal potential_payment.publisher_id,  publisher.id.to_s
-                  if potential_payment.kind == PotentialPayment::CONTRIBUTION
-                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18') - ((20 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i.to_s
-                  elsif potential_payment.kind == PotentialPayment::REFERRAL
-                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18')).to_i.to_s
+                it "has the correct content" do
+                  PotentialPayment.where(payout_report_id: @payout_report.id).each do |potential_payment|
+                    assert_equal potential_payment.address, wallet_response[:wallet][:address]
+                    assert_equal potential_payment.publisher_id, publisher.id.to_s
+                    if potential_payment.kind == PotentialPayment::CONTRIBUTION
+                      assert_equal potential_payment.amount, (20 * BigDecimal("1e18") - ((20 * BigDecimal("1e18")) * @payout_report.fee_rate)).to_i.to_s
+                    elsif potential_payment.kind == PotentialPayment::REFERRAL
+                      assert_equal potential_payment.amount, (20 * BigDecimal("1e18")).to_i.to_s
+                    end
                   end
                 end
-              end
 
-              it 'does not create any extra payments' do
-                assert_difference -> { PotentialPayment.count }, 0 do
-                  PayoutReportPublisherIncluder.new(payout_report: @payout_report,
-                                                    publisher: publisher,
-                                                    should_send_notifications: should_send_notifications).perform
+                it "does not create any extra payments" do
+                  assert_difference -> { PotentialPayment.count }, 0 do
+                    PayoutReportPublisherIncluder.new(payout_report: @payout_report,
+                                                      publisher: publisher,
+                                                      should_send_notifications: should_send_notifications).perform
+                  end
+                end
+
+                it "sends no emails" do
+                  assert_empty ActionMailer::Base.deliveries
                 end
               end
 
-              it 'sends no emails' do
-                assert_empty ActionMailer::Base.deliveries 
+              describe "when payout_report is nil" do
+                before do
+                  perform_enqueued_jobs do
+                    PayoutReportPublisherIncluder.new(payout_report: nil,
+                                                      publisher: publisher,
+                                                      should_send_notifications: should_send_notifications).perform
+                  end
+                end
+
+                it "does not add to any potentional payments" do
+                  assert_equal 0, PotentialPayment.count
+                end
               end
             end
 
-            describe 'when should_send_notifications is true' do
+            describe "when should_send_notifications is true" do
               let(:should_send_notifications) { true }
 
               before do
+                stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+                  .to_return(status: 200, body: wallet_response.to_json, headers: {})
                 subject
               end
 
               # This is the happy path, the publisher is in the happy state and does not need any additional contact.
-              it 'sends no emails' do
-                assert_empty ActionMailer::Base.deliveries 
+              it "sends no emails" do
+                assert_empty ActionMailer::Base.deliveries
               end
 
-              it 'is not included in payout report' do
+              it "is not included in payout report" do
                 assert_equal @payout_report.num_payments, publisher.channels.count + 1
-                assert_equal @payout_report.amount, (80 * BigDecimal('1e18') - ((60 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i
-                assert_equal @payout_report.fees, (60 * BigDecimal('1e18') * @payout_report.fee_rate).to_i
+                assert_equal @payout_report.amount, (80 * BigDecimal("1e18") - ((60 * BigDecimal("1e18")) * @payout_report.fee_rate)).to_i
+                assert_equal @payout_report.fees, (60 * BigDecimal("1e18") * @payout_report.fee_rate).to_i
               end
 
-              it 'has the correct content' do
+              it "has the correct content" do
                 PotentialPayment.where(payout_report_id: @payout_report.id).each do |potential_payment|
                   assert_equal potential_payment.address, wallet_response[:wallet][:address]
                   assert_equal potential_payment.publisher_id, publisher.id.to_s
                   if potential_payment.kind == PotentialPayment::CONTRIBUTION
-                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18') - ((20 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i.to_s
+                    assert_equal potential_payment.amount, (20 * BigDecimal("1e18") - ((20 * BigDecimal("1e18")) * @payout_report.fee_rate)).to_i.to_s
                   elsif potential_payment.kind == PotentialPayment::REFERRAL
-                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18')).to_i.to_s
+                    assert_equal potential_payment.amount, (20 * BigDecimal("1e18")).to_i.to_s
                   end
                 end
               end
 
-              it 'does not create any extra payments' do
+              it "does not create any extra payments" do
                 assert_difference -> { PotentialPayment.count }, 0 do
                   PayoutReportPublisherIncluder.new(payout_report: @payout_report,
                                                     publisher: publisher,
@@ -267,56 +357,55 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
             end
           end
 
-          describe 'not a member' do
-            # Possible that user  
+          describe "not a member" do
+            # Possible that user
             let(:wallet_response) do
               { wallet: { authorized: false, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": false } }
             end
 
             before do
-              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-                to_return(status: 200, body: wallet_response.to_json, headers: {})
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+                .to_return(status: 200, body: wallet_response.to_json, headers: {})
             end
-            
-            describe 'should_send_notifications is true' do
+
+            describe "should_send_notifications is true" do
               let(:should_send_notifications) { true }
 
               before do
                 subject
               end
 
-              it 'does not include in report' do
+              it "does not include in report" do
                 assert_equal 0, PotentialPayment.count
                 assert_equal 0, @payout_report.amount
               end
 
-              it 'receives KYC email' do
+              it "receives KYC email" do
                 email = ActionMailer::Base.deliveries.last
-                assert_equal email.subject, I18n.t('publisher_mailer.uphold_kyc_incomplete.subject')
+                assert_equal email.subject, I18n.t("publisher_mailer.uphold_kyc_incomplete.subject")
               end
             end
 
-            describe 'should_send_notifications is false' do
+            describe "should_send_notifications is false" do
               let(:should_send_notifications) { false }
 
               before do
                 subject
               end
 
-              it 'does not include in report' do
+              it "does not include in report" do
                 assert_equal 0, PotentialPayment.count
                 assert_equal 0, @payout_report.amount
               end
 
-              it 'recieves no emails' do
-                assert_empty ActionMailer::Base.deliveries 
+              it "recieves no emails" do
+                assert_empty ActionMailer::Base.deliveries
               end
             end
           end
-
         end
 
-        describe 'without balance' do
+        describe "without balance" do
           let(:balance_response) { [] }
           let(:should_send_notifications) { true }
 
@@ -324,25 +413,26 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
             Rails.application.secrets[:fee_rate] = 0.05
             @payout_report = PayoutReport.create(fee_rate: 0.05)
 
-            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?").
-              to_return(status: 200, body: balance_response.to_json)
+            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?")
+              .to_return(status: 200, body: balance_response.to_json)
 
             subject
           end
 
-          it 'is not included in the payout report' do 
+          it "is not included in the payout report" do
             assert_equal 0, PotentialPayment.count
+
             assert_equal 0, @payout_report.amount
           end
 
-          it 'recieves no emails' do
-            assert_empty ActionMailer::Base.deliveries 
+          it "recieves no emails" do
+            assert_empty ActionMailer::Base.deliveries
           end
         end
       end
 
-      describe 'without address' do
-        describe 'with balance' do
+      describe "without address" do
+        describe "with balance" do
           let(:balance_response) do
             [
               {
@@ -359,7 +449,7 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
                 account_id: "twitch#author:ucTw",
                 account_type: "channel",
                 balance: "20.00"
-              },      {
+              }, {
                 account_id: "twitter#channel:def456",
                 account_type: "channel",
                 balance: "20.00"
@@ -371,438 +461,99 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
             Rails.application.secrets[:fee_rate] = 0.05
             @payout_report = PayoutReport.create(fee_rate: 0.05)
             account_ids = balance_response.map { |x| "account=#{x[:account_id]}" }.join("&")
-            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}").
-              to_return(status: 200, body: balance_response.to_json)
+            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}")
+              .to_return(status: 200, body: balance_response.to_json)
           end
 
           # Technically this path would only be possible if the user was restricted
           #  eyeshade omits the wallet address if the status is not ok
-          describe 'is a member' do 
+          describe "is a member" do
             let(:wallet_response) do
               { wallet: { authorized: false, status: "restricted", "isMember": true } }
             end
 
             before do
-              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-                to_return(status: 200, body: wallet_response.to_json, headers: {})
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+                .to_return(status: 200, body: wallet_response.to_json, headers: {})
             end
 
-            describe 'should_send_notifications is true' do
+            describe "should_send_notifications is true" do
               let(:should_send_notifications) { true }
 
               before do
                 subject
               end
 
-              it 'is not included in the report' do
+              it "is not included in the report" do
                 assert_equal 0, PotentialPayment.count
                 assert_equal 0, @payout_report.amount
               end
 
-              it 'recieves an email to check uphold' do
+              it "recieves an email to check uphold" do
                 email = ActionMailer::Base.deliveries.last
-                assert_equal email&.subject, I18n.t('publisher_mailer.uphold_member_restricted.subject')
+                assert_equal email&.subject, I18n.t("publisher_mailer.uphold_member_restricted.subject")
               end
             end
 
-            describe 'should_send_notifications is false' do
+            describe "should_send_notifications is false" do
               let(:should_send_notifications) { false }
 
               before do
                 subject
               end
 
-              it 'is not included in the report' do
+              it "is not included in the report" do
                 assert_equal 0, PotentialPayment.count
                 assert_equal 0, @payout_report.amount
               end
 
-              it 'does not recieve any emails' do
-                assert_empty ActionMailer::Base.deliveries 
+              it "does not recieve any emails" do
+                assert_empty ActionMailer::Base.deliveries
               end
             end
           end
 
-          describe 'not a member' do
+          describe "not a member" do
             let(:wallet_response) do
-              { wallet: { authorized: false, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": false } }
+              { wallet: { authorized: false, status: "restricted", "isMember": false } }
             end
 
             before do
-              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-                to_return(status: 200, body: wallet_response.to_json, headers: {})
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/)
+                .to_return(status: 200, body: wallet_response.to_json, headers: {})
             end
 
-            describe 'should_send_notifications is true' do
+            describe "should_send_notifications is true" do
               let(:should_send_notifications) { true }
               before { subject }
 
-              it 'is not included in report' do
+              it "is not included in report" do
                 assert_equal 0, PotentialPayment.count
                 assert_equal 0, @payout_report.amount
               end
 
-              it 'recieves an email to connect uphold' do
+              it "recieves an email to KYC uphold" do
                 email = ActionMailer::Base.deliveries.last
-                assert_equal email&.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
+                assert_equal email&.subject, I18n.t("publisher_mailer.uphold_kyc_incomplete.subject")
               end
             end
 
-            describe 'should_send_notifications is false' do
+            describe "should_send_notifications is false" do
               let(:should_send_notifications) { false }
               before { subject }
 
-              it 'is not included in report' do
+              it "is not included in report" do
                 assert_equal 0, PotentialPayment.count
                 assert_equal 0, @payout_report.amount
               end
 
-              it 'does not receive any emails ' do
-                assert_empty ActionMailer::Base.deliveries 
+              it "does not receive any emails " do
+                assert_empty ActionMailer::Base.deliveries
               end
             end
-
           end
         end
       end
     end
   end
-
-  # test "publisher with verified channel that is not uphold verified is not included in the report" do
-  #   Rails.application.secrets[:api_eyeshade_offline] = false
-
-  #   payout_report = PayoutReport.create()
-  #   prev_num_potential_payments = PotentialPayment.count
-
-  #   # Clear database
-  #   publisher = publishers(:youtube_initial) # has verified channel, is not uphold connected
-  #   delete_publishers_except([publisher.id])
-
-  #   # Stub /wallet reponse
-  #   wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2"}}.to_json
-
-  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-  #     to_return(status: 200, body: wallet_response, headers: {})
-
-  #   # Stub /balances response
-  #   balance_response = [
-  #     {
-  #       "account_id" => "publishers#uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77",
-  #       "account_type" => "owner",
-  #       "balance" => "500.00"
-  #     },
-  #     {
-  #       "account_id" => "youtube#channel:",
-  #       "account_type" => "channel",
-  #       "balance" => "500.00"
-  #     }
-  #   ].to_json
-
-  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77&account=youtube%23channel:").
-  #     to_return(status: 200, body: balance_response)
-
-  #   perform_enqueued_jobs do
-  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
-  #                                       publisher: publisher,
-  #                                       should_send_notifications: true).perform
-  #   end
-
-  #   email = ActionMailer::Base.deliveries.last
-
-  #   # Ensure the correct email is sent
-  #   assert_equal email.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
-
-  #   # Ensure empty payout & payments
-  #   assert_equal PotentialPayment.count, prev_num_potential_payments
-  #   assert_equal payout_report.amount, 0
-  # end
-
-  # test "publisher with verified channel that is uphold verified but not a member is not included in the report" do
-  #   Rails.application.secrets[:api_eyeshade_offline] = false
-
-  #   payout_report = PayoutReport.create()
-  #   prev_num_potential_payments = PotentialPayment.count
-
-  #   # Clear database
-  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-
-  #   delete_publishers_except([publisher.id])
-
-  #   # Stub /wallet reponse
-  #   wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", "status": "restricted", "isMember": false}}.to_json
-
-  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-  #     to_return(status: 200, body: wallet_response, headers: {})
-
-  #   # Stub /balances response
-  #   balance_response = [
-  #     {
-  #       "account_id" => publisher.owner_identifier,
-  #       "account_type" => "owner",
-  #       "balance" => "500.00"
-  #     },
-  #     {
-  #       "account_id" => "youtube#channel:",
-  #       "account_type" => "channel",
-  #       "balance" => "500.00"
-  #     }
-  #   ].to_json
-
-  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=#{URI.escape(publisher.owner_identifier)}}&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-  #     to_return(status: 200, body: balance_response)
-
-  #   perform_enqueued_jobs do
-  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
-  #                                       publisher: publisher,
-  #                                       should_send_notifications: true).perform
-  #   end
-
-  #   email = ActionMailer::Base.deliveries.last
-
-  #   # Ensure the correct email is sent
-  #   assert_equal email.subject, I18n.t('publisher_mailer.uphold_kyc_incomplete.subject')
-
-  #   # Ensure empty payout & payments
-  #   assert_equal PotentialPayment.count, prev_num_potential_payments
-  #   assert_equal payout_report.amount, 0
-  # end
-
-  # test "uphold verified publisher with verified channel with no address supplied is not included in the report, and is sent email" do
-  #   Rails.application.secrets[:api_eyeshade_offline] = false
-
-  #   payout_report = PayoutReport.create()
-  #   prev_num_potential_payments = PotentialPayment.count
-
-  #   # Clear database
-  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-
-  #   delete_publishers_except([publisher.id])
-
-  #   # Stub disconnected /wallet response
-  #   wallet_response = {}.to_json
-
-  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-  #     to_return(status: 200, body: wallet_response, headers: {})
-
-  #   # Stub /balances response
-  #   balance_response = [
-  #     {
-  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-  #       "account_type" => "owner",
-  #       "balance" => "20.00"
-  #     },
-  #     {
-  #       "account_id" => "uphold_connected.org",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },
-  #     {
-  #       "account_id" => "twitch#channel:ucTw",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },      {
-  #       "account_id" => "twitter#channel:def456",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     }
-  #   ].to_json
-
-  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-  #     to_return(status: 200, body: balance_response)
-
-  #   # Deliver the email
-  #   perform_enqueued_jobs do
-  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
-  #                                       publisher: publisher,
-  #                                       should_send_notifications: true).perform
-  #   end
-
-  #   email = ActionMailer::Base.deliveries.last
-
-  #   # Ensure the correct email is sent
-  #   assert_equal email.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
-
-  #   # Ensure payout is empty and no potential payment was created
-  #   assert_equal PotentialPayment.count, prev_num_potential_payments
-
-  #   assert_equal payout_report.num_payments, 0
-  #   assert_equal payout_report.amount, 0
-  # end
-
-  # test "uphold verified publisher with verified channel with address and balance is included in payout report" do
-  #   Rails.application.secrets[:api_eyeshade_offline] = false
-  #   Rails.application.secrets[:fee_rate] = 0.05
-
-  #   payout_report = PayoutReport.create(fee_rate: 0.05)
-
-  #   # Clear database
-  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-  #   delete_publishers_except([publisher.id])
-
-  #   # Stub disconnected /wallet response
-  #   wallet_response = {"wallet" => {address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "ok", isMember: true}}.to_json
-
-  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-  #     to_return(status: 200, body: wallet_response, headers: {})
-
-  #   # Stub /balances response
-  #   balance_response = [
-  #     {
-  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-  #       "account_type" => "owner",
-  #       "balance" => "20.00"
-  #     },
-  #     {
-  #       "account_id" => "uphold_connected.org",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },
-  #     {
-  #       "account_id" => "twitch#author:ucTw",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },      {
-  #       "account_id" => "twitter#channel:def456",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     }
-  #   ].to_json
-
-  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-  #     to_return(status: 200, body: balance_response)
-
-  #   # Ensure no emails sent
-  #   assert_enqueued_jobs(1) do
-  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
-  #                                       publisher: publisher,
-  #                                       should_send_notifications: true).perform
-  #   end
-
-  #   # Ensure data is correct
-  #   assert_equal payout_report.num_payments, publisher.channels.count + 1
-  #   assert_equal payout_report.amount, (80 * BigDecimal('1e18') - ((60 * BigDecimal.new('1e18')) * payout_report.fee_rate)).to_i
-  #   assert_equal payout_report.fees, (60 * BigDecimal('1e18') * payout_report.fee_rate).to_i
-
-  #   # Ensure individual potential payment data is correct
-  #   PotentialPayment.where(payout_report_id: payout_report.id).each do |potential_payment|
-  #     assert_equal potential_payment.address, JSON.parse(wallet_response)["wallet"]["address"]
-  #     assert_equal potential_payment.publisher_id, "#{publisher.id}"
-  #     if potential_payment.kind == PotentialPayment::CONTRIBUTION
-  #       assert_equal potential_payment.amount, (20 * BigDecimal('1e18') - ((20 * BigDecimal.new('1e18')) * payout_report.fee_rate)).to_i.to_s
-  #     elsif potential_payment.kind == PotentialPayment::REFERRAL
-  #       assert_equal potential_payment.amount, (20 * BigDecimal('1e18')).to_i.to_s
-  #     end
-  #   end
-
-  #   # Run the includer again with same parameters and ensure no extra potential payments
-  #   # were created (idempotence)
-
-  #   assert_difference -> { PotentialPayment.count }, 0 do
-  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
-  #                                       publisher: publisher,
-  #                                       should_send_notifications: true).perform
-  #   end
-  # end
-
-  # test "publisher with only a contribution balance but no wallet address receives an email" do
-  #   Rails.application.secrets[:api_eyeshade_offline] = false
-  #   Rails.application.secrets[:fee_rate] = 0.05
-
-  #   payout_report = PayoutReport.create(fee_rate: 0.05)
-
-  #   # Clear database
-  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-  #   delete_publishers_except([publisher.id])
-
-  #   # Stub disconnected /wallet response
-  #   wallet_response = {"wallet" => {"address" => ""}}.to_json
-
-  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-  #     to_return(status: 200, body: wallet_response, headers: {})
-
-  #   # Stub /balances response
-  #   balance_response = [
-  #     {
-  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-  #       "account_type" => "owner",
-  #       "balance" => "0.00"
-  #     },
-  #     {
-  #       "account_id" => "uphold_connected.org",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },
-  #     {
-  #       "account_id" => "twitch#author:ucTw",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },      {
-  #       "account_id" => "twitter#channel:def456",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     }
-  #   ].to_json
-
-  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-  #     to_return(status: 200, body: balance_response)
-
-  #   # Ensure is emails sent
-  #   assert_enqueued_jobs(2) do
-  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
-  #                                       publisher: publisher,
-  #                                       should_send_notifications: true).perform
-  #   end
-  # end
-
-  # test "only sends notifications if payout_id is false" do
-  #   Rails.application.secrets[:api_eyeshade_offline] = false
-  #   Rails.application.secrets[:fee_rate] = 0.05
-
-  #   payout_report = PayoutReport.create(fee_rate: 0.05)
-
-  #   # Clear database
-  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-  #   delete_publishers_except([publisher.id])
-
-  #   # Stub disconnected /wallet response
-  #   wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": false}}.to_json
-
-  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-  #     to_return(status: 200, body: wallet_response, headers: {})
-
-  #   # Stub /balances response
-  #   balance_response = [
-  #     {
-  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-  #       "account_type" => "owner",
-  #       "balance" => "0.00"
-  #     },
-  #     {
-  #       "account_id" => "uphold_connected.org",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },
-  #     {
-  #       "account_id" => "twitch#author:ucTw",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     },      {
-  #       "account_id" => "twitter#channel:def456",
-  #       "account_type" => "channel",
-  #       "balance" => "20.00"
-  #     }
-  #   ].to_json
-
-  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-  #     to_return(status: 200, body: balance_response)
-
-  #   # Ensure is emails sent
-  #   assert_difference -> { PotentialPayment.count }, 0 do
-  #     assert_enqueued_jobs(2) do
-  #       PayoutReportPublisherIncluder.new(payout_report: nil,
-  #                                         publisher: publisher,
-  #                                         should_send_notifications: true).perform
-  #     end
-  #   end
-  # end
 end

--- a/test/services/payout_report_publisher_includer_test.rb
+++ b/test/services/payout_report_publisher_includer_test.rb
@@ -3,6 +3,7 @@ require "webmock/minitest"
 
 class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
   before do
+    ActionMailer::Base.deliveries.clear 
     @prev_offline = Rails.application.secrets[:api_eyeshade_offline]
     @prev_fee_rate = Rails.application.secrets[:fee_rate]
   end
@@ -21,341 +22,787 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
     end
   end
 
-  test "publisher with verified channel that is not uphold verified is not included in the report" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
+  describe 'when publisher does not have a verified channel' do
+    it 'does not generate a report' do
 
-    payout_report = PayoutReport.create()
-    prev_num_potential_payments = PotentialPayment.count
-
-    # Clear database
-    publisher = publishers(:youtube_initial) # has verified channel, is not uphold connected
-    delete_publishers_except([publisher.id])
-
-    # Stub /wallet reponse
-    wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2"}}.to_json
-
-    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-      to_return(status: 200, body: wallet_response, headers: {})
-
-    # Stub /balances response
-    balance_response = [
-      {
-        "account_id" => "publishers#uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77",
-        "account_type" => "owner",
-        "balance" => "500.00"
-      },
-      {
-        "account_id" => "youtube#channel:",
-        "account_type" => "channel",
-        "balance" => "500.00"
-      }
-    ].to_json
-
-    stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77&account=youtube%23channel:").
-      to_return(status: 200, body: balance_response)
-
-    perform_enqueued_jobs do
-      PayoutReportPublisherIncluder.new(payout_report: payout_report,
-                                        publisher: publisher,
-                                        should_send_notifications: true).perform
     end
-
-    email = ActionMailer::Base.deliveries.last
-
-    # Ensure the correct email is sent
-    assert_equal email.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
-
-    # Ensure empty payout & payments
-    assert_equal PotentialPayment.count, prev_num_potential_payments
-    assert_equal payout_report.amount, 0
   end
 
-  test "publisher with verified channel that is uphold verified but not a member is not included in the report" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
-
-    payout_report = PayoutReport.create()
-    prev_num_potential_payments = PotentialPayment.count
-
-    # Clear database
-    publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-
-    delete_publishers_except([publisher.id])
-
-    # Stub /wallet reponse
-    wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", "isMember": false}}.to_json
-
-    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-      to_return(status: 200, body: wallet_response, headers: {})
-
-    # Stub /balances response
-    balance_response = [
-      {
-        "account_id" => publisher.owner_identifier,
-        "account_type" => "owner",
-        "balance" => "500.00"
-      },
-      {
-        "account_id" => "youtube#channel:",
-        "account_type" => "channel",
-        "balance" => "500.00"
-      }
-    ].to_json
-
-    stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=#{URI.escape(publisher.owner_identifier)}}&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-      to_return(status: 200, body: balance_response)
-
-    perform_enqueued_jobs do
-      PayoutReportPublisherIncluder.new(payout_report: payout_report,
-                                        publisher: publisher,
-                                        should_send_notifications: true).perform
+  describe 'when publisher is suspended' do
+    it 'does not generate a report' do
     end
-
-    email = ActionMailer::Base.deliveries.last
-
-    # Ensure the correct email is sent
-    assert_equal email.subject, I18n.t('publisher_mailer.uphold_kyc_incomplete.subject')
-
-    # Ensure empty payout & payments
-    assert_equal PotentialPayment.count, prev_num_potential_payments
-    assert_equal payout_report.amount, 0
   end
 
-  test "uphold verified publisher with verified channel with no address supplied is not included in the report, and is sent email" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
-
-    payout_report = PayoutReport.create()
-    prev_num_potential_payments = PotentialPayment.count
-
-    # Clear database
-    publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-
-    delete_publishers_except([publisher.id])
-
-    # Stub disconnected /wallet response
-    wallet_response = {}.to_json
-
-    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-      to_return(status: 200, body: wallet_response, headers: {})
-
-    # Stub /balances response
-    balance_response = [
-      {
-        "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-        "account_type" => "owner",
-        "balance" => "20.00"
-      },
-      {
-        "account_id" => "uphold_connected.org",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },
-      {
-        "account_id" => "twitch#channel:ucTw",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },      {
-        "account_id" => "twitter#channel:def456",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      }
-    ].to_json
-
-    stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-      to_return(status: 200, body: balance_response)
-
-    # Deliver the email
-    perform_enqueued_jobs do
-      PayoutReportPublisherIncluder.new(payout_report: payout_report,
-                                        publisher: publisher,
-                                        should_send_notifications: true).perform
+  describe 'publisher has a verified channel' do
+    before do
+      Rails.application.secrets[:api_eyeshade_offline] = false
+      PotentialPayment.destroy_all
     end
 
-    email = ActionMailer::Base.deliveries.last
+    describe 'when not uphold verified' do
+      let(:publisher) { publishers(:youtube_initial) }
+      let(:should_send_notifications) { true }
+      let(:wallet_response) { {} }
 
-    # Ensure the correct email is sent
-    assert_equal email.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
+      let(:balance_response) do
+        [
+          {
+            account_id: "publishers#uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77",
+            account_type: "owner",
+            balance: "500.00"
+          },
+          {
+            account_id: "youtube#channel:",
+            account_type: "channel",
+            balance: "500.00"
+          }
+        ]
+      end
 
-    # Ensure payout is empty and no potential payment was created
-    assert_equal PotentialPayment.count, prev_num_potential_payments
+      let(:subject) do
+        perform_enqueued_jobs do
+          PayoutReportPublisherIncluder.new(payout_report: PayoutReport.create,
+                                            publisher: publisher,
+                                            should_send_notifications: should_send_notifications).perform
+        end
+      end
 
-    assert_equal payout_report.num_payments, 0
-    assert_equal payout_report.amount, 0
-  end
+      before do
+        account_ids = balance_response.map { |x| "account=#{x[:account_id]}" }.join("&")
 
-  test "uphold verified publisher with verified channel with address and balance is included in payout report" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
-    Rails.application.secrets[:fee_rate] = 0.05
+        stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+          to_return(status: 200, body: wallet_response.to_json, headers: {})
 
-    payout_report = PayoutReport.create(fee_rate: 0.05)
+        stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{account_ids}").
+          to_return(status: 200, body: balance_response.to_json)
 
-    # Clear database
-    publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-    delete_publishers_except([publisher.id])
+        subject
+      end
 
-    # Stub disconnected /wallet response
-    wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", "isMember": true}}.to_json
+      it 'is not included in the report' do
+        assert_equal 0, PotentialPayment.count
+      end
 
-    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-      to_return(status: 200, body: wallet_response, headers: {})
-
-    # Stub /balances response
-    balance_response = [
-      {
-        "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-        "account_type" => "owner",
-        "balance" => "20.00"
-      },
-      {
-        "account_id" => "uphold_connected.org",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },
-      {
-        "account_id" => "twitch#author:ucTw",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },      {
-        "account_id" => "twitter#channel:def456",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      }
-    ].to_json
-
-    stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-      to_return(status: 200, body: balance_response)
-
-    # Ensure no emails sent
-    assert_enqueued_jobs(1) do
-      PayoutReportPublisherIncluder.new(payout_report: payout_report,
-                                        publisher: publisher,
-                                        should_send_notifications: true).perform
-    end
-
-    # Ensure data is correct
-    assert_equal payout_report.num_payments, publisher.channels.count + 1
-    assert_equal payout_report.amount, (80 * BigDecimal('1e18') - ((60 * BigDecimal.new('1e18')) * payout_report.fee_rate)).to_i
-    assert_equal payout_report.fees, (60 * BigDecimal('1e18') * payout_report.fee_rate).to_i
-
-    # Ensure individual potential payment data is correct
-    PotentialPayment.where(payout_report_id: payout_report.id).each do |potential_payment|
-      assert_equal potential_payment.address, JSON.parse(wallet_response)["wallet"]["address"]
-      assert_equal potential_payment.publisher_id, "#{publisher.id}"
-      if potential_payment.kind == PotentialPayment::CONTRIBUTION
-        assert_equal potential_payment.amount, (20 * BigDecimal('1e18') - ((20 * BigDecimal.new('1e18')) * payout_report.fee_rate)).to_i.to_s
-      elsif potential_payment.kind == PotentialPayment::REFERRAL
-        assert_equal potential_payment.amount, (20 * BigDecimal('1e18')).to_i.to_s
+      it 'sends email to connect uphold' do
+        email = ActionMailer::Base.deliveries.last
+        assert_equal email&.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
       end
     end
 
-    # Run the includer again with same parameters and ensure no extra potential payments
-    # were created (idempotence)
+    describe 'when uphold verified' do
+      let(:publisher) { publishers(:uphold_connected) }
+      let(:subject) do
+        perform_enqueued_jobs do
+          PayoutReportPublisherIncluder.new(payout_report: @payout_report,
+                                            publisher: publisher,
+                                            should_send_notifications: should_send_notifications).perform
+        end
+      end
 
-    assert_difference -> { PotentialPayment.count }, 0 do
-      PayoutReportPublisherIncluder.new(payout_report: payout_report,
-                                        publisher: publisher,
-                                        should_send_notifications: true).perform
-    end
-  end
+        # All members should have addresses 
+      describe 'with address' do
+        describe 'with balance' do
+          let(:balance_response) do
+            [
+              {
+                account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+                account_type: "owner",
+                balance: "20.00"
+              },
+              {
+                account_id: "uphold_connected.org",
+                account_type: "channel",
+                balance: "20.00"
+              },
+              {
+                account_id: "twitch#author:ucTw",
+                account_type: "channel",
+                balance: "20.00"
+              },      {
+                account_id: "twitter#channel:def456",
+                account_type: "channel",
+                balance: "20.00"
+              }
+            ]
+          end
 
-  test "publisher with only a contribution balance but no wallet address receives an email" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
-    Rails.application.secrets[:fee_rate] = 0.05
+          before do
+            Rails.application.secrets[:fee_rate] = 0.05
+            @payout_report = PayoutReport.create(fee_rate: 0.05)
 
-    payout_report = PayoutReport.create(fee_rate: 0.05)
+            account_ids = balance_response.map { |x| "account=#{x[:account_id]}" }.join("&")
+            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}").
+              to_return(status: 200, body: balance_response.to_json)
+          end
 
-    # Clear database
-    publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-    delete_publishers_except([publisher.id])
+          # Edge case when user has reached uphold transaction limits
+          describe 'when is a member and restricted' do
+            let(:wallet_response) do
+              { wallet: { authorized: false, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": true } }
+            end
 
-    # Stub disconnected /wallet response
-    wallet_response = {"wallet" => {"address" => ""}}.to_json
+            before do
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+                to_return(status: 200, body: wallet_response.to_json, headers: {})
+            end
 
-    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-      to_return(status: 200, body: wallet_response, headers: {})
+            describe 'when should_send_notifications is false' do
+              let(:should_send_notifications) { false }
 
-    # Stub /balances response
-    balance_response = [
-      {
-        "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-        "account_type" => "owner",
-        "balance" => "0.00"
-      },
-      {
-        "account_id" => "uphold_connected.org",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },
-      {
-        "account_id" => "twitch#author:ucTw",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },      {
-        "account_id" => "twitter#channel:def456",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      }
-    ].to_json
+              before do
+                subject
+              end
+              
+              it 'does not include in report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, payout_report.amount
+              end
 
-    stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-      to_return(status: 200, body: balance_response)
+              it 'sends no emails' do
+                assert_empty ActionMailer::Base.deliveries 
+              end
+            end
 
-    # Ensure is emails sent
-    assert_enqueued_jobs(2) do
-      PayoutReportPublisherIncluder.new(payout_report: payout_report,
-                                        publisher: publisher,
-                                        should_send_notifications: true).perform
-    end
-  end
+            describe 'when should_send_notifications is true' do
+              let(:should_send_notifications) { true }
 
-  test "only sends notifications if payout_id is false" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
-    Rails.application.secrets[:fee_rate] = 0.05
+              before do
+                subject
+              end
+              
+              it 'does not include in report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
 
-    payout_report = PayoutReport.create(fee_rate: 0.05)
+              it 'sends an email notifying restricted' do
+                assert ActionMailer::Base.deliveries.present?
+              end
+            end
+          end
 
-    # Clear database
-    publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
-    delete_publishers_except([publisher.id])
+          describe 'when is a member' do
+            let(:wallet_response) do
+              { wallet: { authorized: true, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "ok", "isMember": true } }
+            end
 
-    # Stub disconnected /wallet response
-    wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", "isMember": false}}.to_json
+            describe 'when should_send_notifications is false' do
+              let(:should_send_notifications) { false }
 
-    stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
-      to_return(status: 200, body: wallet_response, headers: {})
+              before do
+                stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+                  to_return(status: 200, body: wallet_response.to_json, headers: {})
 
-    # Stub /balances response
-    balance_response = [
-      {
-        "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-        "account_type" => "owner",
-        "balance" => "0.00"
-      },
-      {
-        "account_id" => "uphold_connected.org",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },
-      {
-        "account_id" => "twitch#author:ucTw",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      },      {
-        "account_id" => "twitter#channel:def456",
-        "account_type" => "channel",
-        "balance" => "20.00"
-      }
-    ].to_json
+                subject
+              end
 
-    stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
-      to_return(status: 200, body: balance_response)
+              it 'is included in payout report' do
+                assert_equal @payout_report.num_payments, publisher.channels.count + 1
+                assert_equal @payout_report.amount, (80 * BigDecimal('1e18') - ((60 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i
+                assert_equal @payout_report.fees, (60 * BigDecimal('1e18') * @payout_report.fee_rate).to_i
+              end
 
-    # Ensure is emails sent
-    assert_difference -> { PotentialPayment.count }, 0 do
-      assert_enqueued_jobs(2) do
-        PayoutReportPublisherIncluder.new(payout_report: nil,
-                                          publisher: publisher,
-                                          should_send_notifications: true).perform
+              it 'has the correct content' do
+                PotentialPayment.where(payout_report_id: @payout_report.id).each do |potential_payment|
+                  assert_equal potential_payment.address, wallet_response[:wallet][:address]
+                  assert_equal potential_payment.publisher_id,  publisher.id.to_s
+                  if potential_payment.kind == PotentialPayment::CONTRIBUTION
+                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18') - ((20 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i.to_s
+                  elsif potential_payment.kind == PotentialPayment::REFERRAL
+                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18')).to_i.to_s
+                  end
+                end
+              end
+
+              it 'does not create any extra payments' do
+                assert_difference -> { PotentialPayment.count }, 0 do
+                  PayoutReportPublisherIncluder.new(payout_report: @payout_report,
+                                                    publisher: publisher,
+                                                    should_send_notifications: should_send_notifications).perform
+                end
+              end
+
+              it 'sends no emails' do
+                assert_empty ActionMailer::Base.deliveries 
+              end
+            end
+
+            describe 'when should_send_notifications is true' do
+              let(:should_send_notifications) { true }
+
+              before do
+                subject
+              end
+
+              # This is the happy path, the publisher is in the happy state and does not need any additional contact.
+              it 'sends no emails' do
+                assert_empty ActionMailer::Base.deliveries 
+              end
+
+              it 'is not included in payout report' do
+                assert_equal @payout_report.num_payments, publisher.channels.count + 1
+                assert_equal @payout_report.amount, (80 * BigDecimal('1e18') - ((60 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i
+                assert_equal @payout_report.fees, (60 * BigDecimal('1e18') * @payout_report.fee_rate).to_i
+              end
+
+              it 'has the correct content' do
+                PotentialPayment.where(payout_report_id: @payout_report.id).each do |potential_payment|
+                  assert_equal potential_payment.address, wallet_response[:wallet][:address]
+                  assert_equal potential_payment.publisher_id, publisher.id.to_s
+                  if potential_payment.kind == PotentialPayment::CONTRIBUTION
+                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18') - ((20 * BigDecimal.new('1e18')) * @payout_report.fee_rate)).to_i.to_s
+                  elsif potential_payment.kind == PotentialPayment::REFERRAL
+                    assert_equal potential_payment.amount, (20 * BigDecimal('1e18')).to_i.to_s
+                  end
+                end
+              end
+
+              it 'does not create any extra payments' do
+                assert_difference -> { PotentialPayment.count }, 0 do
+                  PayoutReportPublisherIncluder.new(payout_report: @payout_report,
+                                                    publisher: publisher,
+                                                    should_send_notifications: should_send_notifications).perform
+                end
+              end
+            end
+          end
+
+          describe 'not a member' do
+            # Possible that user  
+            let(:wallet_response) do
+              { wallet: { authorized: false, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": false } }
+            end
+
+            before do
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+                to_return(status: 200, body: wallet_response.to_json, headers: {})
+            end
+            
+            describe 'should_send_notifications is true' do
+              let(:should_send_notifications) { true }
+
+              before do
+                subject
+              end
+
+              it 'does not include in report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it 'receives KYC email' do
+                email = ActionMailer::Base.deliveries.last
+                assert_equal email.subject, I18n.t('publisher_mailer.uphold_kyc_incomplete.subject')
+              end
+            end
+
+            describe 'should_send_notifications is false' do
+              let(:should_send_notifications) { false }
+
+              before do
+                subject
+              end
+
+              it 'does not include in report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it 'recieves no emails' do
+                assert_empty ActionMailer::Base.deliveries 
+              end
+            end
+          end
+
+        end
+
+        describe 'without balance' do
+          let(:balance_response) { [] }
+          let(:should_send_notifications) { true }
+
+          before do
+            Rails.application.secrets[:fee_rate] = 0.05
+            @payout_report = PayoutReport.create(fee_rate: 0.05)
+
+            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?").
+              to_return(status: 200, body: balance_response.to_json)
+
+            subject
+          end
+
+          it 'is not included in the payout report' do 
+            assert_equal 0, PotentialPayment.count
+            assert_equal 0, @payout_report.amount
+          end
+
+          it 'recieves no emails' do
+            assert_empty ActionMailer::Base.deliveries 
+          end
+        end
+      end
+
+      describe 'without address' do
+        describe 'with balance' do
+          let(:balance_response) do
+            [
+              {
+                account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+                account_type: "owner",
+                balance: "20.00"
+              },
+              {
+                account_id: "uphold_connected.org",
+                account_type: "channel",
+                balance: "20.00"
+              },
+              {
+                account_id: "twitch#author:ucTw",
+                account_type: "channel",
+                balance: "20.00"
+              },      {
+                account_id: "twitter#channel:def456",
+                account_type: "channel",
+                balance: "20.00"
+              }
+            ]
+          end
+
+          before do
+            Rails.application.secrets[:fee_rate] = 0.05
+            @payout_report = PayoutReport.create(fee_rate: 0.05)
+            account_ids = balance_response.map { |x| "account=#{x[:account_id]}" }.join("&")
+            stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?#{URI.escape(account_ids)}").
+              to_return(status: 200, body: balance_response.to_json)
+          end
+
+          # Technically this path would only be possible if the user was restricted
+          #  eyeshade omits the wallet address if the status is not ok
+          describe 'is a member' do 
+            let(:wallet_response) do
+              { wallet: { authorized: false, status: "restricted", "isMember": true } }
+            end
+
+            before do
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+                to_return(status: 200, body: wallet_response.to_json, headers: {})
+            end
+
+            describe 'should_send_notifications is true' do
+              let(:should_send_notifications) { true }
+
+              before do
+                subject
+              end
+
+              it 'is not included in the report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it 'recieves an email to check uphold' do
+                email = ActionMailer::Base.deliveries.last
+                assert_equal email&.subject, I18n.t('publisher_mailer.uphold_member_restricted.subject')
+              end
+            end
+
+            describe 'should_send_notifications is false' do
+              let(:should_send_notifications) { false }
+
+              before do
+                subject
+              end
+
+              it 'is not included in the report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it 'does not recieve any emails' do
+                assert_empty ActionMailer::Base.deliveries 
+              end
+            end
+          end
+
+          describe 'not a member' do
+            let(:wallet_response) do
+              { wallet: { authorized: false, address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": false } }
+            end
+
+            before do
+              stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+                to_return(status: 200, body: wallet_response.to_json, headers: {})
+            end
+
+            describe 'should_send_notifications is true' do
+              let(:should_send_notifications) { true }
+              before { subject }
+
+              it 'is not included in report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it 'recieves an email to connect uphold' do
+                email = ActionMailer::Base.deliveries.last
+                assert_equal email&.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
+              end
+            end
+
+            describe 'should_send_notifications is false' do
+              let(:should_send_notifications) { false }
+              before { subject }
+
+              it 'is not included in report' do
+                assert_equal 0, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it 'does not receive any emails ' do
+                assert_empty ActionMailer::Base.deliveries 
+              end
+            end
+
+          end
+        end
       end
     end
   end
+
+  # test "publisher with verified channel that is not uphold verified is not included in the report" do
+  #   Rails.application.secrets[:api_eyeshade_offline] = false
+
+  #   payout_report = PayoutReport.create()
+  #   prev_num_potential_payments = PotentialPayment.count
+
+  #   # Clear database
+  #   publisher = publishers(:youtube_initial) # has verified channel, is not uphold connected
+  #   delete_publishers_except([publisher.id])
+
+  #   # Stub /wallet reponse
+  #   wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2"}}.to_json
+
+  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+  #     to_return(status: 200, body: wallet_response, headers: {})
+
+  #   # Stub /balances response
+  #   balance_response = [
+  #     {
+  #       "account_id" => "publishers#uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77",
+  #       "account_type" => "owner",
+  #       "balance" => "500.00"
+  #     },
+  #     {
+  #       "account_id" => "youtube#channel:",
+  #       "account_type" => "channel",
+  #       "balance" => "500.00"
+  #     }
+  #   ].to_json
+
+  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77&account=youtube%23channel:").
+  #     to_return(status: 200, body: balance_response)
+
+  #   perform_enqueued_jobs do
+  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
+  #                                       publisher: publisher,
+  #                                       should_send_notifications: true).perform
+  #   end
+
+  #   email = ActionMailer::Base.deliveries.last
+
+  #   # Ensure the correct email is sent
+  #   assert_equal email.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
+
+  #   # Ensure empty payout & payments
+  #   assert_equal PotentialPayment.count, prev_num_potential_payments
+  #   assert_equal payout_report.amount, 0
+  # end
+
+  # test "publisher with verified channel that is uphold verified but not a member is not included in the report" do
+  #   Rails.application.secrets[:api_eyeshade_offline] = false
+
+  #   payout_report = PayoutReport.create()
+  #   prev_num_potential_payments = PotentialPayment.count
+
+  #   # Clear database
+  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
+
+  #   delete_publishers_except([publisher.id])
+
+  #   # Stub /wallet reponse
+  #   wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", "status": "restricted", "isMember": false}}.to_json
+
+  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+  #     to_return(status: 200, body: wallet_response, headers: {})
+
+  #   # Stub /balances response
+  #   balance_response = [
+  #     {
+  #       "account_id" => publisher.owner_identifier,
+  #       "account_type" => "owner",
+  #       "balance" => "500.00"
+  #     },
+  #     {
+  #       "account_id" => "youtube#channel:",
+  #       "account_type" => "channel",
+  #       "balance" => "500.00"
+  #     }
+  #   ].to_json
+
+  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=#{URI.escape(publisher.owner_identifier)}}&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
+  #     to_return(status: 200, body: balance_response)
+
+  #   perform_enqueued_jobs do
+  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
+  #                                       publisher: publisher,
+  #                                       should_send_notifications: true).perform
+  #   end
+
+  #   email = ActionMailer::Base.deliveries.last
+
+  #   # Ensure the correct email is sent
+  #   assert_equal email.subject, I18n.t('publisher_mailer.uphold_kyc_incomplete.subject')
+
+  #   # Ensure empty payout & payments
+  #   assert_equal PotentialPayment.count, prev_num_potential_payments
+  #   assert_equal payout_report.amount, 0
+  # end
+
+  # test "uphold verified publisher with verified channel with no address supplied is not included in the report, and is sent email" do
+  #   Rails.application.secrets[:api_eyeshade_offline] = false
+
+  #   payout_report = PayoutReport.create()
+  #   prev_num_potential_payments = PotentialPayment.count
+
+  #   # Clear database
+  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
+
+  #   delete_publishers_except([publisher.id])
+
+  #   # Stub disconnected /wallet response
+  #   wallet_response = {}.to_json
+
+  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+  #     to_return(status: 200, body: wallet_response, headers: {})
+
+  #   # Stub /balances response
+  #   balance_response = [
+  #     {
+  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+  #       "account_type" => "owner",
+  #       "balance" => "20.00"
+  #     },
+  #     {
+  #       "account_id" => "uphold_connected.org",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },
+  #     {
+  #       "account_id" => "twitch#channel:ucTw",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },      {
+  #       "account_id" => "twitter#channel:def456",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     }
+  #   ].to_json
+
+  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
+  #     to_return(status: 200, body: balance_response)
+
+  #   # Deliver the email
+  #   perform_enqueued_jobs do
+  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
+  #                                       publisher: publisher,
+  #                                       should_send_notifications: true).perform
+  #   end
+
+  #   email = ActionMailer::Base.deliveries.last
+
+  #   # Ensure the correct email is sent
+  #   assert_equal email.subject, I18n.t('publisher_mailer.wallet_not_connected.subject')
+
+  #   # Ensure payout is empty and no potential payment was created
+  #   assert_equal PotentialPayment.count, prev_num_potential_payments
+
+  #   assert_equal payout_report.num_payments, 0
+  #   assert_equal payout_report.amount, 0
+  # end
+
+  # test "uphold verified publisher with verified channel with address and balance is included in payout report" do
+  #   Rails.application.secrets[:api_eyeshade_offline] = false
+  #   Rails.application.secrets[:fee_rate] = 0.05
+
+  #   payout_report = PayoutReport.create(fee_rate: 0.05)
+
+  #   # Clear database
+  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
+  #   delete_publishers_except([publisher.id])
+
+  #   # Stub disconnected /wallet response
+  #   wallet_response = {"wallet" => {address: "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "ok", isMember: true}}.to_json
+
+  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+  #     to_return(status: 200, body: wallet_response, headers: {})
+
+  #   # Stub /balances response
+  #   balance_response = [
+  #     {
+  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+  #       "account_type" => "owner",
+  #       "balance" => "20.00"
+  #     },
+  #     {
+  #       "account_id" => "uphold_connected.org",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },
+  #     {
+  #       "account_id" => "twitch#author:ucTw",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },      {
+  #       "account_id" => "twitter#channel:def456",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     }
+  #   ].to_json
+
+  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
+  #     to_return(status: 200, body: balance_response)
+
+  #   # Ensure no emails sent
+  #   assert_enqueued_jobs(1) do
+  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
+  #                                       publisher: publisher,
+  #                                       should_send_notifications: true).perform
+  #   end
+
+  #   # Ensure data is correct
+  #   assert_equal payout_report.num_payments, publisher.channels.count + 1
+  #   assert_equal payout_report.amount, (80 * BigDecimal('1e18') - ((60 * BigDecimal.new('1e18')) * payout_report.fee_rate)).to_i
+  #   assert_equal payout_report.fees, (60 * BigDecimal('1e18') * payout_report.fee_rate).to_i
+
+  #   # Ensure individual potential payment data is correct
+  #   PotentialPayment.where(payout_report_id: payout_report.id).each do |potential_payment|
+  #     assert_equal potential_payment.address, JSON.parse(wallet_response)["wallet"]["address"]
+  #     assert_equal potential_payment.publisher_id, "#{publisher.id}"
+  #     if potential_payment.kind == PotentialPayment::CONTRIBUTION
+  #       assert_equal potential_payment.amount, (20 * BigDecimal('1e18') - ((20 * BigDecimal.new('1e18')) * payout_report.fee_rate)).to_i.to_s
+  #     elsif potential_payment.kind == PotentialPayment::REFERRAL
+  #       assert_equal potential_payment.amount, (20 * BigDecimal('1e18')).to_i.to_s
+  #     end
+  #   end
+
+  #   # Run the includer again with same parameters and ensure no extra potential payments
+  #   # were created (idempotence)
+
+  #   assert_difference -> { PotentialPayment.count }, 0 do
+  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
+  #                                       publisher: publisher,
+  #                                       should_send_notifications: true).perform
+  #   end
+  # end
+
+  # test "publisher with only a contribution balance but no wallet address receives an email" do
+  #   Rails.application.secrets[:api_eyeshade_offline] = false
+  #   Rails.application.secrets[:fee_rate] = 0.05
+
+  #   payout_report = PayoutReport.create(fee_rate: 0.05)
+
+  #   # Clear database
+  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
+  #   delete_publishers_except([publisher.id])
+
+  #   # Stub disconnected /wallet response
+  #   wallet_response = {"wallet" => {"address" => ""}}.to_json
+
+  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+  #     to_return(status: 200, body: wallet_response, headers: {})
+
+  #   # Stub /balances response
+  #   balance_response = [
+  #     {
+  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+  #       "account_type" => "owner",
+  #       "balance" => "0.00"
+  #     },
+  #     {
+  #       "account_id" => "uphold_connected.org",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },
+  #     {
+  #       "account_id" => "twitch#author:ucTw",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },      {
+  #       "account_id" => "twitter#channel:def456",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     }
+  #   ].to_json
+
+  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
+  #     to_return(status: 200, body: balance_response)
+
+  #   # Ensure is emails sent
+  #   assert_enqueued_jobs(2) do
+  #     PayoutReportPublisherIncluder.new(payout_report: payout_report,
+  #                                       publisher: publisher,
+  #                                       should_send_notifications: true).perform
+  #   end
+  # end
+
+  # test "only sends notifications if payout_id is false" do
+  #   Rails.application.secrets[:api_eyeshade_offline] = false
+  #   Rails.application.secrets[:fee_rate] = 0.05
+
+  #   payout_report = PayoutReport.create(fee_rate: 0.05)
+
+  #   # Clear database
+  #   publisher = publishers(:uphold_connected) # has >1 verified channel, is uphold connected
+  #   delete_publishers_except([publisher.id])
+
+  #   # Stub disconnected /wallet response
+  #   wallet_response = {"wallet" => {"address" => "ae42daaa-69d8-4400-a0f4-d359279cd3d2", status: "restricted", "isMember": false}}.to_json
+
+  #   stub_request(:get, /v1\/owners\/#{URI.escape(publisher.owner_identifier)}\/wallet/).
+  #     to_return(status: 200, body: wallet_response, headers: {})
+
+  #   # Stub /balances response
+  #   balance_response = [
+  #     {
+  #       "account_id" => "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+  #       "account_type" => "owner",
+  #       "balance" => "0.00"
+  #     },
+  #     {
+  #       "account_id" => "uphold_connected.org",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },
+  #     {
+  #       "account_id" => "twitch#author:ucTw",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     },      {
+  #       "account_id" => "twitter#channel:def456",
+  #       "account_type" => "channel",
+  #       "balance" => "20.00"
+  #     }
+  #   ].to_json
+
+  #   stub_request(:get, "#{api_eyeshade_base_uri}/v1/accounts/balances?account=publishers%23uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8&account=uphold_connected.org&account=twitch%23author:ucTw&account=twitter%23channel:def456").
+  #     to_return(status: 200, body: balance_response)
+
+  #   # Ensure is emails sent
+  #   assert_difference -> { PotentialPayment.count }, 0 do
+  #     assert_enqueued_jobs(2) do
+  #       PayoutReportPublisherIncluder.new(payout_report: nil,
+  #                                         publisher: publisher,
+  #                                         should_send_notifications: true).perform
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
Changed the following

* We can actually search by a UUID now
* We can search for identical Uphold accounts
* Rewrote the `payout_report_publisher_includer_test` to handle more permutations of statuses
* Sorting by Last Signed In will show the null values last so we can see who was the most recent signed in user
