### PR TITLE
Use camel case for payout report json

### DIFF
--- a/app/models/json_builders/payout_report_json_builder.rb
+++ b/app/models/json_builders/payout_report_json_builder.rb
@@ -17,7 +17,7 @@ class JsonBuilders::PayoutReportJsonBuilder
           "owner" => "#{Publisher.find(potential_payment.publisher_id).owner_identifier}",
           "type" => PotentialPayment::REFERRAL,
           "address" => "#{potential_payment.address}",
-          "uphold_id" => "#{potential_payment.uphold_id}"
+          "upholdId" => "#{potential_payment.uphold_id}"
         })
       else
         channel = Channel.find_by(id: potential_payment.channel_id)
@@ -34,7 +34,7 @@ class JsonBuilders::PayoutReportJsonBuilder
             "type" => PotentialPayment::CONTRIBUTION,
             "URL" => "#{Channel.find(potential_payment.channel_id).details.url}",
             "address" => "#{potential_payment.address}",
-            "uphold_id" => "#{potential_payment.uphold_id}"
+            "upholdId" => "#{potential_payment.uphold_id}"
           })
         end
       end

--- a/test/models/json_builders/payout_report_json_builder_test.rb
+++ b/test/models/json_builders/payout_report_json_builder_test.rb
@@ -9,7 +9,7 @@ class PayoutReportJsonBuilderTest < ActiveSupport::TestCase
     payout_json.each do |potential_payment|
       assert_equal "90000000000", potential_payment["probi"]
       assert_equal "bc29c05c-e6aa-450c-8ea2-7d598666fac0", potential_payment["address"]
-      assert_equal "6c6bb015-f307-4440-9935-552a9fa184cb", potential_payment["uphold_id"]
+      assert_equal "6c6bb015-f307-4440-9935-552a9fa184cb", potential_payment["upholdId"]
     end
   end
 end


### PR DESCRIPTION
I accidentally used snake case for uphold id.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
