### PR TITLE
Create "only  user funds" state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - yarn install
   - yarn audit
   - yarn lint
-  - bin/rails test
+  - bundle exec rails test
   - yarn test
   - bundle exec brakeman
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn --version
-  - gem update --system
-  - gem install bundler
 cache:
   bundler: true
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn --version
+  - gem update --system
+  - gem install bundler
 cache:
   bundler: true
   yarn: true

--- a/app/assets/stylesheets/pages/home.scss
+++ b/app/assets/stylesheets/pages/home.scss
@@ -66,7 +66,6 @@
   }
 
   @include media-breakpoint-down(md) {
-
     .title,
     .btn {
       display: none;
@@ -120,7 +119,7 @@
 
     &-header {
       color: #326183;
-      letter-spacing: .5px;
+      letter-spacing: 0.5px;
     }
 
     .promo-flex-col {
@@ -172,7 +171,7 @@
         font-weight: 600;
         padding: 0 8px 0 0;
         font-size: 24px;
-        color: #FFF;
+        color: #fff;
       }
     }
 
@@ -283,7 +282,7 @@
 
     .referral-link-copy-button {
       background: $braveBrand;
-      color: $braveText-2;
+      color: white;
       height: 100%;
       border-radius: 0px 4px 4px 0px;
       cursor: pointer;
@@ -317,7 +316,6 @@
     }
 
     @include media-breakpoint-down(sm) {
-
       .referral-link-button {
         &-mobile {
           display: table-cell;
@@ -495,7 +493,6 @@
     }
 
     &.uphold-timeout {
-
       .status-summary .action,
       #uphold_dashboard,
       #uphold_connect,
@@ -507,7 +504,6 @@
 
     &.uphold-complete,
     &.uphold-processing {
-
       .status-summary .action .connect-uphold,
       #uphold_connect {
         display: none;
@@ -515,7 +511,6 @@
     }
 
     &.uphold-processing {
-
       #uphold_dashboard,
       #last_settlement,
       .statements-available {
@@ -555,7 +550,6 @@
 
     &.uphold-reauthorization-needed,
     &.uphold-unconnected {
-
       .status-summary .action .disconnect-uphold,
       .reconnect-instructions {
         display: none;
@@ -563,7 +557,6 @@
     }
 
     &.uphold-restricted {
-
       .status-summary .action .connect-uphold,
       .reconnect-instructions {
         display: none;
@@ -684,7 +677,7 @@
     padding: 32px;
 
     &:hover {
-      background: rgba(255, 255, 255, .8);
+      background: rgba(255, 255, 255, 0.8);
       text-decoration: none;
     }
   }
@@ -739,7 +732,8 @@
           font-size: 14px;
           padding: 3px 0 3px 115px;
           margin-right: 10px;
-          background: url(asset-path("channel-progress.png")) no-repeat center left;
+          background: url(asset-path("channel-progress.png")) no-repeat center
+            left;
         }
       }
     }
@@ -747,7 +741,8 @@
     &.channel-failed {
       .channel-status {
         display: flex;
-        background: url(asset-path("icn-warning@1x.png")) no-repeat top left / 24px 24px;
+        background: url(asset-path("icn-warning@1x.png")) no-repeat top left /
+          24px 24px;
         padding: 0 0 12px 38px;
         font-weight: bold;
 
@@ -1014,7 +1009,7 @@
 .modal-container--modal-identifier--choose-channel-type {
   max-width: 685px;
 
-  &>div {
+  & > div {
     width: 100%;
     background-image: url(asset-path("choose-channel/header.jpg"));
     background-repeat: no-repeat;
@@ -1151,7 +1146,14 @@
   margin: 0 0 24px;
 }
 
-p, body, h1, h2, h3, h4, h5, h6 {
+p,
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   color: $braveText-2;
 }
 

--- a/app/controllers/admin/publishers/publisher_status_updates_controller.rb
+++ b/app/controllers/admin/publishers/publisher_status_updates_controller.rb
@@ -20,6 +20,12 @@ class Admin::Publishers::PublisherStatusUpdatesController < Admin::PublishersCon
       end
     end
 
+    # If the user is being transitioned to only user funds remove all their promo registrations
+    if @publisher.only_user_funds?
+      @publisher.promo_registrations.destroy_all
+      @publisher.channels.find_each { |c| c.promo_registration&.destroy }
+    end
+
     flash[:notice] = "Updated publisher's status to #{@publisher.inferred_status}"
     redirect_to admin_publisher_path(id: @publisher.id)
   end

--- a/app/controllers/admin/publishers/publisher_status_updates_controller.rb
+++ b/app/controllers/admin/publishers/publisher_status_updates_controller.rb
@@ -20,10 +20,8 @@ class Admin::Publishers::PublisherStatusUpdatesController < Admin::PublishersCon
       end
     end
 
-    # If the user is being transitioned to only user funds remove all their promo registrations
     if @publisher.only_user_funds?
-      @publisher.promo_registrations.destroy_all
-      @publisher.channels.find_each { |c| c.promo_registration&.destroy }
+      flash[:alert] = "FYI: The promo registrations have not been destroyed for this user - however they will not see their promotions"
     end
 
     flash[:notice] = "Updated publisher's status to #{@publisher.inferred_status}"

--- a/app/helpers/admin/publishers_helper.rb
+++ b/app/helpers/admin/publishers_helper.rb
@@ -10,11 +10,12 @@ module Admin
 
     def status_badge_class(status)
       label = case status
-      when PublisherStatusUpdate::SUSPENDED
+      when PublisherStatusUpdate::SUSPENDED, PublisherStatusUpdate::ONLY_USER_FUNDS
+        "badge-danger"
         "badge-danger"
       when PublisherStatusUpdate::LOCKED
         "badge-warning"
-      when PublisherStatusUpdate::NO_GRANTS
+      when PublisherStatusUpdate::NO_GRANTS, PublisherStatusUpdate::HOLD
         "badge-dark"
       when PublisherStatusUpdate::ACTIVE
         "badge-success"

--- a/app/javascript/views/admin/components/userNavbar/components/TopNav/TopNavStyle.ts
+++ b/app/javascript/views/admin/components/userNavbar/components/TopNav/TopNavStyle.ts
@@ -111,7 +111,7 @@ export const Status = styled.div`
     background-color: #CB2431;
     `}
   ${(props: Partial<IStatusProps>) =>
-    props.status === "only user funds" &&
+    props.status === "only_user_funds" &&
     `
     background-color: #CB2431;
     `}

--- a/app/javascript/views/admin/components/userNavbar/components/TopNav/TopNavStyle.ts
+++ b/app/javascript/views/admin/components/userNavbar/components/TopNav/TopNavStyle.ts
@@ -111,6 +111,11 @@ export const Status = styled.div`
     background-color: #CB2431;
     `}
   ${(props: Partial<IStatusProps>) =>
+    props.status === "only user funds" &&
+    `
+    background-color: #CB2431;
+    `}
+  ${(props: Partial<IStatusProps>) =>
     props.status === "locked" &&
     `
     background-color: #FCCD56;

--- a/app/jobs/delete_publisher_channel_job.rb
+++ b/app/jobs/delete_publisher_channel_job.rb
@@ -17,23 +17,6 @@ class DeletePublisherChannelJob < ApplicationJob
 
     channel_is_verified = @channel.verified?
 
-    if should_update_promo_server
-      referral_code = @channel.promo_registration.referral_code
-    end
-
-    success = @channel.destroy!
-
-    # Update Eyeshade and Promo
-    if success && channel_is_verified && should_update_promo_server
-      Promo::ChannelOwnerUpdater.new(referral_code: referral_code).perform
-    end
-
-    success
-  end
-
-  private
-
-  def should_update_promo_server
-    @channel.promo_registration.present?
+    @channel.destroy!
   end
 end

--- a/app/jobs/include_publisher_in_payout_report_job.rb
+++ b/app/jobs/include_publisher_in_payout_report_job.rb
@@ -1,12 +1,12 @@
 class IncludePublisherInPayoutReportJob < ApplicationJob
   queue_as :scheduler
-  
+
   def perform(payout_report_id:, publisher_id:, should_send_notifications:)
 
     # If payout_report_id is not present, we only want to send notifications
     # not create payments
     if payout_report_id.present?
-      payout_report = PayoutReport.find(payout_report_id) 
+      payout_report = PayoutReport.find(payout_report_id)
     else
       payout_report = nil
     end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -365,7 +365,7 @@ class Channel < ApplicationRecord
   def should_register_channel_for_promo
     promo_running = Rails.application.secrets[:active_promo_id].present? # Could use PromosHelper#active_promo_id
     publisher_enabled_promo = publisher.promo_enabled_2018q1?
-    promo_running && publisher_enabled_promo && saved_change_to_verified? && verified
+    promo_running && publisher_enabled_promo && saved_change_to_verified? && verified && !publisher.only_user_funds?
   end
 
   def clear_verified_at_if_necessary

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -42,6 +42,12 @@ class PromoRegistration < ApplicationRecord
   scope :channels_only, -> { where(kind: CHANNEL) }
   scope :has_stats, -> { where.not(stats: "[]") }
 
+  before_destroy :delete_from_promo_server
+
+  def delete_from_promo_server
+    Promo::ChannelOwnerUpdater.new(referral_code: referral_code).perform
+  end
+
   # Parses the events associated with a promo registration and returns
   # the aggregate totals for each event type
   def aggregate_stats

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -225,6 +225,10 @@ class Publisher < ApplicationRecord
     last_status_update&.status == PublisherStatusUpdate::HOLD
   end
 
+  def only_user_funds?
+    last_status_update&.status == PublisherStatusUpdate::ONLY_USER_FUNDS
+  end
+
   def locked?
     last_status_update&.status == PublisherStatusUpdate::LOCKED
   end

--- a/app/models/publisher_status_update.rb
+++ b/app/models/publisher_status_update.rb
@@ -7,7 +7,7 @@ class PublisherStatusUpdate < ApplicationRecord
   DELETED = 'deleted'.freeze
   NO_GRANTS = 'no_grants'.freeze
   HOLD = 'hold'.freeze
-  ONLY_USER_FUNDS = 'only user funds'.freeze
+  ONLY_USER_FUNDS = 'only_user_funds'.freeze
 
   ALL_STATUSES = [CREATED, ONBOARDING, ACTIVE, SUSPENDED, LOCKED, NO_GRANTS, DELETED, HOLD, ONLY_USER_FUNDS].freeze
 

--- a/app/models/publisher_status_update.rb
+++ b/app/models/publisher_status_update.rb
@@ -7,8 +7,21 @@ class PublisherStatusUpdate < ApplicationRecord
   DELETED = 'deleted'.freeze
   NO_GRANTS = 'no_grants'.freeze
   HOLD = 'hold'.freeze
+  ONLY_USER_FUNDS = 'only user funds'.freeze
 
-  ALL_STATUSES = [CREATED, ONBOARDING, ACTIVE, SUSPENDED, LOCKED, NO_GRANTS, DELETED, HOLD].freeze
+  ALL_STATUSES = [CREATED, ONBOARDING, ACTIVE, SUSPENDED, LOCKED, NO_GRANTS, DELETED, HOLD, ONLY_USER_FUNDS].freeze
+
+  DESCRIPTIONS = {
+    CREATED => "User has signed up but not signed in.",
+    ONBOARDING => "User has signed in but not completed entering their information",
+    ACTIVE => "User is an active publisher. User can perform normal account operations.",
+    SUSPENDED => "Account has been placed under review.",
+    ONLY_USER_FUNDS => "User will not receive any Brave funds. Only funds that will be sent are user funded.",
+    LOCKED => "User has removed 2-FA but still needs to wait until a month has passed to receive payout.",
+    NO_GRANTS => "User can receive user funded tips and use the referral promotion system.",
+    HOLD => "User's payment is held awaiting additional information and interview on how they obtained referrals and contributions.",
+    DELETED => "user has been deleted from the publishers system.",
+  }.freeze
 
   belongs_to :publisher
   belongs_to :publisher_note

--- a/app/views/admin/publishers/publisher_status_updates/index.html.slim
+++ b/app/views/admin/publishers/publisher_status_updates/index.html.slim
@@ -33,6 +33,22 @@ h5.admin-header Change current status for #{@publisher.name}
       = " Send email (suspended & hold only)"
   = f.submit("Update Status", class: 'btn btn-primary')
 
+
+.legend.my-5
+  h2.mb-0 Legend
+  table.table
+    thead
+      tr
+        th Status
+        th Description
+    tbody
+      - PublisherStatusUpdate::DESCRIPTIONS.each do |description|
+        tr
+          td
+            span class=status_badge_class(description.first)
+              = description.first
+          td= description.second
+
 hr
 
 h5.admin-header Status history

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -203,7 +203,7 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
               .channel-panel--intro-body
                 = channel_type(channel).upcase
             - if channel.verified?
-              - if current_publisher.promo_status(promo_running?) == :active && channel.promo_enabled?
+              - if current_publisher.promo_status(promo_running?) == :active && channel.promo_enabled? && !current_publisher.only_user_funds?
                 .channel--promo-info-container
                   = link_to("", tweet_url(channel.promo_registration.referral_code), target: :_blank, class: "promo-share-button promo-share-button-twitter")
                   = link_to("", facebook_url(channel.promo_registration.referral_code), target: :_blank, class: "promo-share-button promo-share-button-facebook")

--- a/test/fixtures/publisher_status_updates.yml
+++ b/test/fixtures/publisher_status_updates.yml
@@ -39,3 +39,7 @@ suspended_partner:
 partner:
   publisher_id: ade27753-2327-40dc-a1f8-06d3339f08cf
   status: "active"
+
+only_user_funds:
+  publisher: promo_enabled_but_only_user_funds
+  status: "only user funds"

--- a/test/fixtures/publisher_status_updates.yml
+++ b/test/fixtures/publisher_status_updates.yml
@@ -42,4 +42,4 @@ partner:
 
 only_user_funds:
   publisher: promo_enabled_but_only_user_funds
-  status: "only user funds"
+  status: "only_user_funds"

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -246,6 +246,12 @@ locked_out_verifier:
 promo_enabled:
   email: "enabled@promo.org"
   name: "peter promo"
+  promo_enabled_2018q1: true
+
+promo_enabled_but_only_user_funds:
+  email: "only user funds@promo.org"
+  name: "peter promo"
+  promo_enabled_2018q1: true
 
 potentially_paid:
   email: "priscilla@potentiallypaid.org"

--- a/test/tasks/launch_promo_test.rb
+++ b/test/tasks/launch_promo_test.rb
@@ -9,8 +9,8 @@ class LaunchPromoTest < ActiveJob::TestCase
   end
 
   test "generates a promo token and sends email to each publisher" do
-    assert_difference("Publisher.where.not(promo_token_2018q1: nil).count", Publisher.where.not(email: nil).count) do
-      assert_enqueued_jobs(Publisher.where.not(email: nil).count) do
+    assert_difference("Publisher.where.not(promo_token_2018q1: nil).count", Publisher.where.not(email: nil, promo_enabled_2018q1: true).count) do
+      assert_enqueued_jobs(Publisher.where.not(email: nil, promo_enabled_2018q1: true).count) do
         Rake::Task["promo:launch_promo"].invoke
         Rake::Task["promo:launch_promo"].reenable
       end


### PR DESCRIPTION
## Create "only  user funds" state


#### Features

- Create new state called "only user funds"
  - Remove promo registrations when they are being deleted
- Handle new 409 statuses being returned when promo server has user under `no-ugp` owner state.

#### How To Test

Prereqs
- Have the promo server running
- Be able to create many channels

1. Create a channel that will be able to generate a promo code
2. Insert into our publisher into the the promo server

```sql
INSERT INTO owner_states (owner_id, state) VALUES ('3a1dd608-7552-40f2-ad49-92439bb91fa2', 'no-ugp');
```

3. Try to add another channel
4. No promo registration will be created for it 🎉
5. Move publisher over to the `only user funds` state.
6. It deletes all the `PromoRegi`strations