### PR TITLE
Fix missing payout info on Admin Publisher Page 🏷 

### DIFF
--- a/app/models/payout_report.rb
+++ b/app/models/payout_report.rb
@@ -63,7 +63,7 @@ class PayoutReport < ApplicationRecord
     end
 
     def most_recent_final_report
-      PayoutReport.all.where(final: true).order("created_at").last
+      PayoutReport.all.where(final: true, manual: false).order("created_at").last
     end
 
     def expected_num_payments(publishers)


### PR DESCRIPTION
## Fix missing payout info on Admin Publisher Page 


#### Features

Exclude `manual` payout reports from `most_recent_final_report` which will allow publisher payout data to show up again on their page. 

#### Pull Request Checklist

- [x] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [x] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [x] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [x] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [x] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [x] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
