### PR TITLE
Move create_uphold_cards to be after_commit

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -77,7 +77,9 @@ class Channel < ApplicationRecord
   validate :verified_duplicate_channels_must_be_contested, if: -> { verified? }
 
   after_save :register_channel_for_promo, if: :should_register_channel_for_promo
-  after_save :create_channel_card, :notify_slack, if: -> { :saved_change_to_verified? && verified? }
+  after_save :notify_slack, if: -> { :saved_change_to_verified? && verified? }
+
+  after_commit :create_channel_card, if: -> { :saved_change_to_verified? && verified? }
 
   before_save :clear_verified_at_if_necessary
 


### PR DESCRIPTION
## Change after_save to be after_commit

#### Features

It seems like when a user adds a new channel then the job fails on the first time. I googled this and found that this is a fairly common "gotcha" 
https://www.justinweiss.com/articles/a-couple-callback-gotchas-and-a-rails-5-fix/

This fix should allow users to have their channels be created successfully