### PR TITLE
Fix calculation of last settlement

### DIFF
--- a/lib/eyeshade/last_settlement_balance.rb
+++ b/lib/eyeshade/last_settlement_balance.rb
@@ -10,7 +10,7 @@ module Eyeshade
         @amount_bat = last_settlement[:amount_bat]
         @timestamp = last_settlement[:timestamp]
         @settlement_currency = last_settlement[:currency]
-        @amount_settlement_currency = last_settlement[:amount]
+        @amount_settlement_currency = last_settlement[:amount_currency]
       end
     end
 

--- a/lib/eyeshade/last_settlement_balance.rb
+++ b/lib/eyeshade/last_settlement_balance.rb
@@ -1,16 +1,16 @@
 module Eyeshade
   class LastSettlementBalance < BaseBalance
-    attr_reader :date, :amount_settlement_currency, :timestamp, :settlement_currency
+    attr_reader :date, :amount_bat, :amount_settlement_currency, :timestamp, :settlement_currency
 
     def initialize(rates, default_currency, transactions)
       super(rates, default_currency)
 
       last_settlement = calculate_last_settlement(transactions)
       if last_settlement.present?
-        @amount_bat = last_settlement["amount_bat"]
-        @timestamp = last_settlement["timestamp"]
-        @settlement_currency = last_settlement["currency"]
-        @amount_settlement_currency = convert(@amount_bat, @settlement_currency)
+        @amount_bat = last_settlement[:amount_bat]
+        @timestamp = last_settlement[:timestamp]
+        @settlement_currency = last_settlement[:currency]
+        @amount_settlement_currency = last_settlement[:amount]
       end
     end
 
@@ -35,11 +35,23 @@ module Eyeshade
 
       # Sum the all the settlement transactions
       last_settlement_currency = last_settlement_transactions&.first["settlement_currency"] || nil
-      last_settlement_bat = last_settlement_transactions.map { |transaction|
+
+      # The amount is the BAT that was withdrawn from our ledger. This is a negative value.
+      last_settlement_amount_bat = last_settlement_transactions.map { |transaction|
+        transaction["amount"].to_d.abs
+      }.reduce(:+)
+
+      # Settlement amount will be in the user's default currency
+      last_settlement_amount_currency = last_settlement_transactions.map { |transaction|
         transaction["settlement_amount"].to_d
       }.reduce(:+)
 
-      {"amount_bat" => last_settlement_bat, "timestamp" => last_settlement_time.to_i, "currency" => last_settlement_currency}
+      {
+        amount_bat: last_settlement_amount_bat,
+        amount_currency: last_settlement_amount_currency,
+        timestamp: last_settlement_time.to_i,
+        currency: last_settlement_currency
+      }
     end
   end
 end

--- a/test/helpers/publishers_helper_test.rb
+++ b/test/helpers/publishers_helper_test.rb
@@ -145,10 +145,10 @@ class PublishersHelperTest < ActionView::TestCase
     assert_equal "58.22", publisher_overall_bat_balance(publisher)
 
     # ensure last settlement balance does not have fee applied
-    assert_equal publisher_last_settlement_bat_balance(publisher), "18.81"
+    assert_equal publisher_last_settlement_bat_balance(publisher), "94.62"
 
     # ensure publisher_converted_last_settlement does not have fee applied
-    assert_equal publisher_converted_last_settlement_balance(publisher), "~ 0.01 ETH"
+    assert_equal publisher_converted_last_settlement_balance(publisher), "~ 18.81 ETH"
 
     publisher = FakePublisher.new(
       wallet_info: nil,

--- a/test/services/publisher_wallet_getter_test.rb
+++ b/test/services/publisher_wallet_getter_test.rb
@@ -321,8 +321,8 @@ class PublisherWalletGetterTest < ActiveJob::TestCase
     wallet = PublisherWalletGetter.new(publisher: publisher).perform
     last_settlement_balance = wallet.last_settlement_balance
 
-    assert_equal last_settlement_balance.amount_bat.to_s, "226.86"
-    assert_equal last_settlement_balance.amount_settlement_currency.to_s, "0.18042880927910732262"
+    assert_equal last_settlement_balance.amount_bat.to_s, "1123.510515576367299039"
+    assert_equal last_settlement_balance.amount_settlement_currency.to_s, "226.86"
     assert_equal last_settlement_balance.settlement_currency, "ETH"
   end
 

--- a/test/unit/wallet_test.rb
+++ b/test/unit/wallet_test.rb
@@ -213,8 +213,8 @@ class WalletTest < ActiveSupport::TestCase
   test "last settlement balance has correct timestamp and amount" do
     last_settlement_balance = test_wallet.last_settlement_balance
     assert_equal last_settlement_balance.timestamp, 1544169600
-    assert_equal last_settlement_balance.amount_bat.to_s, "151.24"
-    assert_equal last_settlement_balance.amount_settlement_currency.to_s, "0.12028587285273821508"
+    assert_equal last_settlement_balance.amount_bat.to_s, "749.007010384244866026"
+    assert_equal last_settlement_balance.amount_settlement_currency.to_s, "151.24"
   end
 
   test "supports action" do


### PR DESCRIPTION
## Fix calculation of last settlement

Closes #1792

### This was the behavior before
<img width="444" alt="Brave UI error screenshot" src="https://user-images.githubusercontent.com/5459225/57714117-6dde2800-7639-11e9-85e1-daad0b31adfa.png">


#### Features

When we did the Eyeshade refactor we miscalculated the last settlement balance. Basically we assumed that the `settlement_amount` was always going to be in BAT when in reality it is set to the default currency that has set. 

Because of this we were effectively double converting the last settlement and obtaining incorrect information on the last settlement amount. 


#### How To Test

You might have to connect to eyeshade to effectively test. Basically to code this I connected to our prod instance and figured out what entries that eyeshade was returning for the transactions. For example

```json
[
  {
    "channel": "REVOKED",
    "created_at": "2019-05-09T07:16:50.772Z",
    "description": "payout for referral",
    "amount": "-12411.568331542155128098",
    "settlement_currency": "USD",
    "settlement_amount": "3777.250000000000000000",
    "settlement_destination_type": "uphold",
    "settlement_destination": "HIDDEN",
    "transaction_type": "referral_settlement"
  },
  {
    "channel": "REVOKED",
    "created_at": "2019-05-09T17:32:22.359Z",
    "description": "payout for contribution",
    "amount": "-4.750000000000000000",
    "settlement_currency": "USD",
    "settlement_amount": "1.390000000000000000",
    "settlement_destination_type": "uphold",
    "settlement_destination": "REVOKED",
    "transaction_type": "contribution_settlement"
  }
]
```

The user messaged me and said the following
>My last payment was 12411.56 BAT (worth $3778.64 USD).
>However, the interface shows 3778.64 BAT along with $1340.29 USD (which is the USD equivalent of 3778.64 BAT, but the conversion is incorrect because I actually received 12411.56 BAT).

