### PR TITLE
Remove Self-XSS for pending_email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,6 @@ gem 'omniauth-rails_csrf_protection', '~> 0.1.1'
 
 gem "dnsruby", "~> 1.60.0", require: false
 
-gem "email_validator", "~> 1.6"
-
 # HTTP library wrapper
 gem "faraday", "~> 0.9.2", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,8 +165,6 @@ GEM
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    email_validator (1.6.0)
-      activemodel
     encryptor (3.0.0)
     erubi (1.8.0)
     et-orbi (1.2.1)
@@ -550,7 +548,6 @@ DEPENDENCIES
   devise (~> 4.6.1)
   dnsruby (~> 1.60.0)
   domain_name
-  email_validator (~> 1.6)
   faraday (~> 0.9.2)
   font-awesome-rails (~> 4.7.0.4)
   i18n-tasks (~> 0.9.12)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -294,7 +294,7 @@ class PublishersController < ApplicationController
         # Register the new email address with sendgrid, and clear the publisher interests on the old member
         update_sendgrid(publisher: publisher, prior_email: prior_email)
 
-        flash[:alert] = t(".email_confirmed", email: publisher.email)
+        flash[:notice] = t(".email_confirmed", email: publisher.email)
       end
 
       if two_factor_enabled?(publisher)

--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -31,7 +31,7 @@ function showPendingContactEmail(pendingEmail) {
   let pendingEmailNotice = document.getElementById("pending_email_notice");
   let showContactEmail = document.getElementById("show_contact_email");
   if (pendingEmail && pendingEmail != showContactEmail.innerText) {
-    pendingEmailNotice.innerHTML = `Pending: Email address has been updated to: <strong>${pendingEmail}</strong>. An email has been sent to this address to confirm this change.`;
+    pendingEmailNotice.innerText = `Pending: Email address has been updated to: ${pendingEmail}. An email has been sent to this address to confirm this change.`;
     pendingEmailNotice.classList.remove("hidden");
   } else {
     pendingEmailNotice.classList.add("hidden");
@@ -636,7 +636,7 @@ document.addEventListener("DOMContentLoaded", function() {
           let pendingEmailNotice = document.getElementById(
             "pending_email_notice"
           );
-          pendingEmailNotice.innerHTML =
+          pendingEmailNotice.innerText =
             "Unable to change email; the email address may be in use. Please enter a different email address.";
           pendingEmailNotice.classList.remove("hidden");
         }

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -44,9 +44,20 @@ class Publisher < ApplicationRecord
 
   attr_encrypted :authentication_token, key: :encryption_key
 
-  validates :email, email: { strict_mode: true }, presence: true, unless: -> { pending_email.present? || deleted? }
-  validates :email, uniqueness: { case_sensitive: false }, allow_nil: true, unless: -> { deleted? }
-  validates :pending_email, email: { strict_mode: true }, presence: true, if: -> { email.blank? && !deleted? }
+  validates :email,
+    format: { with: URI::MailTo::EMAIL_REGEXP },
+    presence: true,
+    allow_nil: true,
+    uniqueness: { case_sensitive: false },
+    unless: -> { deleted? }
+
+  validates :pending_email,
+    format: { with: URI::MailTo::EMAIL_REGEXP },
+    presence: true,
+    allow_nil: true,
+    uniqueness: { case_sensitive: false },
+    unless: -> { deleted? }
+
   validates :promo_registrations, length: { maximum: MAX_PROMO_REGISTRATIONS }
   validate :pending_email_must_be_a_change, unless: -> { deleted? }
   validate :pending_email_can_not_be_in_use, unless: -> { deleted? }


### PR DESCRIPTION
## Remove Self-XSS for pending_email

closes #2171 


#### Features

- Improve validations on emails
- Removes the use of `innerHTML` for user based strings
- Removes unused email validator gem

#### How To Test

1. Create a valid account
2. Remove the HTML `type="email"` on the Update Contact section of the publishers dashboard
3. Update fails

I tested this on a variety of different emails and everything seems to be working 🎉 