### PR TITLE
Manual Report Download Fix 🔧 

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -60,9 +60,9 @@ class Admin::PayoutReportsController < AdminController
 
   def assign_authority(report_contents)
     report_contents = JSON.parse(report_contents)
-
     report_contents.each do |potential_payout|
-      potential_payout["authority"] = current_publisher.email # Assigns authority to admin email
+      # Assign current admin as authority, unless it is a manual report.
+      potential_payout["authority"] = current_publisher.email unless potential_payout["type"] == PotentialPayment::MANUAL 
     end
 
     report_contents.to_json

--- a/app/models/json_builders/manual_payout_report_json_builder.rb
+++ b/app/models/json_builders/manual_payout_report_json_builder.rb
@@ -12,7 +12,7 @@ class JsonBuilders::ManualPayoutReportJsonBuilder
           "altcurrency" => "BAT",
           "probi" => potential_payment.amount.to_s,
           "fees" => potential_payment.fees.to_s,
-          "authority" => Publisher.find(potential_payment.finalized_by_id).to_s,
+          "authority" => Publisher.find(potential_payment.finalized_by_id).email,
           "transactionId" => potential_payment.payout_report_id.to_s,
           "owner" => Publisher.find(potential_payment.publisher_id).owner_identifier.to_s,
           "type" => PotentialPayment::MANUAL,


### PR DESCRIPTION
## Manual Report Download Fix  🔧 

#### Summary 
There was a small issue in downloading manual reports, the existing code would overwrite the `authority` field with the currently signed in `admin`. For `manual reports` we want the `authority` field to display the admin that `finalized the invoice`. 

#### Features
* Manual report `authority` is not overwritten by the currently signed in `admin`
* Manual report `authority` field now displays the `e-mail address` instead of the `name` 

#### Notes
* For regular payout reports, the default `authority` field is null, it is set when the `download` button is clicked. 

#### How to Test
* As an `admin` request an `invoice` on a `partner`
* Finalize the `invoice`
* Log in as a different `admin`
* Generate a `manual payout report`, ensure the `authority` field is the first `admin` 
* Generate a `regular payout report`, ensure the `authority` field is the current `admin` 