### PR TITLE
Fix Publisher Uphold Cards

### DIFF
--- a/app/jobs/create_uphold_cards_job.rb
+++ b/app/jobs/create_uphold_cards_job.rb
@@ -9,16 +9,37 @@ class CreateUpholdCardsJob < ApplicationJob
       return
     end
 
-    card = nil
+    # We create the cards, so let's first check to see if the publisher has an address so we might not have to change anything
+    if uphold_connection.address.present?
+      begin
+        card = uphold_connection.uphold_client.card.find(uphold_connection: uphold_connection, id: uphold_connection.address)
+
+        return if card&.currency.eql?(uphold_connection.default_currency)
+      rescue Faraday::ResourceNotFound
+        # This most likely won't ever happen because it's not possible to delete a card. Better safe than sorry.
+      end
+    end
 
     # Search for an existing card
     cards = uphold_connection.uphold_client.card.where(uphold_connection: uphold_connection)
     existing_private_cards = UpholdConnectionForChannel.select(:card_id).where(uphold_connection: uphold_connection).to_a
 
+    # This is the default label that we apply to a card. If we find it then it's safe to assume that this was one we've created prior.
+    card = cards.detect { |c| c.label.eql?("Brave Rewards") }
+
+    # User's can change the label's on their cards so if we couldn't find it, we'll have to iterate until we find a card that matches are criteria
+    # 1. Isn't the browser's wallet card
+    # 2. Isn't a channel card
     cards.each do |c|
+      break if card.present?
+
       # We don't want to accidentally set the Publisher's card used for auto contribute and referral deposits into a channel card
-      # So we should check the address for the card and make sure that we haven't already used it
-      card = c and break if existing_private_cards.exclude?(c.id)
+      # So we should check the address for the card and make sure it doesn't have a private address.
+      next if existing_private_cards.include?(c.id)
+      # Failsafe, for if the private card is missing
+      next if has_private_address?(uphold_connection, c.id)
+
+      card = c
     end
 
     # If the card doesn't exist so we should create it
@@ -29,5 +50,14 @@ class CreateUpholdCardsJob < ApplicationJob
 
     # Finally let's update the address with the id of the card
     uphold_connection.update(address: card.id)
+  end
+
+  # Makes an HTTP Call to the Uphold card/:id/address endpoint to determine if the card has a private address
+  #
+  # Returns true if the card has a private address
+  def has_private_address?(uphold_connection, card_id)
+    addresses = uphold_connection.uphold_client.address.all(uphold_connection: uphold_connection, id: card_id)
+
+    addresses.detect { |a| a.type == UpholdConnectionForChannel::NETWORK }.present?
   end
 end

--- a/app/jobs/create_uphold_cards_job.rb
+++ b/app/jobs/create_uphold_cards_job.rb
@@ -4,43 +4,15 @@ class CreateUpholdCardsJob < ApplicationJob
 
   def perform(uphold_connection_id:)
     uphold_connection = UpholdConnection.find(uphold_connection_id)
+
     unless uphold_connection.can_create_uphold_cards?
       Rails.logger.info("Could not create uphold card for publisher #{uphold_connection.publisher_id}. Uphold Verified: #{uphold_connection.uphold_verified}")
       return
     end
 
-    # We create the cards, so let's first check to see if the publisher has an address so we might not have to change anything
-    if uphold_connection.address.present?
-      begin
-        card = uphold_connection.uphold_client.card.find(uphold_connection: uphold_connection, id: uphold_connection.address)
+    return if address_already_exists?(uphold_connection)
 
-        return if card&.currency.eql?(uphold_connection.default_currency)
-      rescue Faraday::ResourceNotFound
-        # This most likely won't ever happen because it's not possible to delete a card. Better safe than sorry.
-      end
-    end
-
-    # Search for an existing card
-    cards = uphold_connection.uphold_client.card.where(uphold_connection: uphold_connection)
-    existing_private_cards = UpholdConnectionForChannel.select(:card_id).where(uphold_connection: uphold_connection).to_a
-
-    # This is the default label that we apply to a card. If we find it then it's safe to assume that this was one we've created prior.
-    card = cards.detect { |c| c.label.eql?("Brave Rewards") }
-
-    # User's can change the label's on their cards so if we couldn't find it, we'll have to iterate until we find a card that matches are criteria
-    # 1. Isn't the browser's wallet card
-    # 2. Isn't a channel card
-    cards.each do |c|
-      break if card.present?
-
-      # We don't want to accidentally set the Publisher's card used for auto contribute and referral deposits into a channel card
-      # So we should check the address for the card and make sure it doesn't have a private address.
-      next if existing_private_cards.include?(c.id)
-      # Failsafe, for if the private card is missing
-      next if has_private_address?(uphold_connection, c.id)
-
-      card = c
-    end
+    card = find_existing_card(uphold_connection)
 
     # If the card doesn't exist so we should create it
     if card.blank?
