### PR TITLE
Minor fixes for invoices

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -42,7 +42,7 @@ class Admin::PayoutReportsController < AdminController
     json.each do |entry|
       next unless entry["type"] == MANUAL && entry["owner"] && entry["amount"]
 
-      partner_id = entry["owner"].sub("publishers#uuid:", "")
+      partner_id = entry["owner"].sub(Publisher::OWNER_PREFIX, "")
 
       invoice = Invoice.where(
         partner_id: partner_id,

--- a/app/views/admin/invoices/show.html.slim
+++ b/app/views/admin/invoices/show.html.slim
@@ -4,7 +4,7 @@
   - if @invoice.in_progress?
     .ml-3
       = link_to "Generate Manual Payout", admin_partner_generate_manual_payout_path(id: @invoice.partner), class: 'btn btn-info'
-  - else
+  - elsif @invoice.pending?
     .ml-3
       = link_to "Edit", edit_admin_partner_invoice_path(@invoice), class: 'btn btn-primary'
     .ml-3


### PR DESCRIPTION
## Minor fixes for invoices

#### Features

Due to the settlement tools removing the `documentId` attribute from the list we must find by the owner and the amount to mark things as paid.

Once an invoice was paid users were able to click "Edit" which was a mistake

#### How To Test

1. Create a partner
2. Create an invoice
3. Mark that invoice as ready to be paid out
4. Copy the publisher id and the amount put it in the JSON below
5. Upload this settlement report JSON file
```json
[
  {
    "altcurrency": "BAT",
    "authority": "user@brave.com",
    "amount": "4321",
    "commission": "0",
    "currency": "BAT",
    "address": "redacted",
    "owner": "publishers#uuid:d2d9c735-522c-484c-90a6-e2da78e12c99",
    "fees": "0",
    "probi": "redacted",
    "hash": "redacted",
    "publisher": "",
    "signedTx": "",
    "status": "completed",
    "transactionId": "redacted",
    "fee": "0",
    "type": "manual",
    "validUntil": "2019-04-09T01:15:21.434437557Z",
    "note": ""
  }
]
```

