### PR TITLE
Move 2fa removal links 🏷 

### DIFF
--- a/app/views/two_factor_authentications/index.html.slim
+++ b/app/views/two_factor_authentications/index.html.slim
@@ -62,7 +62,10 @@
       - elsif @totp_enabled
         = render "totp"
     .single-panel--footer
-      span = t(".lost_account.body")
-      span = link_to(" " + t(".lost_account.body_link"), "https://support.brave.com/hc/en-us/articles/360022724391-What-do-I-do-if-I-get-locked-out-of-my-account-")
+      span = t(".lost_account.lost_2fa")
+      span = link_to(" " + t(".lost_account.lost_2fa_link"), two_factor_authentication_removal_publishers_path)
+      br
+      br
+      p = t(".lost_account.lost_2fa_note_html")
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -803,8 +803,11 @@ en:
           protocol. Please use a current release of Google Chrome or Opera.
           (IMPLEMENTATION_INCOMPLETE)
       lost_account:
-        body: Lost your 2FA?
-        body_link: Visit our Help Center to restore your account access.
+        lost_2fa: Lost your 2-factor-authentication?
+        lost_2fa_link: We can help.
+        lost_2fa_note_html: |
+          For information related to account settings, visit our <a href="https://support.brave.com/hc/en-us/articles/360022724391-What-do-I-do-if-I-get-locked-out-of-my-account-">Help Center.</a>
+
   two_factor_registrations:
     index:
       heading: Two-factor Authentication


### PR DESCRIPTION
## Move 2fa removal links 🏷 

![Screen Shot 2019-04-11 at 4 18 33 PM](https://user-images.githubusercontent.com/4713771/55990435-ac1cac00-5c75-11e9-95be-5c8921685919.png)


#### Features

Move Lost 2FA links to the 2fa auth page, to account for the new landing page. 

#### How To Test

1. Create a Publisher with U2F
2. Attempt Login
3. Create a Publisher with 2FA
4. Attempt Login

#### Pull Request Checklist

- [x] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [x] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [x] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [x] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [x] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [x] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
