### PR TITLE
Create Uphold cards when the wallet address is blank

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -411,7 +411,7 @@ class PublishersController < ApplicationController
       }
     end
   end
-  
+
   def wallet
     wallet = current_publisher.wallet
     if wallet
@@ -435,7 +435,7 @@ class PublishersController < ApplicationController
   def create_uphold_card_for_default_currency_if_needed
     if current_publisher.can_create_uphold_cards? &&
       current_publisher.default_currency_confirmed_at.present? &&
-      current_publisher.wallet.available_currencies.exclude?(current_publisher.default_currency)
+      current_publisher.wallet.address.blank?
       CreateUpholdCardsJob.perform_now(publisher_id: current_publisher.id)
     end
   end

--- a/app/javascript/wallet.js
+++ b/app/javascript/wallet.js
@@ -4,7 +4,6 @@ export class Wallet {
 
     // Wallet info
     this.authorized = data.authorized;
-    this.availableCurrencies = data.available_currencies ? data.available_currencies : [];
     this.possibleCurrencies = data.possible_currencies ? data.possible_currencies : [];
     this.defaultCurrency = data.default_currency;
 

--- a/app/javascript/wallet.test.tsx
+++ b/app/javascript/wallet.test.tsx
@@ -13,7 +13,6 @@ describe("Wallet", () => {
     provider: "uphold",
     scope: "cards:read user:read",
     default_currency: "GBP",
-    available_currencies: ["USD", "EUR", "BTC", "ETH", "BAT"],
     possible_currencies: [
       "AED",
       "ARS",
@@ -115,7 +114,6 @@ describe("Wallet", () => {
     let wallet = new Wallet(walletData);
     expect(wallet.defaultCurrency).toEqual("GBP");
     expect(wallet.authorized).toEqual(true);
-    expect(wallet.availableCurrencies.includes("USD")).toEqual(true);
     expect(wallet.possibleCurrencies.includes("HKD")).toEqual(true);
   });
 

--- a/app/jobs/create_uphold_cards_job.rb
+++ b/app/jobs/create_uphold_cards_job.rb
@@ -4,19 +4,19 @@ class CreateUpholdCardsJob < ApplicationJob
 
   def perform(publisher_id:)
     publisher = Publisher.find(publisher_id)
-    
+
     raise unless publisher.can_create_uphold_cards?
 
     default_currency = publisher.default_currency
 
-    if publisher.wallet.currency_is_possible_but_not_available?(default_currency)
+    if publisher.wallet.address.blank?
       UpholdServices::CardCreationService.new(publisher: publisher,
                                               currency_code: default_currency).perform
     end
 
-    if default_currency != "BAT" && publisher.wallet.currency_is_possible_but_not_available?("BAT")
+    if default_currency != "BAT" && publisher.wallet.address.blank?
       UpholdServices::CardCreationService.new(publisher: publisher, currency_code: "BAT").perform
-    end      
+    end
 
     if default_currency != publisher.wallet.default_currency
       PublisherDefaultCurrencySetter.new(publisher: publisher).perform

--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -76,7 +76,6 @@ class PublisherWalletGetter < BaseApiClient
             "defaultCurrency" => @publisher.default_currency,
             "isMember" => true,
             "status" => "ok",
-            "availableCurrencies" => [ "USD", "EUR", "BTC", "ETH", "BAT" ],
             "possibleCurrencies"=> ["BAT", "AED", "ARS", "AUD", "BRL", "CAD", "CHF", "CNY", "DKK", "EUR", "GBP", "HKD", "ILS", "INR", "JPY", "KES", "MXN", "NOK", "NZD", "PHP", "PLN", "SEK", "SGD", "USD", "XAG", "XAU", "XPD", "XPT"],
             "scope"=> "cards:read user:read"
         },

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -12,7 +12,6 @@ module Eyeshade
                 :provider,
                 :scope,
                 :default_currency,
-                :available_currencies,
                 :possible_currencies,
                 :channel_balances,
                 :rates,

--- a/lib/eyeshade/wallet.rb
+++ b/lib/eyeshade/wallet.rb
@@ -31,7 +31,6 @@ module Eyeshade
       @provider = wallet_info.dig("wallet", "provider") # Wallet provider e.g. Uphold
       @scope = wallet_info.dig("wallet", "scope") # Permissions e.g. cards:read, cards:write
       @default_currency = wallet_info.dig("wallet", "defaultCurrency")
-      @available_currencies = wallet_info.dig("wallet", "availableCurrencies") || []
       @possible_currencies = wallet_info.dig("wallet", "possibleCurrencies") || []
       @address = wallet_info.dig("wallet", "address") || ""
       @is_member = wallet_info.dig("wallet", "isMember") || false
@@ -63,10 +62,6 @@ module Eyeshade
 
     def not_a_member?
       !is_a_member?
-    end
-
-    def currency_is_possible_but_not_available?(currency)
-      @available_currencies.exclude?(currency) && @possible_currencies.include?(currency)
     end
   end
 end

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -725,7 +725,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
     wallet = { "wallet" => { "defaultCurrency" => "USD",
                              "authorized" => false,
-                             "availableCurrencies" => [],
                              "possibleCurrencies" => ["BAT"],
                              "scope" => "cards:read, user:read" },
                "rates" => {},
@@ -763,7 +762,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     # Mock the eyeshade wallet response to include cards:write scope
     wallet = { "wallet" => { "defaultCurrency" => "USD",
                              "authorized" => true,
-                             "availableCurrencies" => [],
                              "possibleCurrencies" => ["BAT"],
                              "scope" => "cards:read, cards:write, user:read"},
                "rates" => {},
@@ -799,7 +797,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     # Mock the eyeshade wallet response to include cards:write scope
     wallet = { "wallet" => { "defaultCurrency" => "USD",
                              "authorized" => true,
-                             "availableCurrencies" => [],
                              "possibleCurrencies" => ["BAT", "BTC"],
                              "scope" => "cards:read, cards:write, user:read" },
                "rates" => {},
@@ -835,7 +832,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     # Mock the eyeshade wallet response to include cards:write scope
     wallet = { "wallet" => { "defaultCurrency" => "BAT",
                              "authorized" => true,
-                             "availableCurrencies" => ["BAT"],
                              "possibleCurrencies" => ["BAT"],
                              "scope" => "cards:read, cards:write, user:read" },
                "rates" => {},
@@ -869,7 +865,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
     wallet = { "wallet" => { "defaultCurrency" => "USD",
                              "authorized" => false,
-                             "availableCurrencies" => [],
                              "possibleCurrencies" => ["BAT"],
                              "scope" => "cards:read, user:read" },
                "rates" => {},
@@ -893,7 +888,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
     wallet = { "wallet" => { "defaultCurrency" => "BAT",
                              "authorized" => true,
-                             "availableCurrencies" => [],  # BAT will not be available
                              "possibleCurrencies" => ["BAT"],
                              "scope" => "cards:read, cards:write, user:read" },
                "rates" => {},

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -62,7 +62,6 @@ class PublishersHelperTest < ActionView::TestCase
           "provider" => "uphold",
           "authorized" => true,
           "defaultCurrency" => 'USD',
-          "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       }
     )
@@ -120,7 +119,6 @@ class PublishersHelperTest < ActionView::TestCase
           "provider" => "uphold",
           "authorized" => true,
           "defaultCurrency" => 'USD',
-          "availableCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       },
       accounts: [

--- a/test/jobs/create_uphold_cards_job_test.rb
+++ b/test/jobs/create_uphold_cards_job_test.rb
@@ -14,7 +14,7 @@ class CreateUpholdCardsJobTest < ActiveJob::TestCase
     Rails.application.secrets[:api_eyeshade_offline] = @prev_offline
   end
 
-  test "creates default currency card if default currency is possible but not available" do
+  test "creates default currency card if wallet address missing" do
     Rails.application.secrets[:api_eyeshade_offline] = false
 
     publisher = publishers(:uphold_connected)
@@ -49,7 +49,7 @@ class CreateUpholdCardsJobTest < ActiveJob::TestCase
       times: 1
   end
 
-  test "does not create default currency card if default currency is available" do
+  test "does not create default currency card if wallet address present" do
     Rails.application.secrets[:api_eyeshade_offline] = false
 
     publisher = publishers(:uphold_connected)
@@ -63,6 +63,7 @@ class CreateUpholdCardsJobTest < ActiveJob::TestCase
                              "availableCurrencies" => "BAT",
                              "possibleCurrencies" => "BAT",
                              "scope" => "cards:read, cards:write, user:read",
+                             "address" => "cc053a27-cdcd-4fdb-aa90-f0417df26242"
                            },
                "rates" => {},
                "contributions" => { "currency" => "USD"}
@@ -83,72 +84,5 @@ class CreateUpholdCardsJobTest < ActiveJob::TestCase
       "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet",
       body: "{\n  \"defaultCurrency\": \"BAT\" \n}\n",
       times: 1
-  end
-
-  test "creates BAT card if default currency is not BAT, but BAT is possible" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
-
-    publisher = publishers(:uphold_connected)
-    publisher.default_currency = "LOL"
-    publisher.save!
-
-    # stub wallet response
-    wallet = { "wallet" => { "defaultCurrency" => "USD",
-                             "authorized" => true,
-                             "availableCurrencies" => "",
-                             "possibleCurrencies" => "BAT, LOL",
-                             "scope" => "cards:read, cards:write, user:read",
-                           },
-               "rates" => {},
-               "contributions" => { "currency" => "USD"}
-    }
-
-    stub_all_eyeshade_wallet_responses(publisher: publisher, wallet: wallet)
-
-    CreateUpholdCardsJob.perform_now(publisher_id: publisher.id)
-
-    # ensure request to create BAT card was made
-    assert_requested :post,
-      "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v3/owners/#{URI.escape(publisher.owner_identifier)}/wallet/card",
-      body: '{"currency":"BAT","label":"Brave Rewards"}',
-      times: 1
-
-    # ensure request to create LOL card was made
-    assert_requested :post,
-      "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v3/owners/#{URI.escape(publisher.owner_identifier)}/wallet/card",
-      body: '{"currency":"LOL","label":"Brave Rewards"}',
-      times: 1
-
-    # ensure only one request to update eyeshade default currency was made
-    assert_requested :patch,
-      "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/owners/#{URI.escape(publisher.owner_identifier)}/wallet",
-      times: 1
-  end
-
-  test "does not create BAT card if default currency is BAT" do
-    Rails.application.secrets[:api_eyeshade_offline] = false
-
-    publisher = publishers(:uphold_connected)
-    publisher.default_currency = "BAT"
-    publisher.save!
-
-    wallet = { "wallet" => { "defaultCurrency" => "BAT",
-                             "authorized" => true,
-                             "availableCurrencies" => "BAT",
-                             "possibleCurrencies" => "BAT,LOL",
-                             "scope" => "cards:read, cards:write, user:read",
-                           },
-               "rates" => {},
-               "contributions" => { "currency" => "USD"}
-    }
-
-    stub_all_eyeshade_wallet_responses(publisher: publisher, wallet: wallet)
-
-    CreateUpholdCardsJob.perform_now(publisher_id: publisher.id)
-
-    # ensure request to create LOL card was made
-    assert_requested :post,
-      "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v3/owners/#{URI.escape(publisher.owner_identifier)}/wallet/card",
-      times: 0
   end
 end

--- a/test/jobs/create_uphold_cards_job_test.rb
+++ b/test/jobs/create_uphold_cards_job_test.rb
@@ -26,7 +26,6 @@ class CreateUpholdCardsJobTest < ActiveJob::TestCase
                              "authorized" => true,
                              "isMember" => true,
                              "status" => "ok",
-                             "availableCurrencies" => "",
                              "possibleCurrencies" => "BAT",
                              "scope" => "cards:read, cards:write, user:read",
                            },
@@ -60,7 +59,6 @@ class CreateUpholdCardsJobTest < ActiveJob::TestCase
                              "authorized" => true,
                              "isMember" => true,
                              "status" => "ok",
-                             "availableCurrencies" => "BAT",
                              "possibleCurrencies" => "BAT",
                              "scope" => "cards:read, cards:write, user:read",
                              "address" => "cc053a27-cdcd-4fdb-aa90-f0417df26242"

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -213,7 +213,6 @@ class PublisherTest < ActiveSupport::TestCase
           "provider": "uphold",
           "authorized": true,
           "defaultCurrency": 'USD',
-          "availableCurrencies": [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       }
 
@@ -255,7 +254,6 @@ class PublisherTest < ActiveSupport::TestCase
           "provider": "uphold",
           "authorized": false,
           "defaultCurrency": 'USD',
-          "availableCurrencies": [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ]
         }
       }
 
@@ -561,7 +559,6 @@ class PublisherTest < ActiveSupport::TestCase
         "provider": "uphold",
         "authorized": true,
         "defaultCurrency": 'USD',
-        "availableCurrencies": [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ],
         "scope": ["cards:write"]
       }
     }

--- a/test/services/publisher_wallet_getter_test.rb
+++ b/test/services/publisher_wallet_getter_test.rb
@@ -32,7 +32,6 @@ class PublisherWalletGetterTest < ActiveJob::TestCase
           "isMember": true,
           "status": "ok",
           "defaultCurrency": "USD",
-          "availableCurrencies": [ "EUR", "BTC", "ETH" ],
           "possibleCurrencies": [ "USD", "EUR", "BTC", "ETH", "BAT" ],
           "scope": ["cards:write"]
         },
@@ -193,7 +192,6 @@ class PublisherWalletGetterTest < ActiveJob::TestCase
         "provider": "uphold",
         "authorized": true,
         "defaultCurrency": "USD",
-        "availableCurrencies": [ "EUR", "BTC", "ETH" ],
         "possibleCurrencies": [ "USD", "EUR", "BTC", "ETH", "BAT" ],
         "scope": ["cards:write"]
       }
@@ -216,7 +214,6 @@ class PublisherWalletGetterTest < ActiveJob::TestCase
         "provider": "uphold",
         "authorized": true,
         "defaultCurrency": "USD",
-        "availableCurrencies": [ "EUR", "BTC", "ETH" ],
         "possibleCurrencies": [ "USD", "EUR", "BTC", "ETH", "BAT" ],
         "scope": ["cards:write"]
       }
