### PR TITLE
Fix payout date rollover before SetPayoutInProgressJob is run

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -31,7 +31,9 @@ module PublishersHelper
   end
 
   def next_deposit_date
-    (DateTime.now + 1.month).strftime("%B 8th")
+    today = DateTime.now
+    today = today + 1.month if today.day > 8
+    today.strftime("%B 8th")
   end
 
   def publisher_overall_bat_balance(publisher)

--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -30,8 +30,7 @@ module PublishersHelper
     !!Rails.cache.fetch('payout_in_progress')
   end
 
-  def next_deposit_date
-    today = DateTime.now
+  def next_deposit_date(today = DateTime.now)
     today = today + 1.month if today.day > 8
     today.strftime("%B 8th")
   end

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -188,4 +188,14 @@ class PublishersHelperTest < ActionView::TestCase
     publisher.uphold_status = Publisher::UpholdAccountState::BLOCKED
     assert_equal "uphold-complete", uphold_status_class(publisher)
   end
+
+  test '#next_deposit_date when it is midnight UTC displays the current month' do
+    date = DateTime.parse("2019-05-01T00:00:00+0000")
+    assert_equal next_deposit_date(date), "May 8th"
+  end
+
+  test '#next_deposit_date when it is midnight PST displays current month' do
+    date = DateTime.parse("2019-05-01T00:00:00-0800")
+    assert_equal next_deposit_date(date), "May 8th"
+  end
 end


### PR DESCRIPTION
## Fix payout date rollover before SetPayoutInProgressJob is run

#### Features
This reverts the calculation of the next deposit date, Since the job runs after midnight UTC users will believe that the next time they get paid is in the month afterwards

Closes #1809