### PR TITLE
Do not destroy dependent promo registrations for a publisher

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -24,7 +24,7 @@ class Publisher < ApplicationRecord
   has_many :login_activities
 
   has_many :channels, validate: true, autosave: true
-  has_many :promo_registrations, dependent: :destroy
+  has_many :promo_registrations
   has_many :site_banners
   has_many :site_channel_details, through: :channels, source: :details, source_type: 'SiteChannelDetails'
   has_many :youtube_channel_details, through: :channels, source: :details, source_type: 'YoutubeChannelDetails'


### PR DESCRIPTION
We had some reports of some publishers who lost all their promo stats after deleting a channel with no referrals credited to it.  When they added the channel back, their channels stats were reinstated.

Stepping through the flow I found that after a channel was destroyed on this line

https://github.com/brave-intl/publishers/blob/3069160c7e65efe81a406b72cf202e620e24bbcd/app/jobs/delete_publisher_channel_job.rb#L19

the total number of promo registrations in the database decreased by more than one.  It seems like this call was not only destroying the promo registration for that channel, but for all channels the publisher had.  When they re-added their channels, the Promo::PublisherChannelsRegistrar would recreate all the old promo registrations.

It looks like the `has_many :promo_registrations, dependent: :destroy` on the Publisher model is doing more than just deleting all promo registrations that belong to a publisher when the publisher is deleted. 
It's also deleting all the promo registrations that belong to a publisher when one of the publisher's channels are destroyed.

I've removed the `dependent: destroy` because this serves no function that I can see at the moment.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