@@ -253,7 +250,6 @@ class PublisherWalletGetterTest < ActiveJob::TestCase
         "provider": "uphold",
         "authorized": true,
         "defaultCurrency": "USD",
-        "availableCurrencies": [ "EUR", "BTC", "ETH" ],
         "possibleCurrencies": [ "USD", "EUR", "BTC", "ETH", "BAT" ],
         "scope": ["cards:write"]
       }

--- a/test/unit/wallet_test.rb
+++ b/test/unit/wallet_test.rb
@@ -23,7 +23,6 @@ class WalletTest < ActiveSupport::TestCase
           "provider" => "uphold",
           "authorized" => true,
           "defaultCurrency" => 'USD',
-          "availableCurrencies" => [ 'USD', 'EUR', 'BAT' ],
           "possibleCurrencies" => [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ],
           "scope" => 'cards:write'
       }

--- a/test/unit/wallet_test.rb
+++ b/test/unit/wallet_test.rb
@@ -223,7 +223,6 @@ class WalletTest < ActiveSupport::TestCase
   end
 
   test "handles initialization with empty wallet details" do
-    assert empty_wallet.available_currencies.is_a?(Array)
     assert empty_wallet.possible_currencies.is_a?(Array)
     assert empty_wallet.address.is_a?(String)
   end
@@ -234,13 +233,6 @@ class WalletTest < ActiveSupport::TestCase
     assert_equal "uphold", test_wallet.provider
     assert_equal 'cards:write', test_wallet.scope
     assert_equal "USD", test_wallet.default_currency
-    assert_equal [ 'USD', 'EUR', 'BAT' ], test_wallet.available_currencies
     assert_equal [ 'USD', 'EUR', 'BTC', 'ETH', 'BAT' ], test_wallet.possible_currencies
-  end
-
-  test "currency_is_possible_but_not_available? checks available and possible currencies" do
-    assert test_wallet.currency_is_possible_but_not_available?('ETH')
-    refute test_wallet.currency_is_possible_but_not_available?('USD')
-    refute test_wallet.currency_is_possible_but_not_available?('FAKE')
   end
 end


### PR DESCRIPTION
Resolves #1725 

Should be deployed after https://github.com/brave-intl/bat-ledger/pull/582


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
