### PR TITLE
Do not include publishers with missing addresses in payout report

### DIFF
--- a/app/models/json_builders/manual_payout_report_json_builder.rb
+++ b/app/models/json_builders/manual_payout_report_json_builder.rb
@@ -5,7 +5,7 @@ class JsonBuilders::ManualPayoutReportJsonBuilder
 
   def build
     contents = []
-    @payout_report.potential_payments.manual_to_be_paid.find_each do |potential_payment|
+    @payout_report.potential_payments.to_be_paid.where(kind: PotentialPayment::MANUAL).find_each do |potential_payment|
       contents.push(
         {
           "name" => potential_payment.name.to_s,

--- a/app/models/potential_payment.rb
+++ b/app/models/potential_payment.rb
@@ -17,9 +17,9 @@ class PotentialPayment < ApplicationRecord
 
   scope :to_be_paid, -> {
     where(uphold_status: "ok", reauthorization_needed: false, uphold_member: true, suspended: false).
-    where("amount::numeric > ?", 0).
-    where.not(address: "").
-    where.not(address: nil)
+      where("amount::numeric > ?", 0).
+      where.not(address: "").
+      where.not(address: nil)
   }
 
   private

--- a/app/models/potential_payment.rb
+++ b/app/models/potential_payment.rb
@@ -17,12 +17,9 @@ class PotentialPayment < ApplicationRecord
 
   scope :to_be_paid, -> {
     where(uphold_status: "ok", reauthorization_needed: false, uphold_member: true, suspended: false).
-      where("amount::numeric > ?", 0)
-  }
-
-  scope :manual_to_be_paid, -> {
-    where(uphold_status: "ok", reauthorization_needed: false, uphold_member: true, suspended: false, kind: MANUAL).
-      where("amount::numeric > ?", 0)
+    where("amount::numeric > ?", 0).
+    where.not(address: "").
+    where.not(address: nil)
   }
 
   private

--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -35,7 +35,7 @@ table.display.table.table-bordered.table-striped
         td = report.manual ? "Yes" : "No"
         td = report.expected_num_payments - report.num_payments
         td = report.num_payments_to_be_paid
-        td = report.potential_payments.to_be_paid.where(address: "").count
+        td = report.potential_payments.to_be_paid.unscope(where: :address).count
         td = "#{'%.2f' % (report.amount.to_d / 1E18)} BAT"
         td = form_tag refresh_admin_payout_report_path(report.id), method: :patch do
              = submit_tag "refresh", class: "btn btn-info"

--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -33,7 +33,7 @@ table.display.table.table-bordered.table-striped
         td = link_to report.id[0..6], admin_payout_report_path(report.id)
         td = report.final ? "Final" : "Temp"
         td = report.manual ? "Yes" : "No"
-        td = report.expected_num_payments - report.num_payments
+        td = "#{report.expected_num_payments} - #{report.num_payments}"
         td = report.num_payments_to_be_paid
         td = report.potential_payments.to_be_paid.unscope(where: :address).count
         td = "#{'%.2f' % (report.amount.to_d / 1E18)} BAT"

--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -20,45 +20,32 @@ table.display.table.table-bordered.table-striped
     th ID
     th Type
     th Manual
-    th Expected # of payments
-    th Total # of payments
+    th Expected - actual # of payments
     th # Payments to be paid
+    th # Legit payments missing addresses
     th Amount
-    th Fees
     th Refresh JSON
     th Download
   tbody
     - @payout_reports.each do |report|
       tr.gradeX
         td = report.created_at.strftime("%B %d, %Y, %H:%M")
-        td = link_to report.id, admin_payout_report_path(report.id)
+        td = link_to report.id[0..6], admin_payout_report_path(report.id)
         td = report.final ? "Final" : "Temp"
         td = report.manual ? "Yes" : "No"
-        td = report.expected_num_payments
-        td = report.num_payments
+        td = report.expected_num_payments - report.num_payments
         td = report.num_payments_to_be_paid
+        td = report.potential_payments.to_be_paid.where(address: "").count
         td = "#{'%.2f' % (report.amount.to_d / 1E18)} BAT"
-        td = "#{'%.2f' % (report.fees.to_d / 1E18)} BAT"
         td = form_tag refresh_admin_payout_report_path(report.id), method: :patch do
              = submit_tag "refresh", class: "btn btn-info"
         td = link_to "download", download_admin_payout_report_path(report.id), class: "btn btn-primary"
-
-table.display.table.table-bordered.table-striped.dynamic-table id="dynamic-table"
-  tr
-    th Total # Payments
-    th Total Amount
-    th Total Fees
-  tbody
-      tr.gradeX
-        td = PayoutReport.total_payments
-        td = "#{'%.2f' % (PayoutReport.total_amount / 1E18)  } BAT"
-        td = "#{'%.2f' % (PayoutReport.total_fees / 1E18) } BAT"
 
 hr
 
 h3 Generate Payout Report
 = form_tag admin_payout_reports_path do
-    p Final - the report will be used in settlement. 
+    p Final - the report will be used in settlement.
     p Manual - the report will include only partners with finalized invoices. ** Note - A report can be both final and manual **
     = check_box_tag :final
     span = "   "

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -85,19 +85,23 @@
           - if @potential_referral_payment.present?
             h4= payout_report_status_header('owner')
             .db-info-row
-              .db-field = "Uphold status was"
+              .db-field = "Uphold status"
               .db-value = @potential_referral_payment.uphold_status || 'unavailable'
             - if @potential_referral_payment.reauthorization_needed
               .db-info-row
-                .db-field = "Reauthorization was needed"
+                .db-field = "Reauthorization status"
                 .db-value = @potential_referral_payment.reauthorization_needed
             .db-info-row
-              .db-field = "Was Uphold member"
+              .db-field = "Uphold membership stattus"
               .db-value = @potential_referral_payment.uphold_member
             - if @potential_referral_payment.suspended
               .db-info-row
-                .db-field = "Was suspended"
+                .db-field = "Suspendension status"
                 .db-value = @potential_referral_payment.suspended
+            - if @potential_referral_payment.address.blank?
+              .db-info-row
+                .db-field = "Wallet address"
+                .db-value = "Missing"
             .db-info-row
               .db-field = "Approx. amount"
               .db-value = "#{@potential_referral_payment.amount.to_d * 1/1E18} BAT"

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -96,7 +96,7 @@
               .db-value = @potential_referral_payment.uphold_member
             - if @potential_referral_payment.suspended
               .db-info-row
-                .db-field = "Suspendension status"
+                .db-field = "Suspension status"
                 .db-value = @potential_referral_payment.suspended
             - if @potential_referral_payment.address.blank?
               .db-info-row


### PR DESCRIPTION
Resolves #1685 

A missing address causes the transaction to fail at execution time.  However that failure serves as an alert that there may be a bug with us or uphold, which we would likely miss if this pr goes in as is.

I think we may need one more component to this pr that makes sure we're aware if many people didn't make it into the payout report.  Maybe another column on the payout report page displaying # payments with of missing addresses for unknown reasons would do the job.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave-intl/publishers/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Tagged reviewers.
- [ ] Integrated piwik/matomo (for code that adds new buttons).
- [ ] Addressed or ignored all brakeman warnings

Test Plan:


Reviewer Checklist:

Tests
- [ ] Adequate test coverage exists to prevent regressions

Security:
- [ ] No raw SQL -- Always prefer ActiveRecord query helpers ([more info on StackOverflow](https://stackoverflow.com/questions/41410752/rails-5-sql-injection#41452695))
- [ ] XSS is mitigated -- Avoid `html_safe` and `raw`; escape untrusted content from users and 3rd party APIs ([Rails XSS guide](https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails) and [OWASP XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet))
