### PR TITLE
Alert for duplicate channels

### DIFF
--- a/app/controllers/admin/channels_controller.rb
+++ b/app/controllers/admin/channels_controller.rb
@@ -29,6 +29,17 @@ module Admin
       @channels = @channels.paginate(page: params[:page])
     end
 
+    def duplicates
+      @channels = Channel.duplicates
+
+      respond_to do |format|
+        format.html {}
+        format.json {
+          render json: @channels
+        }
+      end
+    end
+
     private
 
     def sortable_columns

--- a/app/javascript/packs/views/admin/publishers/Duplicates.js
+++ b/app/javascript/packs/views/admin/publishers/Duplicates.js
@@ -4,12 +4,48 @@ import * as ReactDOM from "react-dom";
 class Duplicates extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      count: 0
+    };
   }
 
-  componentDidMount() {}
+  componentDidMount() {
+    const _this = this;
+
+    fetch("/admin/channels/duplicates", {
+      headers: {
+        Accept: "application/json",
+        "X-CSRF-Token": document.head
+          .querySelector("[name=csrf-token]")
+          .getAttribute("content"),
+        "X-Requested-With": "XMLHttpRequest"
+      },
+      method: "GET"
+    })
+      .then(function(response) {
+        return response.json();
+      })
+      .then(function(myJson) {
+        _this.setState({ count: myJson.length });
+      })
+      .catch(error => console.error(error));
+  }
 
   render() {
-    return <div className="alert w-100 alert-warning">Loading</div>;
+    return (
+      <React.Fragment>
+        {this.state.count > 0 && (
+          <div className="alert mb-2 alert-warning">
+            <i className="fa fa-exclamation-circle mr-2" />
+            There are{" "}
+            <a href="/admin/channels/duplicates">
+              {this.state.count} duplicate channel(s).
+            </a>{" "}
+            This could impact payout.
+          </div>
+        )}
+      </React.Fragment>
+    );
   }
 }
 

--- a/app/javascript/packs/views/admin/publishers/Duplicates.js
+++ b/app/javascript/packs/views/admin/publishers/Duplicates.js
@@ -1,0 +1,23 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+class Duplicates extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount() {}
+
+  render() {
+    return <div className="alert w-100 alert-warning">Loading</div>;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  ReactDOM.render(
+    <Duplicates />,
+    document
+      .getElementById("duplicates")
+      .appendChild(document.createElement("div"))
+  );
+});

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -145,6 +145,22 @@ class Channel < ApplicationRecord
     }
   end
 
+  def self.duplicates
+    entries = [
+      TwitchChannelDetails.select(:name).group(:name),
+      YoutubeChannelDetails.select(:youtube_channel_id).group(:youtube_channel_id),
+      TwitterChannelDetails.select(:twitter_channel_id).group(:twitter_channel_id),
+      SiteChannelDetails.joins(:channel).where("channels.verified = true").select(:brave_publisher_id).group(:brave_publisher_id),
+      VimeoChannelDetails.select(:vimeo_channel_id).group(:vimeo_channel_id)
+    ]
+
+    duplicates = entries.map do |entry|
+      entry.having("count(*) >1").map { |x,y| x.channel_identifier }
+    end
+
+    @duplicates ||= duplicates.flatten
+  end
+
   def publication_title
     details.publication_title
   end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -147,15 +147,15 @@ class Channel < ApplicationRecord
 
   def self.duplicates
     entries = [
-      TwitchChannelDetails.select(:name).group(:name),
-      YoutubeChannelDetails.select(:youtube_channel_id).group(:youtube_channel_id),
-      TwitterChannelDetails.select(:twitter_channel_id).group(:twitter_channel_id),
+      TwitchChannelDetails.joins(:channel).where("channels.verified = true").select(:name).group(:name),
+      YoutubeChannelDetails.joins(:channel).where("channels.verified = true").select(:youtube_channel_id).group(:youtube_channel_id),
+      TwitterChannelDetails.joins(:channel).where("channels.verified = true").select(:twitter_channel_id).group(:twitter_channel_id),
       SiteChannelDetails.joins(:channel).where("channels.verified = true").select(:brave_publisher_id).group(:brave_publisher_id),
-      VimeoChannelDetails.select(:vimeo_channel_id).group(:vimeo_channel_id)
+      VimeoChannelDetails.joins(:channel).where("channels.verified = true").select(:vimeo_channel_id).group(:vimeo_channel_id),
     ]
 
     duplicates = entries.map do |entry|
-      entry.having("count(*) >1").map { |x,y| x.channel_identifier }
+      entry.having("count(*) >1").map { |x, y| x.channel_identifier }
     end
 
     @duplicates ||= duplicates.flatten

--- a/app/views/admin/channels/duplicates.html.slim
+++ b/app/views/admin/channels/duplicates.html.slim
@@ -1,0 +1,15 @@
+div.row
+  div.col-sm-12
+    section.panel
+      header.panel-heading
+        h4= "Duplicate Channels"
+      br
+      div.panel-body
+        table.display.table.table-bordered.table-striped.dynamic-table id="dynamic-table"
+          tr
+            th Channel
+          tbody
+            - @channels.each do |channel|
+              tr.gradeX
+                td
+                  = link_to(channel, admin_publishers_path(q: channel))

