### PR TITLE
Remove useless slack message and skip 

### DIFF
--- a/app/jobs/create_uphold_cards_job.rb
+++ b/app/jobs/create_uphold_cards_job.rb
@@ -6,7 +6,6 @@ class CreateUpholdCardsJob < ApplicationJob
     uphold_connection = UpholdConnection.find(uphold_connection_id)
     unless uphold_connection.can_create_uphold_cards?
       Rails.logger.info("Could not create uphold card for publisher #{uphold_connection.publisher_id}. Uphold Verified: #{uphold_connection.uphold_verified}")
-      SlackMessenger.new(message: "Could not create uphold card for publisher #{uphold_connection.publisher_id}.", channel: SlackMessenger::ALERTS).perform
       return
     end
 

--- a/app/jobs/migrate_uphold_access_parameters_job.rb
+++ b/app/jobs/migrate_uphold_access_parameters_job.rb
@@ -12,7 +12,10 @@ class MigrateUpholdAccessParametersJob < ApplicationJob
         default_currency_confirmed_at: connection.publisher.default_currency_confirmed_at || Time.now
       )
 
-      connection.sync_from_uphold!
+      was_successful = connection.sync_from_uphold!
+      # Let's not queue up a job that will ultimately not work due to invalid access_parameters
+      next unless was_successful
+
       connection.reload
 
       # Sync the uphold card or create it if the card is missing


### PR DESCRIPTION
## Remove useless slack message and skip 

#### Features

During the staging migration we received a lot of slack alerts. This led me to find that if Uphold returns a 401 (`invalid_token`) then we continue down and try to create an uphold card for that user. 

This will improve performance during the migration