### PR TITLE
TOS Email update - Add in some optional parameters

### DIFF
--- a/lib/tasks/email_tos_update.rake
+++ b/lib/tasks/email_tos_update.rake
@@ -1,19 +1,27 @@
 namespace :email do
-  task :tos_update => :environment do
-    puts "Emailing #{Publisher.count} users"
+  task :tos_update, [:id ] => :environment do |t, args|
 
-    Publisher.order(:id).find_each.with_index do |user, index|
+    publisher = Publisher
+    if args[:id].present?
+      publisher = publisher.where("id >= ?", args[:id])
+    end
+
+    puts "Emailing #{publisher.count} users"
+    publisher.order(id: :desc).find_each.with_index do |user, index|
       begin
         PublisherMailer.update_to_tos(user).deliver_now
         print '.' if index % 1000 == 0
-      rescue
-        # Let's rescue all exceptions
-        print "X"
-        Rails.logger.info "[#{Time.now.iso8601}] Could not send terms and conditions for [#{user.id}]"
+      rescue => ex
+        puts
+        puts "Rescued from exception: #{ex.message}"
+        puts "Could not send email to #{user.id} - Restart the job by running the following"
+        puts
+        puts "    rake email:tos_update[\"#{user.id}\"]"
+        break
       end
     end
 
     puts
-    puts "✨ Done"
+    puts "Done"
   end
 end


### PR DESCRIPTION
## TOS Email Update

#### Features

* Allows you to resume if there was an exception found

```sh
Emailing 4 users
.
Rescued from exception: idk timeout or somethin
Could not send email to e086cf4e-efc5-4a42-a132-f8fb47ca5742 - Restart the job by running the following

    rake email:tos_update["e086cf4e-efc5-4a42-a132-f8fb47ca5742"]
```

Now if you run 

```sh
~/r/publishers ❯❯❯     rake email:tos_update["e086cf4e-efc5-4a42-a132-f8fb47ca5742"]
2019-06-19 13:57:12 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
Emailing 2 users
.
Done
```