--- a/app/views/admin/publishers/index.html.slim
+++ b/app/views/admin/publishers/index.html.slim
@@ -1,6 +1,6 @@
+#duplicates
+= javascript_pack_tag 'views/admin/publishers/Duplicates'
 div.row
-  #duplicates
-  = javascript_pack_tag 'views/admin/publishers/Duplicates'
   div.col-sm-12
     section.panel
       header.panel-heading

--- a/app/views/admin/publishers/index.html.slim
+++ b/app/views/admin/publishers/index.html.slim
@@ -1,4 +1,6 @@
 div.row
+  #duplicates
+  = javascript_pack_tag 'views/admin/publishers/Duplicates'
   div.col-sm-12
     section.panel
       header.panel-heading
@@ -36,7 +38,7 @@ div.row
                   td = publisher.notes.order(created_at: :desc).first&.note
                   - if publisher.two_factor_authentication_removal
                     td = publisher.two_factor_authentication_removal.total_time_remaining
-                  - else 
+                  - else
                      td = "N/A"
                   td = publisher.created_at.strftime('%B %d, %Y')
                   td = distance_of_time_in_words(publisher.last_sign_in_at, Time.now) if publisher.last_sign_in_at.present?

--- a/app/views/admin/shared/_sidebar.html.slim
+++ b/app/views/admin/shared/_sidebar.html.slim
@@ -26,6 +26,7 @@ aside
             = nav_link "Youtube", admin_channels_path(type: 'youtube')
             = nav_link "Transfers", admin_channel_transfers_path
             = nav_link "Approvals", admin_channel_approvals_path
+            = nav_link "Duplicates", duplicates_admin_channels_path
 
         = nav_link "Organizations", admin_organizations_path
         = nav_link "Partners", admin_partners_path

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -4,6 +4,7 @@ html
     title Publisher Admin Dashboard
     = stylesheet_link_tag 'admin/main'
     = javascript_pack_tag 'admin'
+    = csrf_meta_tags
   body data-action=params[:action] data-controller=params[:controller]
     section id='container'
       = render 'admin/shared/header'

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ default: &default
 
 development:
   <<: *default
-  url: <%= ENV['DATABASE_URL'] || "postgres://postgres@localhost/publishers_production" %>
+  url: <%= ENV['DATABASE_URL'] || "postgres://postgres@localhost/brave_publishers_dev" %>
 
 test:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ default: &default
 
 development:
   <<: *default
-  url: <%= ENV['DATABASE_URL'] || "postgres://postgres@localhost/brave_publishers_dev" %>
+  url: <%= ENV['DATABASE_URL'] || "postgres://postgres@localhost/publishers_production" %>
 
 test:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,7 +148,12 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :channels, only: [:index]
+    resources :channels, only: [:index] do
+      collection do
+        get :duplicates
+      end
+    end
+
     resources :faq_categories, except: [:show]
     resources :faqs, except: [:show]
     resources :payout_reports, only: %i(index show create) do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 2019_04_22_195852) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
@@ -135,7 +136,7 @@ ActiveRecord::Schema.define(version: 2019_04_22_195852) do
     t.string "name"
     t.string "email"
     t.string "verification_token"
-    t.boolean "verified", default: true
+    t.boolean "verified", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sign_in_count", default: 0, null: false
@@ -361,12 +362,12 @@ ActiveRecord::Schema.define(version: 2019_04_22_195852) do
     t.datetime "updated_at", null: false
     t.datetime "two_factor_prompted_at"
     t.boolean "visible", default: true
-    t.boolean "promo_enabled_2018q1", default: false
     t.datetime "agreed_to_tos"
+    t.boolean "promo_enabled_2018q1", default: false
     t.string "promo_token_2018q1"
     t.text "role", default: "publisher"
-    t.datetime "default_currency_confirmed_at"
     t.datetime "javascript_last_detected_at"
+    t.datetime "default_currency_confirmed_at"
     t.boolean "excluded_from_payout", default: false, null: false
     t.uuid "created_by_id"
     t.uuid "default_site_banner_id"
@@ -381,8 +382,8 @@ ActiveRecord::Schema.define(version: 2019_04_22_195852) do
   create_table "sessions", id: :serial, force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
@@ -412,8 +413,8 @@ ActiveRecord::Schema.define(version: 2019_04_22_195852) do
     t.string "detected_web_host"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "https_error"
     t.jsonb "stats", default: "{}", null: false
+    t.string "https_error"
   end
 
   create_table "totp_registrations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|


### PR DESCRIPTION
# Shows an alert message on the publishers page if there's any duplicate channels

![image (13)](https://user-images.githubusercontent.com/5459225/58586210-2bfbd700-8220-11e9-8801-3f9a58422a1b.png)
<img width="1004" alt="Screen Shot 2019-05-29 at 2 39 24 PM" src="https://user-images.githubusercontent.com/5459225/58586221-31f1b800-8220-11e9-915f-891977392f29.png">

#### Features

This is so we can properly figure out what is happening when we have duplicate channels. The last time this happened we had a sentry issue but weren't aware that duplicates were an issue of the bug

#### How To Test

1. Log in, create a duplicate channel
