### PR TITLE
Clean up versions table

### DIFF
--- a/app/models/potential_payment.rb
+++ b/app/models/potential_payment.rb
@@ -2,7 +2,6 @@ class PotentialPayment < ApplicationRecord
   REFERRAL = "referral".freeze
   CONTRIBUTION = "contribution".freeze
   MANUAL = "manual".freeze
-  has_paper_trail
 
   belongs_to :payout_report
   belongs_to :publisher

--- a/app/models/youtube_channel_details.rb
+++ b/app/models/youtube_channel_details.rb
@@ -1,5 +1,5 @@
 class YoutubeChannelDetails < BaseChannelDetails
-  has_paper_trail
+  has_paper_trail, ignore: [:stats]
 
   validate :youtube_channel_not_changed_once_initialized
   validates :youtube_channel_id, presence: true

--- a/app/models/youtube_channel_details.rb
+++ b/app/models/youtube_channel_details.rb
@@ -1,6 +1,4 @@
 class YoutubeChannelDetails < BaseChannelDetails
-  has_paper_trail, ignore: [:stats]
-
   validate :youtube_channel_not_changed_once_initialized
   validates :youtube_channel_id, presence: true
   validates :title, presence: true

--- a/db/migrate/20190327195041_drop_legacy_versions.rb
+++ b/db/migrate/20190327195041_drop_legacy_versions.rb
@@ -1,0 +1,9 @@
+class DropLegacyVersions < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :legacy_versions
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_22_143005) do
+ActiveRecord::Schema.define(version: 2019_03_27_195041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -184,17 +184,6 @@ ActiveRecord::Schema.define(version: 2019_03_22_143005) do
     t.datetime "updated_at", null: false
     t.index ["key_handle"], name: "index_legacy_u2f_registrations_on_key_handle"
     t.index ["publisher_id"], name: "index_legacy_u2f_registrations_on_publisher_id"
-  end
-
-  create_table "legacy_versions", id: :serial, force: :cascade do |t|
-    t.string "item_type", null: false
-    t.integer "item_id", null: false
-    t.string "event", null: false
-    t.string "whodunnit"
-    t.text "object"
-    t.datetime "created_at"
-    t.text "object_changes"
-    t.index ["item_type", "item_id"], name: "index_legacy_versions_on_item_type_and_item_id"
   end
 
   create_table "legacy_youtube_channels", id: :string, force: :cascade do |t|


### PR DESCRIPTION
This drops the previous legacy versions table 
```
{
 "Channel"=>85130,
 "PayoutReport"=>14,
 "PotentialPayment"=>464330,
 "PromoRegistration"=>1240313,
 "Publisher"=>411606,
 "SiteChannelDetails"=>32483,
 "TwitchChannelDetails"=>2419,
 "YoutubeChannelDetails"=>1825780
}
```

Here are the type of entries for the Legacy versions table. Right now the model `YoutubeChannelDetails` is being updated by a job which is creating a ton of entries. One for every youtube channel. 