### PR TITLE
Fix 500 on statements

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -224,25 +224,25 @@ class Channel < ApplicationRecord
       channel_details_type_identifier = channel_id_split_on_prefix.first
       return SiteChannelDetails.where(brave_publisher_id: channel_details_type_identifier).
           joins(:channel).
-          where('channels.verified = true').first.channel
+          where('channels.verified = true').first&.channel
     end
 
     prefix = channel_id_split_on_prefix.first
     channel_details_type_identifier = channel_id_split_on_prefix.second
     case prefix
     when "youtube#channel"
-      YoutubeChannelDetails.where(youtube_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first.channel
+      YoutubeChannelDetails.where(youtube_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first&.channel
     when "twitter#channel"
-      TwitterChannelDetails.where(twitter_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first.channel
+      TwitterChannelDetails.where(twitter_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first&.channel
     when "vimeo#channel"
-      VimeoChannelDetails.where(vimeo_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first.channel
+      VimeoChannelDetails.where(vimeo_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first&.channel
     when "reddit#channel"
-      RedditChannelDetails.where(reddit_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first.channel
+      RedditChannelDetails.where(reddit_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first&.channel
     when "github#channel"
-      GithubChannelDetails.where(github_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first.channel
+      GithubChannelDetails.where(github_channel_id: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first&.channel
     when "twitch#channel"
     when "twitch#author"
-      TwitchChannelDetails.where(name: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first.channel
+      TwitchChannelDetails.where(name: channel_details_type_identifier).joins(:channel).where('channels.verified = true').first&.channel
     else
       Rails.logger.info("Unable to find channel for channel identifier #{channel_identifier}")
       nil

--- a/app/services/publisher_statement_getter.rb
+++ b/app/services/publisher_statement_getter.rb
@@ -44,7 +44,7 @@ class PublisherStatementGetter < BaseApiClient
         transaction["channel"] = "Manual"
       else
         channel = Channel.find_by_channel_identifier(account_identifier)
-        transaction["channel"] = channel.publication_title
+        transaction["channel"] = channel&.publication_title || account_identifier
       end
       transaction
     }


### PR DESCRIPTION
## Fix 500 on statements

#### Features

Bugfix: Users who have removed a channel can still view their statements

Basically what is happening is that we're trying to find a channel that doesn't exist and so we have a `NoMethodError` on `nil`. 😢 


**This fixes the following sentry errors**
(7 issues are here because of this)
https://sentry.io/organizations/brave-software/issues/?project=225116&query=find_by_channel_identifier&statsPeriod=14d

#### How To Test

1. Have the eyeshade response return something that is currently not in the table
2. Try to download a statement
3. Downloads and doesn't 500
