### PR TITLE
Partner promo registration bugfixes 🏷 

### DIFF
--- a/app/javascript/views/referrals/referralsCard/ReferralsCard.tsx
+++ b/app/javascript/views/referrals/referralsCard/ReferralsCard.tsx
@@ -105,9 +105,11 @@ function processStats(referralCodes) {
   const total = referralCodes.length;
 
   referralCodes.forEach(code => {
-    downloads += JSON.parse(code.stats)[0].retrievals;
-    installs += JSON.parse(code.stats)[0].first_runs;
-    thirtyDayUse += JSON.parse(code.stats)[0].finalized;
+    if (JSON.parse(code.stats)[0]) {
+      downloads += JSON.parse(code.stats)[0].retrievals;
+      installs += JSON.parse(code.stats)[0].first_runs;
+      thirtyDayUse += JSON.parse(code.stats)[0].finalized;
+    }
   });
 
   return { downloads, installs, thirtyDayUse, total };

--- a/app/javascript/views/referrals/referralsHeader/ReferralsHeader.tsx
+++ b/app/javascript/views/referrals/referralsHeader/ReferralsHeader.tsx
@@ -45,9 +45,11 @@ export default class ReferralsHeader extends React.Component<
 
     campaigns.forEach(campaign => {
       campaign.promo_registrations.forEach(code => {
-        downloads += JSON.parse(code.stats)[0].retrievals;
-        installs += JSON.parse(code.stats)[0].first_runs;
-        thirtyDayUse += JSON.parse(code.stats)[0].finalized;
+        if (JSON.parse(code.stats)[0]) {
+          downloads += JSON.parse(code.stats)[0].retrievals || 0;
+          installs += JSON.parse(code.stats)[0].first_runs || 0;
+          thirtyDayUse += JSON.parse(code.stats)[0].finalized || 0;
+        }
         total++;
       });
     });

--- a/app/javascript/views/referrals/referralsInformation/ReferralsInformation.tsx
+++ b/app/javascript/views/referrals/referralsInformation/ReferralsInformation.tsx
@@ -258,9 +258,11 @@ function processStats(referralCodes) {
   let installs = 0;
   let thirtyDayUse = 0;
   referralCodes.forEach(code => {
-    downloads += JSON.parse(code.stats)[0].retrievals;
-    installs += JSON.parse(code.stats)[0].first_runs;
-    thirtyDayUse += JSON.parse(code.stats)[0].finalized;
+    if (JSON.parse(code.stats)[0]) {
+      downloads += JSON.parse(code.stats)[0].retrievals;
+      installs += JSON.parse(code.stats)[0].first_runs;
+      thirtyDayUse += JSON.parse(code.stats)[0].finalized;
+    }
   });
   return { downloads, installs, thirtyDayUse };
 }
@@ -274,12 +276,12 @@ function processDate(created) {
 function copyLink(referralCode) {
   // Copy to Clipboard
   const el = document.createElement("textarea");
-  el.value = "https://brave.com/" + referralCode;
+  el.value = "https://laptop-updates.brave.com/download/" + referralCode;
   document.body.appendChild(el);
   el.select();
   document.execCommand("copy");
   document.body.removeChild(el);
-  alert("Copied! " + el.value);
+  alert("Copied to clipboard! \n" + el.value);
 }
 
 function findCurrentCampaign(campaigns) {
@@ -357,15 +359,33 @@ function ReferralsTable(props) {
           customStyle: contentStyle
         },
         {
-          content: <div>{JSON.parse(referralCode.stats)[0].retrievals}</div>,
+          content: (
+            <div>
+              {JSON.parse(referralCode.stats)[0]
+                ? JSON.parse(referralCode.stats)[0].retrievals
+                : 0}
+            </div>
+          ),
           customStyle: contentStyle
         },
         {
-          content: <div>{JSON.parse(referralCode.stats)[0].first_runs}</div>,
+          content: (
+            <div>
+              {JSON.parse(referralCode.stats)[0]
+                ? JSON.parse(referralCode.stats)[0].first_runs
+                : 0}
+            </div>
+          ),
           customStyle: contentStyle
         },
         {
-          content: <div>{JSON.parse(referralCode.stats)[0].finalized}</div>,
+          content: (
+            <div>
+              {JSON.parse(referralCode.stats)[0]
+                ? JSON.parse(referralCode.stats)[0].finalized
+                : 0}
+            </div>
+          ),
           customStyle: contentStyle
         },
         {

--- a/app/services/promo/owner_registrar.rb
+++ b/app/services/promo/owner_registrar.rb
@@ -20,16 +20,16 @@ class Promo::OwnerRegistrar < BaseApiClient
       request.url("/api/2/promo/referral_code/unattached?number=#{@number}")
     end
 
-    promo_registrations = JSON.parse(response.body)
-    promo_registrations.each do |promo_registration|
-      PromoRegistration.create!(referral_code: promo_registration["referral_code"],
-                                publisher_id: @publisher_id,
-                                promo_id: active_promo_id,
-                                promo_campaign_id: @promo_campaign_id,
-                                description: @description,
-                                kind: PromoRegistration::OWNER)
+    payload = JSON.parse(response.body)
+    payload.each do |promo_registration|
+      PromoRegistration.create!(
+        referral_code: promo_registration["referral_code"],
+        publisher_id: @publisher_id,
+        promo_id: active_promo_id,
+        promo_campaign_id: @promo_campaign_id,
+        description: @description,
+        kind: PromoRegistration::OWNER)
     end
-    Promo::RegistrationsStatsFetcher.new(promo_registrations: promo_registrations).perform
   end
 
   def perform_offline


### PR DESCRIPTION
### Partner promo registration bugfixes

#### Features 
* Fixes issue partners were seeing in creating campaigns and promo registrations
* Also updates the copy link feature to use the correct url 

#### Notes
* Bug was related to the false assumption that the promo server would provide stats `{0, 0, 0}` for a new promo_registration, this is not the case. Rewrote code to handle this. 

#### How To Test
* On a staging environment (or environment with promo-server running) login as a partner
* Navigate to `Referrals`
* Try creating Campaigns and Promo Registrations, codes should appear. 