### PR TITLE
Decrease Redis timeout, retry logic, slack msg

### DIFF
--- a/app/jobs/cache_browser_channels_json_job.rb
+++ b/app/jobs/cache_browser_channels_json_job.rb
@@ -1,9 +1,26 @@
 class CacheBrowserChannelsJsonJob < ApplicationJob
   queue_as :heavy
 
+  MAX_RETRY = 10
+
   def perform
     channels_json = JsonBuilders::ChannelsJsonBuilder.new.build
-    result = Rails.cache.write('browser_channels_json', channels_json)
-    Rails.logger.info("CacheBrowserChannelsJsonJob updated the cached browser channels json. Result: #{result}")
+    retry_count = 0
+    result = nil
+
+    loop do
+      result = Rails.cache.write('browser_channels_json', channels_json)
+      break if result || retry_count > MAX_RETRY
+
+      retry_count += 1
+      Rails.logger.info("CacheBrowserChannelsJsonJob could not write to Redis result: #{result}. Retrying: #{retry_count}/#{MAX_RETRY}")
+    end
+
+    if result
+      Rails.logger.info("CacheBrowserChannelsJsonJob updated the cached browser channels json.")
+    else
+      SlackMessenger.new(message: "🚨 CacheBrowserChannelsJsonJob could not update the channels JSON. @publishers-team  🚨")
+      Rails.logger.info("CacheBrowserChannelsJsonJob could not update the channels JSON.")
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, {
     url: Rails.application.secrets[:redis_url],
     connect_timeout: 30,  # Defaults to 20 seconds
-    read_timeout:    10, # Defaults to 1 second
+    read_timeout:    5, # Defaults to 1 second
     write_timeout:   10, # Defaults to 1 second
 
     error_handler: -> (method:, returning:, exception:) {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
     url: Rails.application.secrets[:redis_url],
     connect_timeout: 30,  # Defaults to 20 seconds
     read_timeout:    10, # Defaults to 1 second
-    write_timeout:   60, # Defaults to 1 second
+    write_timeout:   10, # Defaults to 1 second
 
     error_handler: -> (method:, returning:, exception:) {
       # Report errors to Sentry as warnings

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, {
     url: Rails.application.secrets[:redis_url],
     connect_timeout: 30,  # Defaults to 20 seconds
-    read_timeout:    10, # Defaults to 1 second
+    read_timeout:    5, # Defaults to 1 second
     write_timeout:   10, # Defaults to 1 second
 
     error_handler: -> (method:, returning:, exception:) {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -65,7 +65,7 @@ Rails.application.configure do
     url: Rails.application.secrets[:redis_url],
     connect_timeout: 30,  # Defaults to 20 seconds
     read_timeout:    10, # Defaults to 1 second
-    write_timeout:   60, # Defaults to 1 second
+    write_timeout:   10, # Defaults to 1 second
 
     error_handler: -> (method:, returning:, exception:) {
       # Report errors to Sentry as warnings


### PR DESCRIPTION
## Attempt to fix the channels json job

#### Features

* Reduce the redis timeout to prevent our app from timing out when trying to write
* Add in retry logic
* Create a slack message every time we fail so that we have more awareness than just a sentry message