### PR TITLE
Use api key instead of sendgrid account credentials for transactional emails for prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,8 +79,8 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     port: Rails.application.secrets[:smtp_server_port],
     address: Rails.application.secrets[:smtp_server_address],
-    user_name: Rails.application.secrets[:smtp_server_login],
-    password: Rails.application.secrets[:smtp_server_password],
+    user_name: "apikey", # see https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html
+    password: Rails.application.secrets[:sendgrid_api_key],
     domain: Rails.application.secrets[:url_host],
     authentication: :plain,
     enable_starttls_auto: true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     port: Rails.application.secrets[:smtp_server_port],
     address: Rails.application.secrets[:smtp_server_address],
-    user_name: 'apikey', # see https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html
+    user_name: "apikey", # see https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html
     password: Rails.application.secrets[:sendgrid_api_key],
     domain: Rails.application.secrets[:url_host],
     authentication: :plain,

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -39,8 +39,6 @@ default: &default
   #SMTP Mailer settings
   smtp_server_port: <%= ENV["SENDGRID_SMTP_PORT"] %>
   smtp_server_address: <%= ENV["SENDGRID_SMTP_SERVER"] %>
-  smtp_server_login: <%= ENV["SENDGRID_SMTP_LOGIN"] %>
-  smtp_server_password: <%= ENV["SENDGRID_SMTP_PASSWORD"] %>
   mailer_sender: <%= ENV["MAILER_SENDER"] %>
   redis_url: <%= ENV["REDIS_URL"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
