### PR TITLE
Stats for KYC'd Uphold accounts 🏷 

### DIFF
--- a/app/controllers/api/v1/stats/publishers_controller.rb
+++ b/app/controllers/api/v1/stats/publishers_controller.rb
@@ -67,6 +67,29 @@ class Api::V1::Stats::PublishersController < Api::V1::StatsController
     render(json: fill_in_blank_dates(result).to_json, status: 200)
   end
 
+  def channel_and_kyc_uphold_and_email_verified_signups_per_day
+    sql =
+    """
+      select p.created_at::date, count(*)
+      from (
+        select distinct publishers.*
+        from publishers
+        inner join channels
+        on channels.publisher_id = publishers.id and channels.verified = true
+        inner join uphold_connections
+        on uphold_connections.publisher_id = publishers.id
+        where role = 'publisher'
+        and uphold_connections.uphold_verified = true
+        and uphold_connections.is_member = true
+        and email is not null
+      ) as p
+      group by p.created_at::date
+      order by p.created_at::date
+    """
+    result = ActiveRecord::Base.connection.execute(sql).values
+    render(json: fill_in_blank_dates(result).to_json, status: 200)
+  end
+
   def totals
     if params[:up_to_date].present?
       up_to_date = Date.parse(params[:up_to_date])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
           get :email_verified_signups_per_day
           get :channel_and_email_verified_signups_per_day
           get :channel_uphold_and_email_verified_signups_per_day
+          get :channel_and_kyc_uphold_and_email_verified_signups_per_day
           get :javascript_enabled_usage
           get :totals
         end

--- a/test/controllers/api/v1/stats/publishers_controller_test.rb
+++ b/test/controllers/api/v1/stats/publishers_controller_test.rb
@@ -75,6 +75,25 @@ class Api::V1::Stats::PublishersControllerTest < ActionDispatch::IntegrationTest
       [1.days.ago.to_date.to_s, 0],
       [0.days.ago.to_date.to_s, 0]
     ], JSON.parse(response.body)
+
+    get "/api/v1/stats/publishers/channel_and_kyc_uphold_and_email_verified_signups_per_day", headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" }
+
+    assert_equal 200, response.status
+    assert_equal [
+      [6.days.ago.to_date.to_s, Publisher.distinct.joins(:channels).joins(:uphold_connection)
+                                         .where(created_at: 6.days.ago.beginning_of_day..6.days.ago.end_of_day,
+                                                'uphold_connections.uphold_verified': true, 'uphold_connections.is_member': true,
+                                                role: Publisher::PUBLISHER)
+                                         .where.not(email: nil)
+                                         .where(channels: { verified: true })
+                                         .count],
+      [5.days.ago.to_date.to_s, 0],
+      [4.days.ago.to_date.to_s, 0],
+      [3.days.ago.to_date.to_s, 0],
+      [2.days.ago.to_date.to_s, 0],
+      [1.days.ago.to_date.to_s, 0],
+      [0.days.ago.to_date.to_s, 0]
+    ], JSON.parse(response.body)
   end
 
   test "totals endpoint has content" do

--- a/test/fixtures/uphold_connections.yml
+++ b/test/fixtures/uphold_connections.yml
@@ -19,6 +19,7 @@ created_connection:
 connected_connection:
   uphold_verified: true
   publisher: uphold_connected
+  is_member: true
 
 verified_no_currency:
   uphold_verified: true


### PR DESCRIPTION
## Stats for KYC'd Uphold accounts

#### Features

Opens up `/api/v1/stats/publishers/channel_and_kyc_uphold_and_email_verified_signups_per_day` which tracks publishers who have 

1. Verified their `e-mail`
2. Added a verified channel 
3. Added an uphold account
4. KYC'd their uphold account

Closes #1524 

#### How To Test

1. Create a publisher account with the above criteria satisfied
2. Request `/api/v1/stats/publishers/channel_and_kyc_uphold_and_email_verified_signups_per_day` and ensure the publisher is logged there

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
