### PR TITLE
Fix indentation and align filter

### DIFF
--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -1,13 +1,14 @@
 .panel-heading
   h4 Payout Reports
-  .ml-4
+  .d-flex
     = form_tag upload_settlement_report_admin_payout_reports_path, id: "settlementForm", multipart: :true
       label
         = file_field_tag :file, { class: 'd-none', id: "settlementFile",  accept: ".json,application/json" }
         .btn.btn-primary Upload Settlement Report
+
+    = form_tag toggle_payout_in_progress_admin_payout_reports_path
       - toggle_text = Rails.cache.fetch('payout_in_progress') ? "Remove payout in progress" : "Set payout in progress"
-      = form_tag toggle_payout_in_progress_admin_payout_reports_path
-        = submit_tag("#{toggle_text}", class: "btn btn-primary")
+      = submit_tag(toggle_text, class: "btn btn-primary")
 
 javascript:
   document.getElementById('settlementFile').addEventListener("change", function() {

--- a/app/views/admin/publishers/index.html.slim
+++ b/app/views/admin/publishers/index.html.slim
@@ -3,18 +3,18 @@
 div.row
   div.col-sm-12
     section.panel
-      header.panel-heading
-        h4 Publishers
-      .action-group
-        = form_tag(admin_publishers_path, method: "get")
-          .input-group
-            = text_field_tag(:q, params[:q], class:'form-control')
-            .input-group-btn
-              = submit_tag("Search", class: 'btn btn-default', name: nil)
-          .form-inline.mt-1
-            = select_tag(:status, options_for_select(PublisherStatusUpdate::ALL_STATUSES, params[:status]), include_blank: "Filter by status" , class: "form-control mr-2", onchange:"this.form.submit()")
-            = select_tag(:role, options_for_select(Publisher::ROLES, params[:role]), include_blank: "Filter by role" , class: "form-control",  onchange: "this.form.submit()")
-            = select_tag(:uphold_status, options_for_select(["ok", "blocked", "restricted", "pending"], params[:uphold_status]), include_blank: "Filter by uphold status" , class: "form-control",  onchange: "this.form.submit()")
+      h4 Publishers
+      = form_tag(admin_publishers_path, method: "get", class: 'action-group')
+        .input-group.align-self-end
+          = text_field_tag(:q, params[:q], class:'form-control')
+          .input-group-btn
+            = submit_tag("Search", class: 'btn btn-default', name: nil)
+        .mt-1
+          small.text-muted FILTER
+          .d-flex
+            = select_tag(:status, options_for_select(PublisherStatusUpdate::ALL_STATUSES, params[:status]), include_blank: "Status" , class: "form-control mr-1", onchange:"this.form.submit()")
+            = select_tag(:role, options_for_select(Publisher::ROLES, params[:role]), include_blank: "Role" , class: "mx-1 form-control",  onchange: "this.form.submit()")
+            = select_tag(:uphold_status, options_for_select(["ok", "blocked", "restricted", "pending"], params[:uphold_status]), include_blank: "Uphold status" , class: "ml-1 form-control",  onchange: "this.form.submit()")
       br
       div.panel-body
         div.adv-table


### PR DESCRIPTION
## Fix indention

#### Features

The "Remove payout in progress" and "Set payout in progress" buttons on the payout report were.

Also modified the design of the filters a little bit to correspond with Ross's original design 
<img width="1419" alt="Screen Shot 2019-08-09 at 12 34 20 PM" src="https://user-images.githubusercontent.com/5459225/62797835-4f55c480-baa2-11e9-903d-4932d77dad7a.png">
