### PR TITLE
Fix pack tag

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -82,6 +82,7 @@ class Publisher < ApplicationRecord
   scope :onboarding, -> { filter_status(PublisherStatusUpdate::ONBOARDING) }
   scope :suspended, -> { filter_status(PublisherStatusUpdate::SUSPENDED) }
   scope :locked, -> { filter_status(PublisherStatusUpdate::LOCKED) }
+  scope :deleted, -> { filter_status(PublisherStatusUpdate::DELETED) }
   scope :no_grants, -> { filter_status(PublisherStatusUpdate::NO_GRANTS) }
 
   scope :not_suspended, -> {

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -170,3 +170,4 @@ hr
 
 
 = javascript_pack_tag 'tribute'
+= stylesheet_pack_tag 'tribute'

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -4,7 +4,6 @@ html
     title Publisher Admin Dashboard
     = stylesheet_link_tag 'admin/main'
     = javascript_pack_tag 'admin'
-    = stylesheet_pack_tag 'admin'
   body data-action=params[:action] data-controller=params[:controller]
     section id='container'
       = render 'admin/shared/header'


### PR DESCRIPTION
## Fix the stylesheet_pack_tag


#### Overview

During my development of the notes page I included the tribute.css in the main Admin section. I later extracted it into it's on "Tribute" file so I could isolate it's loading to just the publishers show page.

Well I forgot to take that out and so it's causing an error on staging. This is a pull request to fix that.

#### How To Test

1. I deployed this branch to staging so try logging in there :alien: