### PR TITLE
Fix #2106

### DIFF
--- a/app/controllers/publishers/uphold_controller.rb
+++ b/app/controllers/publishers/uphold_controller.rb
@@ -4,6 +4,8 @@ module Publishers
     # Traditional usage of helpers should really only be for views
     include PublishersHelper
 
+    before_action :authenticate_publisher!
+
     def uphold_status
       publisher = current_publisher
       respond_to do |format|
@@ -54,6 +56,10 @@ module Publishers
 
     # Generates an Uphold State Token for the user
     def connect_uphold
+      # For some reason sometimes the uphold connection doesn't always create in the home controller.
+      # If they click the button we should ensure that the
+      UpholdConnection.create(publisher: current_publisher) if current_publisher.uphold_connection.blank?
+
       current_publisher.uphold_connection&.prepare_uphold_state_token
 
       redirect_to Rails.application.secrets[:uphold_authorization_endpoint].

--- a/app/controllers/publishers/uphold_controller.rb
+++ b/app/controllers/publishers/uphold_controller.rb
@@ -56,16 +56,18 @@ module Publishers
 
     # Generates an Uphold State Token for the user
     def connect_uphold
+      uphold_connection = current_publisher.uphold_connection
+
       # For some reason sometimes the uphold connection doesn't always create in the home controller.
       # If they click the button we should ensure that the
-      UpholdConnection.create(publisher: current_publisher) if current_publisher.uphold_connection.blank?
+      uphold_connection = UpholdConnection.create(publisher: current_publisher) if uphold_connection.blank?
 
-      current_publisher.uphold_connection&.prepare_uphold_state_token
+      uphold_connection.prepare_uphold_state_token
 
       redirect_to Rails.application.secrets[:uphold_authorization_endpoint].
         gsub('<UPHOLD_CLIENT_ID>', Rails.application.secrets[:uphold_client_id]).
         gsub('<UPHOLD_SCOPE>', Rails.application.secrets[:uphold_scope]).
-        gsub('<STATE>', current_publisher.uphold_connection&.uphold_state_token)
+        gsub('<STATE>', uphold_connection.uphold_state_token)
     end
 
     # This creates the uphold connection

--- a/app/controllers/publishers/uphold_controller.rb
+++ b/app/controllers/publishers/uphold_controller.rb
@@ -56,18 +56,12 @@ module Publishers
 
     # Generates an Uphold State Token for the user
     def connect_uphold
-      uphold_connection = current_publisher.uphold_connection
-
-      # For some reason sometimes the uphold connection doesn't always create in the home controller.
-      # If they click the button we should ensure that the
-      uphold_connection = UpholdConnection.create(publisher: current_publisher) if uphold_connection.blank?
-
-      uphold_connection.prepare_uphold_state_token
+      current_publisher.uphold_connection.prepare_uphold_state_token
 
       redirect_to Rails.application.secrets[:uphold_authorization_endpoint].
         gsub('<UPHOLD_CLIENT_ID>', Rails.application.secrets[:uphold_client_id]).
         gsub('<UPHOLD_SCOPE>', Rails.application.secrets[:uphold_scope]).
-        gsub('<STATE>', uphold_connection.uphold_state_token)
+        gsub('<STATE>', current_publisher.uphold_connection.uphold_state_token)
     end
 
     # This creates the uphold connection


### PR DESCRIPTION
## Fix #2106

#### Features

On some accounts the uphold_connection is nil. This adds a check to create the UpholdConnection if the user is trying to access a relation that doesn't exist