### PR TITLE
Don't return early from PayoutReportPublisherIncluders if publisher is suspended

### DIFF
--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -6,7 +6,7 @@ class PayoutReportPublisherIncluder < BaseService
   end
 
   def perform
-    return if @publisher.suspended? || !@publisher.has_verified_channel? || @publisher.excluded_from_payout?
+    return if !@publisher.has_verified_channel? || @publisher.excluded_from_payout?
     publisher_has_unsettled_balance = false
 
     wallet = @publisher.wallet

--- a/test/services/payout_report_publisher_includer_test.rb
+++ b/test/services/payout_report_publisher_includer_test.rb
@@ -47,8 +47,8 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
 
     before { subject }
 
-    it "does not generate a report" do
-      assert_equal 0, PotentialPayment.count
+    it "does generate a report noting publisher is suspended" do
+      assert_equal 2, PotentialPayment.count
     end
   end
 


### PR DESCRIPTION
Resolves #1676 

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