@@ -52,10 +24,49 @@ class CreateUpholdCardsJob < ApplicationJob
     uphold_connection.update(address: card.id)
   end
 
+  # Iterates through the existing cards for an Uphold Account to find if we've already created a card
+  #
+  # Returns nil, or the card that was found
+  def find_existing_card(uphold_connection)
+    cards = uphold_connection.uphold_client.card.where(uphold_connection: uphold_connection)
+
+    # This is the default label that we apply to a card. If we find it then it's safe to assume that this was one we've created prior.
+    card = cards.detect { |c| c.label.eql?("Brave Rewards") }
+
+    # User's can change the label's on their cards so if we couldn't find it, we'll have to iterate until we find a card.
+    # We want to make sure isn't the browser's wallet card and isn't a channel card. We can do this by checking the private address
+    cards.each do |c|
+      break if card.present?
+      next if has_private_address?(uphold_connection, c.id)
+
+      card = c
+    end
+
+    card
+  end
+
+  # Checks to see if the address already exist and is in the right currency
+  #
+  # Returns true if the address is in the same currency as the existing connection address
+  def address_already_exists?(uphold_connection)
+    return if uphold_connection.address.blank?
+
+    card = uphold_connection.uphold_client.card.find(
+      uphold_connection: uphold_connection,
+      id: uphold_connection.address
+    )
+
+    card&.currency.eql?(uphold_connection.default_currency)
+  rescue Faraday::ResourceNotFound
+  end
+
   # Makes an HTTP Call to the Uphold card/:id/address endpoint to determine if the card has a private address
   #
   # Returns true if the card has a private address
   def has_private_address?(uphold_connection, card_id)
+    @existing_private_cards ||= UpholdConnectionForChannel.select(:card_id).where(uphold_connection: uphold_connection).to_a
+    return true if existing_private_cards.include?(c.id)
+
     addresses = uphold_connection.uphold_client.address.all(uphold_connection: uphold_connection, id: card_id)
 
     addresses.detect { |a| a.type == UpholdConnectionForChannel::NETWORK }.present?

--- a/app/jobs/create_uphold_cards_job.rb
+++ b/app/jobs/create_uphold_cards_job.rb
@@ -65,7 +65,7 @@ class CreateUpholdCardsJob < ApplicationJob
   # Returns true if the card has a private address
   def has_private_address?(uphold_connection, card_id)
     @existing_private_cards ||= UpholdConnectionForChannel.select(:card_id).where(uphold_connection: uphold_connection).to_a
-    return true if existing_private_cards.include?(c.id)
+    return true if @existing_private_cards.include?(card_id)
 
     addresses = uphold_connection.uphold_client.address.all(uphold_connection: uphold_connection, id: card_id)
 

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -12,6 +12,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
   before do
     @prev_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
     stub_request(:get, /cards\?q/).to_return(body: [].to_json)
+    stub_request(:get, /v0\/me\/cards/).to_return(body: '{}')
     stub_request(:post, Rails.application.secrets[:uphold_api_uri] + "/v0/me/cards").to_return(body: {id: '123e4567-e89b-12d3-a456-426655440000'}.to_json)
   end
 

--- a/test/jobs/create_uphold_cards_job_test.rb
+++ b/test/jobs/create_uphold_cards_job_test.rb
@@ -9,6 +9,7 @@ class CreateUpholdCardsJobTest < ActiveJob::TestCase
   before(:example) do
     @prev_offline = Rails.application.secrets[:api_eyeshade_offline]
     stub_request(:get, Rails.application.secrets[:uphold_api_uri] + "/v0/me/cards?q=currency:USD").to_return(body: [].to_json)
+    stub_request(:get, /v0\/me\/cards/).to_return(body: '{}')
     stub_request(:post, Rails.application.secrets[:uphold_api_uri] + "/v0/me/cards").to_return(body: {id: '123e4567-e89b-12d3-a456-426655440000'}.to_json)
   end
 


### PR DESCRIPTION
## Fix Publisher Uphold Cards

#### Features

Some of the publishers that have existing cards linked are having their cards link automatically to their wallet. This adds some additional logic to try and prevent that and add deterministic lookups when `CreateUpholdCardsJob` is called.

**The strategy is:**
We look up the existing address on the connection If it’s the same currency as the uphold_connection then we don’t modify anything.

If it’s not, then we get a list of the uphold’s users cards, then iterate on each one of them to ensure that
   1. they aren’t for a channel (we haven’t stored them in the Uphold
   2. they don’t have a private address (This one requires an API card per card to /card/:id/addresses

If there are no results that match that then we simply create the card