### PR TITLE
Publisher Channels V3 API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,6 +165,8 @@ group :development do
   gem "byebug"
   gem "pry-byebug", require: false
 
+  gem 'bullet'
+
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem "web-console"
   gem "listen", "~> 3.0.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,9 @@ GEM
     browser (2.5.3)
     bson (4.5.0)
     builder (3.2.3)
+    bullet (6.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
@@ -485,6 +488,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
+    uniform_notifier (1.12.1)
     vcr (5.0.0)
     warden (1.2.8)
       rack (>= 2.0.6)
@@ -536,6 +540,7 @@ DEPENDENCIES
   bootstrap (>= 4.3.1)
   brakeman
   browser
+  bullet
   bundler-audit
   byebug
   cancancan

--- a/app/controllers/admin/stats/contributions_controller.rb
+++ b/app/controllers/admin/stats/contributions_controller.rb
@@ -4,8 +4,8 @@ class Admin::Stats::ContributionsController < AdminController
     @publishers = Publisher.where(id: @result.map { |entry| entry['account_id'].split(":")[1] }).load
     @youtube_channel_details = YoutubeChannelDetails
       .where(youtube_channel_id:
-             @result.select { |entry| entry['channel'].starts_with?(YoutubeChannelDetails::YOUTUBE_PREFIX) }
-                    .map{ |entry| entry['channel'].remove(YoutubeChannelDetails::YOUTUBE_PREFIX) }
+             @result.select { |entry| entry['channel'].starts_with?(YoutubeChannelDetails::PREFIX) }
+                    .map{ |entry| entry['channel'].remove(YoutubeChannelDetails::PREFIX) }
       ).load
   end
 end

--- a/app/controllers/admin/stats/referrals_controller.rb
+++ b/app/controllers/admin/stats/referrals_controller.rb
@@ -4,8 +4,8 @@ class Admin::Stats::ReferralsController < AdminController
     @publishers = Publisher.where(id: @result.map { |entry| entry['account_id'].split(":")[1] }).load
     @youtube_channel_details = YoutubeChannelDetails
       .where(youtube_channel_id:
-             @result.select { |entry| entry['channel'].starts_with?(YoutubeChannelDetails::YOUTUBE_PREFIX) }
-                    .map{ |entry| entry['channel'].remove(YoutubeChannelDetails::YOUTUBE_PREFIX) }
+             @result.select { |entry| entry['channel'].starts_with?(YoutubeChannelDetails::PREFIX) }
+                    .map{ |entry| entry['channel'].remove(YoutubeChannelDetails::PREFIX) }
       ).load
   end
 end

--- a/app/controllers/api/v3/public/base_controller.rb
+++ b/app/controllers/api/v3/public/base_controller.rb
@@ -1,0 +1,8 @@
+class Api::V3::Public::BaseController < ActionController::API
+    # This BaseController does not IP whitelist, whereas API::BaseController does
+    before_action :set_public_cache_control
+
+    def set_public_cache_control
+      expires_in 1.hour, public: true
+    end
+  end

--- a/app/controllers/api/v3/public/channels_controller.rb
+++ b/app/controllers/api/v3/public/channels_controller.rb
@@ -1,14 +1,55 @@
+require 'sentry-raven'
+
 class Api::V3::Public::ChannelsController < Api::V3::Public::BaseController
   def channels
     channels_json = Rails.cache.fetch('browser_channels_json_v3', race_condition_ttl: 30) do
-      require 'sentry-raven'
-      Raven.capture_message("Failed to use redis cache for /api/public/channels V2, using DB instead.")
+      Raven.capture_message("Failed to use redis cache for /api/public/channels V3, using DB instead.")
       channels_json = JsonBuilders::ChannelsJsonBuilderV3.new.build
     end
     render(json: channels_json, status: 200)
   end
 
   def totals
-    render(json: Channel.statistical_totals, status: 200)
+    channels_json = Rails.cache.fetch('browser_channels_json_v3', race_condition_ttl: 30)
+
+    results = JSON.parse(channels_json)
+
+    prefixes = [
+      TwitchChannelDetails,
+      GithubChannelDetails,
+      YoutubeChannelDetails,
+      SiteChannelDetails,
+      RedditChannelDetails,
+      VimeoChannelDetails,
+      TwitterChannelDetails
+    ].map { |x| x.const_get('PREFIX') if x.const_defined?('PREFIX') }.compact
+
+    counts = { site: {}, all_channels: {} }
+    prefixes.each { |x| counts[x] = {} }
+
+    results.each do |c|
+      status = c[1]
+      next unless status.present?
+
+      entry = c.first.split(':').first + ":"
+      entry = :site if counts.keys.exclude?(entry)
+
+      counts[entry][status] = 0 if counts[entry][status].blank?
+
+      counts[entry][status] += 1
+      counts[:all_channels][status] = 0 if counts[:all_channels][status].blank?
+      counts[:all_channels][status] +=1
+    end
+
+    statistical_totals = counts.transform_keys { |k| k.to_s.split('#')[0] }
+
+    statistical_totals.keys.map do |k|
+      statistical_totals[k][:total] = statistical_totals[k].sum { |k, v| v }
+    end
+    render(json: statistical_totals, status: 200)
   end
+
+  # def totals
+  #   render(json: Channel.statistical_totals, status: 200)
+  # end
 end

--- a/app/controllers/api/v3/public/channels_controller.rb
+++ b/app/controllers/api/v3/public/channels_controller.rb
@@ -14,6 +14,7 @@ class Api::V3::Public::ChannelsController < Api::V3::Public::BaseController
 
     results = JSON.parse(channels_json)
 
+    # This generates a list of the prefixes for channels ["youtube#channel:", "twitter#channel:", "twitch#:channel:"]
     prefixes = [
       TwitchChannelDetails,
       GithubChannelDetails,
@@ -27,29 +28,33 @@ class Api::V3::Public::ChannelsController < Api::V3::Public::BaseController
     counts = { site: {}, all_channels: {} }
     prefixes.each { |x| counts[x] = {} }
 
-    results.each do |c|
-      status = c[1]
+    results.each do |channel|
+      status = channel.second
       next unless status.present?
 
-      entry = c.first.split(':').first + ":"
+      entry = channel.first.split(':').first + ":"
       entry = :site if counts.keys.exclude?(entry)
 
+      # Essentially this is doing the following
+      # counts["reddit#channel:"]["connected"] = 0
+      # counts["github#channel:"]["verified"] = 0
       counts[entry][status] = 0 if counts[entry][status].blank?
 
       counts[entry][status] += 1
+
+      # Initialize if nil
       counts[:all_channels][status] = 0 if counts[:all_channels][status].blank?
-      counts[:all_channels][status] +=1
+      counts[:all_channels][status] += 1
     end
 
+    # Remove the #channel: from youtube#channel: so it's formatted in a readable way
     statistical_totals = counts.transform_keys { |k| k.to_s.split('#')[0] }
 
+    # Generates the totals for each property
     statistical_totals.keys.map do |k|
       statistical_totals[k][:total] = statistical_totals[k].sum { |k, v| v }
     end
+
     render(json: statistical_totals, status: 200)
   end
-
-  # def totals
-  #   render(json: Channel.statistical_totals, status: 200)
-  # end
 end

--- a/app/controllers/api/v3/public/channels_controller.rb
+++ b/app/controllers/api/v3/public/channels_controller.rb
@@ -1,0 +1,14 @@
+class Api::V3::Public::ChannelsController < Api::V3::Public::BaseController
+  def channels
+    channels_json = Rails.cache.fetch('browser_channels_json_v3', race_condition_ttl: 30) do
+      require 'sentry-raven'
+      Raven.capture_message("Failed to use redis cache for /api/public/channels V2, using DB instead.")
+      channels_json = JsonBuilders::ChannelsJsonBuilderV3.new.build
+    end
+    render(json: channels_json, status: 200)
+  end
+
+  def totals
+    render(json: Channel.statistical_totals, status: 200)
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,9 +1,6 @@
 class ApplicationJob < ActiveJob::Base
   # Send handled exceptions to Sentry (which normally only sends unhandled exceptions).
   require "error_handler_delegator"
-
-  include Bullet::ActiveJob if Rails.env.development?
-
   def self.new(*args, &block)
     ErrorHandlerDelegator.new(super)
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,6 +2,8 @@ class ApplicationJob < ActiveJob::Base
   # Send handled exceptions to Sentry (which normally only sends unhandled exceptions).
   require "error_handler_delegator"
 
+  include Bullet::ActiveJob if Rails.env.development?
+
   def self.new(*args, &block)
     ErrorHandlerDelegator.new(super)
   end

--- a/app/jobs/cache_browser_channels_json_job_v3.rb
+++ b/app/jobs/cache_browser_channels_json_job_v3.rb
@@ -1,0 +1,26 @@
+class CacheBrowserChannelsJsonJobV3 < ApplicationJob
+  queue_as :heavy
+
+  MAX_RETRY = 10
+
+  def perform
+    channels_json = JsonBuilders::ChannelsJsonBuilderV3.new.build
+    retry_count = 0
+    result = nil
+
+    loop do
+      result = Rails.cache.write('browser_channels_json_v3', channels_json)
+      break if result || retry_count > MAX_RETRY
+
+      retry_count += 1
+      Rails.logger.info("CacheBrowserChannelsJsonJob V3 could not write to Redis result: #{result}. Retrying: #{retry_count}/#{MAX_RETRY}")
+    end
+
+    if result
+      Rails.logger.info("CacheBrowserChannelsJsonJob V3 updated the cached browser channels json.")
+    else
+      SlackMessenger.new(message: "🚨 CacheBrowserChannelsJsonJob V3 could not update the channels JSON. @publishers-team  🚨", channel: SlackMessenger::ALERTS)
+      Rails.logger.info("CacheBrowserChannelsJsonJob V3 could not update the channels JSON.")
+    end
+  end
+  end

--- a/app/jobs/cache_browser_channels_json_job_v3.rb
+++ b/app/jobs/cache_browser_channels_json_job_v3.rb
@@ -23,4 +23,4 @@ class CacheBrowserChannelsJsonJobV3 < ApplicationJob
       Rails.logger.info("CacheBrowserChannelsJsonJob V3 could not update the channels JSON.")
     end
   end
-  end
+end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -362,7 +362,7 @@ class Channel < ApplicationRecord
   end
 
   def uphold_connection
-    @uphold_connection ||= UpholdConnectionForChannel.joins(:uphold_connection).where(channel_id: id).where("uphold_connections.default_currency = uphold_connection_for_channels.currency").first
+    @uphold_connection ||= uphold_connection_for_channel.detect { |connection| connection.currency == publisher.uphold_connection.default_currency }
   end
 
   private

--- a/app/models/github_channel_details.rb
+++ b/app/models/github_channel_details.rb
@@ -1,7 +1,7 @@
 class GithubChannelDetails < BaseChannelDetails
   has_paper_trail
 
-  GITHUB_PREFIX = "github#channel:".freeze
+  PREFIX = "github#channel:".freeze
 
   validates :github_channel_id, presence: true
   validates :thumbnail_url, presence: true
@@ -9,7 +9,7 @@ class GithubChannelDetails < BaseChannelDetails
   validates :channel_url, presence: true
 
   def channel_identifier
-    "#{GITHUB_PREFIX}#{github_channel_id}"
+    "#{PREFIX}#{github_channel_id}"
   end
 
   def authorizer_name

--- a/app/models/json_builders/channels_json_builder_v3.rb
+++ b/app/models/json_builders/channels_json_builder_v3.rb
@@ -1,0 +1,97 @@
+# V2 Version of Channels list
+#
+# Each channel is an array:
+# [
+#   channel_identifier (string),
+#   verified (boolean),
+#   excluded (boolean),
+#   wallet address
+#   site_banner details
+# ]
+#
+# ex.
+# [
+#   ["brave.com", true, false, {title: 'Hello', description: 'world'...}, 1234-abcd-5678-efgh],
+#   ["google.com", false, true, {}, 1234-abcd-5678-efgh],
+#   ["us.gov", false, false, {}, 1234-abcd-5678-efgh]
+# ]
+
+class JsonBuilders::ChannelsJsonBuilderV2
+  def initialize
+    require "publishers/excluded_channels"
+    @excluded_channel_ids = Publishers::ExcludedChannels.brave_publisher_id_list
+    @excluded_verified_channel_ids = []
+    @channels = []
+    @appended_wallet_addresses = {}
+  end
+
+  def build
+    joined_verified_channels.each do |verified_channels|
+      verified_channels.find_each do |verified_channel|
+        include_verified_channel(verified_channel)
+      end
+    end
+    append_excluded
+    @channels.to_json
+  end
+
+  private
+
+  def joined_verified_channels
+    [
+      Channel.verified.site_channels.includes(:site_banner).includes(publisher: :site_banners).includes(publisher: :uphold_connection),
+      Channel.verified.youtube_channels.includes(:site_banner).includes(publisher: :site_banners).includes(publisher: :uphold_connection),
+      Channel.verified.twitch_channels.includes(:site_banner).includes(publisher: :site_banners).includes(publisher: :uphold_connection),
+      Channel.verified.twitter_channels.includes(:site_banner).includes(publisher: :site_banners).includes(publisher: :uphold_connection),
+      Channel.verified.vimeo_channels.includes(:site_banner).includes(publisher: :site_banners).includes(publisher: :uphold_connection),
+      Channel.verified.reddit_channels.includes(:site_banner).includes(publisher: :site_banners).includes(publisher: :uphold_connection),
+      Channel.verified.github_channels.includes(:site_banner).includes(publisher: :site_banners).includes(publisher: :uphold_connection),
+    ]
+  end
+
+  def include_verified_channel(verified_channel)
+    # Skip if channel is on exclusion list
+    return if @excluded_channel_ids.include?(verified_channel.details.channel_identifier)
+    # Skip if channel publisher has not yet KYC'd
+    return unless verified_channel.publisher&.uphold_connection&.is_member
+
+    wallet_address_id = verified_channel.uphold_connection&.address
+
+    return if wallet_address_id.nil?
+
+    @channels.push([
+      verified_channel.details.channel_identifier,
+      true,
+      false,
+      wallet_address_id,
+      site_banner_details(verified_channel),
+    ])
+    append_wallet_address(wallet_address_id)
+  end
+
+  def site_banner_details(channel)
+    publisher = channel.publisher
+    if publisher.default_site_banner_mode && publisher.default_site_banner_id
+      publisher.default_site_banner.read_only_react_property
+    elsif channel.site_banner
+      channel.site_banner.read_only_react_property
+    else
+      {}
+    end
+  end
+
+  def append_wallet_address(wallet_address_id)
+    @appended_wallet_addresses[wallet_address_id] = true
+  end
+
+  def existing_wallet_address?(wallet_address_id)
+    @appended_wallet_addresses.key?(wallet_address_id)
+  end
+
+  # (Albert Wang): Note: Ordering is different from v1
+  def append_excluded
+    @excluded_channel_ids.each do |excluded_channel_id|
+      @channels.push([excluded_channel_id, false, true, "", {}])
+    end
+  end
+end

--- a/app/models/json_builders/channels_json_builder_v3.rb
+++ b/app/models/json_builders/channels_json_builder_v3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "publishers/excluded_channels"
 # V3 Version of Channels list
 #
@@ -18,6 +20,9 @@ require "publishers/excluded_channels"
 # ]
 
 class JsonBuilders::ChannelsJsonBuilderV3
+  VERIFEID = "verified"
+  CONNECTED = "connected"
+
   def initialize
     @excluded_channel_ids = Publishers::ExcludedChannels.brave_publisher_id_list
     @excluded_verified_channel_ids = Set.new
@@ -79,9 +84,9 @@ class JsonBuilders::ChannelsJsonBuilderV3
     connection = verified_channel.publisher&.uphold_connection
 
     if connection&.is_member && address.present?
-      "verified"
+      VERIFEID
     elsif connection&.uphold_verified?
-      "connected"
+      CONNECTED
     else
       ""
     end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -271,7 +271,7 @@ class Publisher < ApplicationRecord
   end
 
   def default_site_banner
-    site_banners.find_by(id: default_site_banner_id)
+    site_banners.detect { |sb| sb.id == default_site_banner_id }
   end
 
   def inferred_status

--- a/app/models/reddit_channel_details.rb
+++ b/app/models/reddit_channel_details.rb
@@ -1,7 +1,7 @@
 class RedditChannelDetails < BaseChannelDetails
   has_paper_trail
 
-  REDDIT_PREFIX = "reddit#channel:".freeze
+  PREFIX = "reddit#channel:".freeze
 
   validates :reddit_channel_id, presence: true
   validates :thumbnail_url, presence: true
@@ -9,7 +9,7 @@ class RedditChannelDetails < BaseChannelDetails
   validates :channel_url, presence: true
 
   def channel_identifier
-    "#{REDDIT_PREFIX}#{reddit_channel_id}"
+    "#{PREFIX}#{reddit_channel_id}"
   end
 
   def authorizer_name

--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -10,6 +10,7 @@ class SiteBanner < ApplicationRecord
 
   has_one_public_s3 :background_image
   belongs_to :publisher
+  belongs_to :channel
 
   LOGO = "logo".freeze
   LOGO_DIMENSIONS = [480, 480].freeze

--- a/app/models/twitch_channel_details.rb
+++ b/app/models/twitch_channel_details.rb
@@ -5,12 +5,12 @@ class TwitchChannelDetails < BaseChannelDetails
   validates :auth_user_id, presence: true
   validates :display_name, presence: true
 
-  TWITCH_PREFIX = "twitch#author:".freeze
+  PREFIX = "twitch#author:".freeze
 
   ## Begin methods to satisfy the Eyeshade integration
 
   def channel_identifier
-    "#{TWITCH_PREFIX}#{name}"
+    "#{PREFIX}#{name}"
   end
 
   def authorizer_email

--- a/app/models/twitter_channel_details.rb
+++ b/app/models/twitter_channel_details.rb
@@ -5,12 +5,12 @@ class TwitterChannelDetails < BaseChannelDetails
   validates :name, presence: true
   validates :screen_name, presence: true
 
-  TWITTER_PREFIX = "twitter#channel:".freeze
+  PREFIX = "twitter#channel:".freeze
 
   # TODO: Figure out why eyeshade needs the email and name
   ## Begin methods to satisfy the Eyeshade integration
   def channel_identifier
-    "#{TWITTER_PREFIX}#{twitter_channel_id}"
+    "#{PREFIX}#{twitter_channel_id}"
   end
 
   def authorizer_email

--- a/app/models/vimeo_channel_details.rb
+++ b/app/models/vimeo_channel_details.rb
@@ -1,7 +1,7 @@
 class VimeoChannelDetails < BaseChannelDetails
   has_paper_trail
 
-  VIMEO_PREFIX = "vimeo#channel:".freeze
+  PREFIX = "vimeo#channel:".freeze
 
   validates :vimeo_channel_id, presence: true
   validates :thumbnail_url, presence: true
@@ -9,7 +9,7 @@ class VimeoChannelDetails < BaseChannelDetails
   validates :channel_url, presence: true
 
   def channel_identifier
-    "#{VIMEO_PREFIX}#{vimeo_channel_id}"
+    "#{PREFIX}#{vimeo_channel_id}"
   end
 
   def omniauth_url

--- a/app/models/youtube_channel_details.rb
+++ b/app/models/youtube_channel_details.rb
@@ -7,12 +7,12 @@ class YoutubeChannelDetails < BaseChannelDetails
 
   alias_attribute :name, :title
 
-  YOUTUBE_PREFIX = "youtube#channel:".freeze
+  PREFIX = "youtube#channel:".freeze
 
   ## Begin methods to satisfy the Eyeshade integration
 
   def channel_identifier
-    "#{YOUTUBE_PREFIX}#{youtube_channel_id}"
+    "#{PREFIX}#{youtube_channel_id}"
   end
 
   def authorizer_email

--- a/app/views/admin/stats/_top_eyeshade_wallets.html.slim
+++ b/app/views/admin/stats/_top_eyeshade_wallets.html.slim
@@ -12,10 +12,10 @@ div.panel-body
         - @result.each do |entry|
           - publisher_id = entry['account_id'].split(":")[1]
           - publisher = @publishers.find { |publisher| publisher.id == publisher_id }
-          - channel_detail = @youtube_channel_details.find { |youtube_channel_detail| youtube_channel_detail.youtube_channel_id == entry['channel'].remove(YoutubeChannelDetails::YOUTUBE_PREFIX) }
+          - channel_detail = @youtube_channel_details.find { |youtube_channel_detail| youtube_channel_detail.youtube_channel_id == entry['channel'].remove(YoutubeChannelDetails::PREFIX) }
           tr.gradeX
-            - if entry['channel'].starts_with?(YoutubeChannelDetails::YOUTUBE_PREFIX)
-              td = link_to channel_detail&.title, "https://youtube.com/channel/" + entry['channel'].remove(YoutubeChannelDetails::YOUTUBE_PREFIX)
+            - if entry['channel'].starts_with?(YoutubeChannelDetails::PREFIX)
+              td = link_to channel_detail&.title, "https://youtube.com/channel/" + entry['channel'].remove(YoutubeChannelDetails::PREFIX)
             - else
               td = entry['channel']
             td = channel_detail&.stats

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,9 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.rails_logger = true
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,15 @@ Rails.application.routes.draw do
         end
       end
     end
+    # /api/v3/
+    namespace :v3, defaults: { format: :json } do
+      namespace :public, defaults: { format: :json } do
+        get "channels", controller: "channels"
+        namespace :channels, defaults: { format: :json } do
+          get "totals"
+        end
+      end
+    end
   end
 
   namespace :admin do

--- a/test/fixtures/uphold_connection_for_channels.yml
+++ b/test/fixtures/uphold_connection_for_channels.yml
@@ -1,0 +1,10 @@
+default: &default
+  currency: USD
+  card_id: a012caf7-6fab-472d-a4d2-de6d04a54d1d
+  address: 6dfe6c26-e83b-4c5d-833f-3ad95a0e2f93
+  uphold_connection: details_connection
+  channel: uphold_connected_twitch_details
+
+uphold_connected_for_channels_twitch_details:
+  <<: *default
+  channel_identifier: "twitch#author:details"

--- a/test/fixtures/uphold_connection_for_channels.yml
+++ b/test/fixtures/uphold_connection_for_channels.yml
@@ -1,4 +1,4 @@
-default: &default
+default_uphold_connection_for_channel: &default_uphold_connection_for_channel
   currency: USD
   card_id: a012caf7-6fab-472d-a4d2-de6d04a54d1d
   address: 6dfe6c26-e83b-4c5d-833f-3ad95a0e2f93
@@ -6,5 +6,5 @@ default: &default
   channel: uphold_connected_twitch_details
 
 uphold_connected_for_channels_twitch_details:
-  <<: *default
+  <<: *default_uphold_connection_for_channel
   channel_identifier: "twitch#author:details"

--- a/test/models/json_builders/channels_json_builder_test_v3.rb
+++ b/test/models/json_builders/channels_json_builder_test_v3.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require "publishers/excluded_channels"
+
+class ChannelsJsonBuilderTestV3 < ActiveSupport::TestCase
+  let(:subject) { JSON.parse(JsonBuilders::ChannelsJsonBuilderV3.new.build) }
+
+  describe "When a user has completed KYC" do
+    it 'has their channel marked as verified' do
+      identifier = channels(:uphold_connected_twitch_details).details.channel_identifier
+      result = subject.detect { |x| x[0] == identifier }
+
+      assert_equal "verified", result[1]
+    end
+  end
+  describe "When a user has not completed KYC" do
+    it 'has their channel marked as verified' do
+      identifier = channels(:youtube_initial).details.channel_identifier
+      result = subject.detect { |x| x[0] == identifier }
+
+      assert_equal "connected", result[1]
+    end
+  end
+
+  test "number of channels returned in V2 Json is at least as large as number of excluded channels" do
+    @excluded_channel_ids = Publishers::ExcludedChannels.brave_publisher_id_list
+    channels = JSON.parse(JsonBuilders::ChannelsJsonBuilderV3.new.build)
+    assert channels.count >= @excluded_channel_ids.count
+  end
+end


### PR DESCRIPTION
## Publisher Channels V3 API
Closes #2142 

#### Features

- Adds support for non-KYC'd publishers to have their tips held as "pending" on the browser
- Generates statistical totals based on the JSON and not what we have in our database (Reflective of the actual system) 
- Reduces the amount of queries executed / minor performance gains

| Version | Time (seconds)| Channels Generated|
| -------- | ---- | ---------------------- |
|  V1 | 1524.278572 | 251,094 |
| V2 | 1244.177728  | 83,917 |
| V3 | 1617.463192 | 251,094 | 

<i>* Generated using Ruby Benchmark using Production data</i>

Here's the results from the latest `/api/v3/channels/totals` endpoint
```JSON

{
  "site": {
    "verified": 12935,
    "connected": 11830,
    "total": 24765
  },
  "all_channels": {
    "verified": 83927,
    "connected": 97974,
    "total": 181901
  },
  "twitch": {
    "verified": 5586,
    "connected": 4964,
    "total": 10550
  },
  "github": {
    "connected": 481,
    "verified": 488,
    "total": 969
  },
  "youtube": {
    "verified": 56411,
    "connected": 71855,
    "total": 128266
  },
  "reddit": {
    "verified": 1303,
    "connected": 1164,
    "total": 2467
  },
  "vimeo": {
    "connected": 160,
    "verified": 236,
    "total": 396
  },
  "twitter": {
    "verified": 6968,
    "connected": 7520,
    "total": 14488
  }
}
```

#### How To Test

Hit the following URLs

https://localhost:3000/api/v3/public/channels/
https://localhost:3000/api/v3/public/channels/totals