### PR TITLE
Prevent chaining of channel transfers

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -19,7 +19,7 @@ module Publishers
       end
 
       existing_channel = Channel.joins(:youtube_channel_details).
-          where("youtube_channel_details.youtube_channel_id": youtube_channel_data['id']).first
+          where(verified: true, "youtube_channel_details.youtube_channel_id": youtube_channel_data['id']).first
       if existing_channel&.publisher == current_publisher
         redirect_to home_publishers_path, notice: t(".channel_already_registered")
         return
@@ -54,7 +54,7 @@ module Publishers
       uid = twitch_auth_hash[:uid]
 
       existing_channel = Channel.joins(:twitch_channel_details).
-          where("twitch_channel_details.twitch_channel_id": uid).first
+          where(verified: true, "twitch_channel_details.twitch_channel_id": uid).first
 
       if existing_channel&.publisher == current_publisher
         redirect_to home_publishers_path, notice: t(".channel_already_registered", { channel_title: existing_channel.details.display_name })
@@ -141,7 +141,7 @@ module Publishers
       }
 
       existing_channel = Channel.joins(:twitter_channel_details).
-          where("twitter_channel_details.twitter_channel_id": twitter_details_attrs[:twitter_channel_id]).first
+          where(verified: true, "twitter_channel_details.twitter_channel_id": twitter_details_attrs[:twitter_channel_id]).first
 
       if existing_channel&.publisher == current_publisher
         redirect_to home_publishers_path, notice: t(".channel_already_registered", { channel_title: existing_channel.details.screen_name })

--- a/app/models/json_builders/channels_json_builder.rb
+++ b/app/models/json_builders/channels_json_builder.rb
@@ -26,7 +26,7 @@ class JsonBuilders::ChannelsJsonBuilder
   def build
     channels = []
 
-    [Channel.verified.site_channels, Channel.youtube_channels, Channel.twitch_channels, Channel.twitter_channels].each do |verified_channels|
+    [Channel.verified.site_channels, Channel.verified.youtube_channels, Channel.verified.twitch_channels.where(verified: true), Channel.verified.twitter_channels].each do |verified_channels|
       verified_channels.find_each do |verified_channel|
         next if verified_channel.details.nil?
         if @excluded_channel_ids.include?(verified_channel.details.channel_identifier)

--- a/app/models/json_builders/channels_json_builder.rb
+++ b/app/models/json_builders/channels_json_builder.rb
@@ -26,7 +26,7 @@ class JsonBuilders::ChannelsJsonBuilder
   def build
     channels = []
 
-    [Channel.verified.site_channels, Channel.verified.youtube_channels, Channel.verified.twitch_channels.where(verified: true), Channel.verified.twitter_channels].each do |verified_channels|
+    [Channel.verified.site_channels, Channel.verified.youtube_channels, Channel.verified.twitch_channels, Channel.verified.twitter_channels].each do |verified_channels|
       verified_channels.find_each do |verified_channel|
         next if verified_channel.details.nil?
         if @excluded_channel_ids.include?(verified_channel.details.channel_identifier)

--- a/test/controllers/publishers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/publishers/omniauth_callbacks_controller_test.rb
@@ -131,6 +131,67 @@ module Publishers
       end
     end
 
+    test "a publisher who adds a youtube channel that has already been contested" do
+
+      publisher = publishers(:uphold_connected)
+      request_login_email(publisher: publisher)
+      url = publisher_url(publisher, token: publisher.reload.authentication_token)
+      get(url)
+      follow_redirect!
+
+      OmniAuth.config.mock_auth[:register_youtube_channel] = auth_hash
+
+      stub_request(:get, "https://www.googleapis.com/youtube/v3/channels?mine=true&part=statistics,snippet").
+          with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                          'Authorization' => "Bearer #{token}",
+                          'User-Agent' => 'Faraday v0.9.2' }).
+          to_return(status: 200, body: { items: [channel_data("id" => "323541525412313421")] }.to_json, headers: {})
+
+      assert_difference("Channel.count", 1) do
+        get(publisher_register_youtube_channel_omniauth_authorize_url)
+        follow_redirect!
+        assert_redirected_to home_publishers_path
+        follow_redirect!
+      end
+
+      assert_select(".channel-summary", text: channel_data["snippet"]["title"])
+
+
+      # Sign the current pub out
+      sign_out publisher
+
+      publisher = publishers(:uphold_connected_currency_unconfirmed)
+      request_login_email(publisher: publisher)
+      url = publisher_url(publisher, token: publisher.reload.authentication_token)
+      get(url)
+      follow_redirect!
+
+
+      get(publisher_register_youtube_channel_omniauth_authorize_url)
+      follow_redirect!
+      assert_redirected_to home_publishers_path
+      follow_redirect!
+
+      # Channel was transferred
+      assert_select('div.channel-status.float-right') do |element|
+        assert_match(I18n.t("shared.channel_contested", time_until_transfer: time_until_transfer(publisher.channels.where(verification_pending: true).first)), element.text)
+      end
+
+      # Check the previous transfer to make sure it was deleted
+      sign_out publisher
+
+      publisher = publishers(:uphold_connected)
+      request_login_email(publisher: publisher)
+      url = publisher_url(publisher, token: publisher.reload.authentication_token)
+      get(url)
+      follow_redirect!
+
+
+      assert_select('div.channel-status.float-right') do |element|
+        refute_match(I18n.t("shared.channel_contested", time_until_transfer: time_until_transfer(Channel.where(verification_pending: true).first)), element.text)
+      end
+    end
+
     test "a publisher who adds a youtube channel taken by themselves will see .channel_already_registered" do
       publisher = publishers(:google_verified)
       request_login_email(publisher: publisher)


### PR DESCRIPTION
## Prevent chaining of channel transfers

#### Features
This is the bug, where we saw multiple channels transfer to more than one user. 

The problem is that when the user was transferring their channel, we found the first Channel with the same id. However the channel that we found was not the original verified channel.

#### How To Test

1. Create 3 publisher accounts `a@a.com`, `b@b.com`, `c@c.com`
2. Add a channel to `a@a.com`
3. Sign into `b@b.com` add the same channel
4. Sign into `c@c.com`, add the same channel
5. Sign back into `b@b.com` channel should be gone.
6. Reject the transfer for `c@c.com`, channel should be successfully rejected. 

