### PR TITLE
Fix create_uphold_channel_job

### DIFF
--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -35,7 +35,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
 
     # If a user transfers their channel then we should try not to create duplicate uphold cards
     cards = uphold_connection.uphold_client.card.where(uphold_connection: uphold_connection)
-    card_id = cards.detect { |c| c.label.eql?(card_label) }.id
+    card_id = cards.detect { |c| c.label.eql?(card_label) }&.id
 
     if card_id.blank?
       # If the card doesn't exist so we should create it


### PR DESCRIPTION
## Fix create_uphold_channel_job
```

Aug 20 10:45:17 bat-publishers-staging app/web.1: �`<M���t�  �� W6��   
Aug 20 10:45:17 bat-publishers-staging app/web.1: E, [2019-08-20T17:45:17.392476 #4] ERROR -- : [efb6be62-bfde-4bd1-8400-4ab8e2998a9f] [ActiveJob] [CreateUpholdChannelCardJob] [9291fa82-d5d7-4a61-855f-1a0ac75d41c1] Error performing CreateUpholdChannelCardJob (Job ID: 9291fa82-d5d7-4a61-855f-1a0ac75d41c1) from Sidekiq(default) in 469.82ms: NoMethodError (undefined method `id' for nil:NilClass): 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/app/jobs/create_uphold_channel_card_job.rb:38:in `find_or_create_card' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/app/jobs/create_uphold_channel_card_job.rb:23:in `perform' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/execution.rb:39:in `block in perform_now' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:109:in `block in run_callbacks' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-traffic_control-0.1.3/lib/active_job/traffic_control/disable.rb:44:in `block (2 levels) in <module:Disable>' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-traffic_control-0.1.3/lib/active_job/traffic_control/throttle.rb:50:in `block (2 levels) in <module:Throttle>' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-traffic_control-0.1.3/lib/active_job/traffic_control/concurrency.rb:56:in `block (2 levels) in <module:Concurrency>' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/i18n-1.6.0/lib/i18n.rb:292:in `with_locale' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/translation.rb:9:in `block (2 levels) in <module:Translation>' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/logging.rb:26:in `block (4 levels) in <module:Logging>' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `block in instrument' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/notifications/instrumenter.rb:23:in `instrument' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:168:in `instrument' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/logging.rb:25:in `block (3 levels) in <module:Logging>' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/logging.rb:46:in `block in tag_logger' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `block in tagged' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:28:in `tagged' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/tagged_logging.rb:71:in `tagged' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/logging.rb:46:in `tag_logger' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/logging.rb:22:in `block (2 levels) in <module:Logging>' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `instance_exec' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:118:in `block in run_callbacks' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.2.3/lib/active_support/callbacks.rb:136:in `run_callbacks' 
Aug 20 10:45:17 bat-publishers-staging app/web.1: /app/vendor/bundle/ruby/2.5.0/gems/activejob-5.2.3/lib/active_job/execution.rb:38:in `perform_now' 
```

This was the error, this should fix it :)