### PR TITLE
Fix queue priority

### DIFF
--- a/app/jobs/cache/piwik_data_job.rb
+++ b/app/jobs/cache/piwik_data_job.rb
@@ -1,5 +1,5 @@
 class Cache::PiwikDataJob < ApplicationJob
-  queue_as :transactional
+  queue_as :scheduler
 
   PIWIK_VISITS_SUMMARY = "piwikVisitsSummary".freeze
   PIWIK_EVENTS_CATEGORY = "piwikEventsCategory".freeze

--- a/config/heavy_sidekiq.yml
+++ b/config/heavy_sidekiq.yml
@@ -5,7 +5,6 @@
 :queues:
   - heavy
   - mailers
-  - transactional
   - scheduler
   - default
   - low
@@ -39,11 +38,11 @@
   Cache::PiwikDataJob:
     cron: "45 2 * * *"
     description: "Refreshes the redis cache for piwik information everyday at 2:45 AM"
-    queue: transactional
+    queue: scheduler
   Cache::EyeshadeStatsJob:
     cron: "50 2 * * *"
     description: "Refreshes the redis cache for eyeshade stats information"
-    queue: transactional
+    queue: scheduler
   EnqueuePublishersForPayoutJob:
     cron: "0 0 1 * *"
     description: "Generates the list of unsettled transactions on the first of every month"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,8 +5,8 @@
 :queues:
   - mailers
   - transactional
-  - scheduler
   - default
+  - scheduler
   - low
 :schedule:
   EnqueueSiteChannelVerifications:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,7 +4,6 @@
 :max_retries: 3
 :queues:
   - mailers
-  - transactional
   - default
   - scheduler
   - low
@@ -43,11 +42,11 @@
   Cache::PiwikDataJob:
     cron: "45 2 * * *"
     description: "Refreshes the redis cache for piwik information everyday at 2:45 AM"
-    queue: transactional
+    queue: scheduler
   Cache::EyeshadeStatsJob:
     cron: "50 2 * * *"
     description: "Refreshes the redis cache for eyeshade stats information"
-    queue: transactional
+    queue: scheduler
   CleanAbandonedSiteChannelsJob:
     cron: "0 3 * * *"
     description: "Remove abandoned site channels."


### PR DESCRIPTION
## Fix Queue Priority

#### Features

Moves scheduled to be less important than the default queue


Also moved the transaction queue to scheduler queue. This is because the following in the README

>I don't recommend having more than a handful of queues. Lots of queues makes for a more complex system and Sidekiq Pro cannot reliably handle multiple queues without polling. M Sidekiq Pro processes polling N queues means O(M*N) operations per second slamming Redis.

https://github.com/mperham/sidekiq/wiki/Advanced-Options