### PR TITLE
2FA Removal Patch 🏷 

### DIFF
--- a/app/jobs/delete_publisher_channel_job.rb
+++ b/app/jobs/delete_publisher_channel_job.rb
@@ -3,7 +3,8 @@ class DeletePublisherChannelJob < ApplicationJob
 
   def perform(channel_id:)
     @channel = Channel.find(channel_id)
-    raise "Can't remove a channel that is contesting another a channel." if @channel.verification_pending?
+    publisher = @channel.publisher
+    raise "Can't remove a channel that is contesting another a channel." if @channel.verification_pending? && !publisher.is_registered_for_2fa_removal?
 
     # If channel is being contested, approve the channel which will also delete
     if @channel.contested_by_channel.present?

--- a/app/jobs/delete_publisher_channel_job.rb
+++ b/app/jobs/delete_publisher_channel_job.rb
@@ -4,7 +4,7 @@ class DeletePublisherChannelJob < ApplicationJob
   def perform(channel_id:)
     @channel = Channel.find(channel_id)
     publisher = @channel.publisher
-    raise "Can't remove a channel that is contesting another a channel." if @channel.verification_pending? && !publisher.is_registered_for_2fa_removal?
+    raise "Can't remove a channel that is contesting another a channel." if @channel.verification_pending? && !publisher.registered_for_2fa_removal?
 
     # If channel is being contested, approve the channel which will also delete
     if @channel.contested_by_channel.present?

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -256,7 +256,7 @@ class Publisher < ApplicationRecord
     )
   end
 
-  def is_registered_for_2fa_removal?
+  def registered_for_2fa_removal?
     two_factor_authentication_removal.present?
   end
 

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -256,6 +256,10 @@ class Publisher < ApplicationRecord
     )
   end
 
+  def is_registered_for_2fa_removal?
+    two_factor_authentication_removal.present?
+  end
+
   # Remove when new dashboard is finished
   def in_new_ui_whitelist?
     partner?


### PR DESCRIPTION
## 2FA Removal Patch

#### Features

Handles the edge case where a user is attempting both a `Two Factor Removal` and `Channel Transfer` at the same time. 

Fixes - 
https://sentry.io/organizations/brave-software/issues/1016272053/?project=225116&query=transaction%3A%22Sidekiq%2FTwoFactorAuthenticationRemovalJob%22&statsPeriod=14d

#### How To Test

1. Try performing a 2FA Removal on an account with a Channel that's also contesting

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
