### PR TITLE
Include install/download and 30 days/eligible install in referral reports

### DIFF
--- a/app/helpers/promos_helper.rb
+++ b/app/helpers/promos_helper.rb
@@ -100,6 +100,14 @@ module PromosHelper
     end
   end
 
+  def ratios_column_header(is_geo)
+    if is_geo
+      ["Referral code", "Country",  "Downloads", "Installs", "Eligible Installs", "30 days", "Installs / Downloads", "30 days / Eligible Installs"]
+    else
+      ["Referral code", "Downloads", "Installs", "Eligible Installs", "30 days",  "Installs / Downloads", "30 days / Eligible Installs"]
+    end
+  end
+
   def coerce_date_to_start_or_end_of_reporting_interval(date, reporting_interval, start)
     case reporting_interval
     when PromoRegistration::DAILY, PromoRegistration::RUNNING_TOTAL

--- a/app/services/promo/registration_stats_report_generator.rb
+++ b/app/services/promo/registration_stats_report_generator.rb
@@ -88,7 +88,7 @@ class Promo::RegistrationStatsReportGenerator < BaseService
     total_eligible_installs_for_referral_code = events_for_referral_code.select { |event_for_referral_code|
       (Time.now.utc.to_date - 1.month) >= event_for_referral_code["ymd"].to_date
     }.sum { |event_for_referral_code|
-      event_for_referral_code[PromoRegistration::RETRIEVALS]
+      event_for_referral_code[PromoRegistration::FIRST_RUNS]
     } || 0.0
 
     total_30_days_for_referral_code = events_for_referral_code.sum {|event_for_referral_code| event_for_referral_code[PromoRegistration::FINALIZED]} || 0 

--- a/app/services/promo/registration_stats_report_generator.rb
+++ b/app/services/promo/registration_stats_report_generator.rb
@@ -93,8 +93,8 @@ class Promo::RegistrationStatsReportGenerator < BaseService
 
     total_30_days_for_referral_code = events_for_referral_code.sum {|event_for_referral_code| event_for_referral_code[PromoRegistration::FINALIZED]} || 0 
 
-    install_to_download_ratio = total_installs_for_referral_code.to_f / total_downloads_for_referral_code.to_f
-    install_to_30_days_ratio = total_30_days_for_referral_code.to_f / total_eligible_installs_for_referral_code.to_f
+    install_to_download_ratio = (total_installs_for_referral_code.to_f / total_downloads_for_referral_code.to_f).round(2)
+    install_to_30_days_ratio = (total_30_days_for_referral_code.to_f / total_eligible_installs_for_referral_code.to_f).round(2)
 
     if @is_geo
       [

--- a/test/services/promo/registration_stats_report_generator_test.rb
+++ b/test/services/promo/registration_stats_report_generator_test.rb
@@ -128,7 +128,11 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
                           event_type_column_header(PromoRegistration::FIRST_RUNS),
                           event_type_column_header(PromoRegistration::FINALIZED)],
       ["ABC123", "2018-12-01", "6", "6", "6"],
-      ["DEF456", "2018-12-01", "6", "6", "6"]
+      ["DEF456", "2018-12-01", "6", "6", "6"],
+      [],
+      ratios_column_header(false),
+      ["ABC123", "6", "6", "6", "6", "1.0", "1.0"],
+      ["DEF456", "6", "6", "6", "6", "1.0", "1.0"]
     ]
 
     assert_equal CSV.parse(csv), expected
@@ -154,6 +158,10 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
                           event_type_column_header(PromoRegistration::FINALIZED)],
       ["ABC123", "2018-11-28", "5", "5", "5"],
       ["DEF456", "2018-11-28", "5", "5", "5"],
+      [],
+      ratios_column_header(false),
+      ["ABC123", "5", "5", "5", "5", "1.0", "1.0"],
+      ["DEF456", "5", "5", "5", "5", "1.0", "1.0"]
     ]
 
     assert_equal expected, CSV.parse(csv)
@@ -181,7 +189,11 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
       ["ABC123", "2018-11-01", "5", "5", "5"],
       ["ABC123", "2018-12-01", "1", "1", "1"],
       ["DEF456", "2018-11-01", "5", "5", "5"],
-      ["DEF456", "2018-12-01", "1", "1", "1"]
+      ["DEF456", "2018-12-01", "1", "1", "1"],
+      [],
+      ratios_column_header(false),
+      ["ABC123", "6", "6", "6", "6", "1.0", "1.0"],
+      ["DEF456", "6", "6", "6", "6", "1.0", "1.0"]
     ]
 
     assert_equal expected, CSV.parse(csv)
@@ -211,6 +223,10 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
       ["ABC123", "2018-11-05", "1", "1", "1"],
       ["DEF456", "2018-10-29", "1", "1", "1"],
       ["DEF456", "2018-11-05", "1", "1", "1"],
+      [],
+      ratios_column_header(false),
+      ["ABC123", "2", "2", "2", "2", "1.0", "1.0"],
+      ["DEF456", "2", "2", "2", "2", "1.0", "1.0"]
     ]
 
     assert_equal expected, CSV.parse(csv)
@@ -239,6 +255,10 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
       ["ABC123", "2018-11-02", "0", "0", "0"],
       ["DEF456", "2018-11-01", "1", "1", "1"],
       ["DEF456", "2018-11-02", "0", "0", "0"],
+      [],
+      ratios_column_header(false),
+      ["ABC123", "1", "1", "1", "1", "1.0", "1.0"],
+      ["DEF456", "1", "1", "1", "1", "1.0", "1.0"]
     ]
 
     assert_equal expected, CSV.parse(csv)
@@ -269,6 +289,12 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
       ["ABC123", "United States", "2018-12-01", "6", "6", "6"],
       ["DEF456", "Mexico", "2018-12-01", "6", "6", "6"],
       ["DEF456", "United States", "2018-12-01", "6", "6", "6"],
+      [],
+      ratios_column_header(true),
+      ["ABC123", "Mexico", "6", "6", "6", "6", "1.0", "1.0"],
+      ["ABC123", "United States", "6", "6", "6", "6", "1.0", "1.0"],
+      ["DEF456", "Mexico", "6", "6", "6", "6", "1.0", "1.0"],
+      ["DEF456", "United States", "6", "6", "6", "6", "1.0", "1.0"]
     ]
 
     assert_equal expected, CSV.parse(csv)
@@ -306,6 +332,12 @@ class Promo::RegistrationStatsReportGeneratorTest < ActiveJob::TestCase
       ["DEF456", "United States", "2018-10-29", "1", "1", "1",],
       ["DEF456", "United States", "2018-11-05", "1", "1", "1",],
       ["DEF456", "United States", "2018-11-12", "1", "1", "1",],
+      [],
+      ratios_column_header(true),
+      ["ABC123", "Mexico", "3", "3", "3", "3", "1.0", "1.0"],
+      ["ABC123", "United States", "3", "3", "3", "3", "1.0", "1.0"],
+      ["DEF456", "Mexico", "3", "3", "3", "3", "1.0", "1.0"],
+      ["DEF456", "United States", "3", "3", "3", "3", "1.0", "1.0"]
     ]
 
     assert_equal expected, CSV.parse(csv)


### PR DESCRIPTION
Resolves #1540 

This will now automatically calculate the install/download ratio and 30 days/install ratio for each referral code within date period given for standard reports and for each referral code x country pair for geo reports.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
