### PR TITLE
Fix error on homepage load

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ AllCops:
     - app/controllers/publishers/uphold_controller.rb
     - app/services/uphold/**/*
     - app/jobs/create_uphold_cards_job.rb
+    - app/jobs/create_uphold_channel_card_job.rb
     - app/jobs/exchange_uphold_code_for_access_token_job.rb
     - app/jobs/clean_stale_uphold_data_job.rb
     - app/services/payout_report_publisher_includer.rb

--- a/app/jobs/create_uphold_cards_job.rb
+++ b/app/jobs/create_uphold_cards_job.rb
@@ -64,7 +64,7 @@ class CreateUpholdCardsJob < ApplicationJob
   #
   # Returns true if the card has a private address
   def has_private_address?(uphold_connection, card_id)
-    @existing_private_cards ||= UpholdConnectionForChannel.select(:card_id).where(uphold_connection: uphold_connection).to_a
+    @existing_private_cards ||= UpholdConnectionForChannel.select(:card_id).where(uphold_connection: uphold_connection, uphold_id: uphold_connection.uphold_id).to_a
     return true if @existing_private_cards.include?(card_id)
 
     addresses = uphold_connection.uphold_client.address.all(uphold_connection: uphold_connection, id: card_id)

--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -61,7 +61,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
   end
 
   def card_exists?(uphold_connection, card_id)
-    return unless card_id.present?
+    return if card_id.blank?
 
     uphold_connection.uphold_client.card.find(uphold_connection: uphold_connection, id: card_id).present?
   rescue Faraday::ResourceNotFound

--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -61,10 +61,11 @@ class CreateUpholdChannelCardJob < ApplicationJob
   end
 
   def card_exists?(uphold_connection, card_id)
-    return if card_id.blank?
+    return false if card_id.blank?
 
     uphold_connection.uphold_client.card.find(uphold_connection: uphold_connection, id: card_id).present?
   rescue Faraday::ResourceNotFound
+    false
   end
 
   def get_address(uphold_connection, card_id)

--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -18,12 +18,10 @@ class CreateUpholdChannelCardJob < ApplicationJob
     )
 
     # In the past if a user disconnects and reconnects to a different uphold account then the connection for the channel might have an out of date card address
-    if upfc.present?
-      card_id = find_card(uphold_connection, upfc.card_id)&.id
-    end
+    card_id = upfc.card_id if card_exists?(uphold_connection, upfc&.card_id)
 
     if card_id.blank?
-      (card_id, upfc) = find_or_create_card(uphold_connection, channel)
+      (card_id, upfc) = create_uphold_connection_for_channel(uphold_connection, channel)
     end
 
     # If the channel was deleted and then recreated we should update this to be the new channel id
@@ -34,7 +32,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
     )
   end
 
-  def find_or_create_card(uphold_connection, channel)
+  def create_uphold_connection_for_channel(uphold_connection, channel)
     card_label = "#{channel.type_display} - #{channel.details.publication_title} - Brave Rewards"
 
     # If a user transfers their channel then we should try not to create duplicate uphold cards
@@ -62,11 +60,11 @@ class CreateUpholdChannelCardJob < ApplicationJob
     [card_id, upfc]
   end
 
-  def find_card(uphold_connection, card_id)
-    uphold_connection.uphold_client.card.find(uphold_connection: uphold_connection, id: card_id)
+  def card_exists?(uphold_connection, card_id)
+    return unless card_id.present?
 
+    uphold_connection.uphold_client.card.find(uphold_connection: uphold_connection, id: card_id).present?
   rescue Faraday::ResourceNotFound
-    nil
   end
 
   def get_address(uphold_connection, card_id)

--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -58,11 +58,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
   end
 
   def get_address(uphold_connection, card_id)
-    addresses = uphold_connection.uphold_client.address.all(
-      uphold_connection: uphold_connection,
-      id: card_id
-    )
-    address = addresses.detect { |a| a.type == UpholdConnectionForChannel::NETWORK }
+    address = addresses(uphold_connection, card_id).detect { |a| a.type == UpholdConnectionForChannel::NETWORK }
     address = address.formats.first.dig('value') if address.present?
 
     return address if address.present?
@@ -72,5 +68,14 @@ class CreateUpholdChannelCardJob < ApplicationJob
       id: card_id,
       network: UpholdConnectionForChannel::NETWORK
     )
+  end
+
+  def addresses(uphold_connection, card_id)
+    uphold_connection.uphold_client.address.all(
+      uphold_connection: uphold_connection,
+      id: card_id
+    )
+  rescue Faraday::ResourceNotFound
+    []
   end
 end

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UpholdConnection < ActiveRecord::Base
+  has_paper_trail only: [:is_member, :uphold_id, :address, :status, :default_currency]
+
   UPHOLD_CODE_TIMEOUT = 5.minutes
   UPHOLD_ACCESS_PARAMS_TIMEOUT = 2.hours
 

--- a/app/models/uphold_connection_for_channel.rb
+++ b/app/models/uphold_connection_for_channel.rb
@@ -10,5 +10,5 @@ class UpholdConnectionForChannel < ApplicationRecord
 
   NETWORK = 'anonymous'
 
-  validates :channel_identifier, uniqueness: { scope: [:uphold_connection_id, :channel_identifier, :currency] }
+  validates :channel_identifier, uniqueness: { scope: [:uphold_connection_id, :channel_identifier, :currency, :uphold_id] }
 end

--- a/db/migrate/20190828175151_add_uphold_id_to_uphold_connection_for_channel.rb
+++ b/db/migrate/20190828175151_add_uphold_id_to_uphold_connection_for_channel.rb
@@ -1,0 +1,5 @@
+class AddUpholdIdToUpholdConnectionForChannel < ActiveRecord::Migration[5.2]
+  def change
+    add_column :uphold_connection_for_channels, :uphold_id, :uuid
+  end
+end

--- a/db/migrate/20190828175151_add_uphold_id_to_uphold_connection_for_channel.rb
+++ b/db/migrate/20190828175151_add_uphold_id_to_uphold_connection_for_channel.rb
@@ -1,5 +1,6 @@
 class AddUpholdIdToUpholdConnectionForChannel < ActiveRecord::Migration[5.2]
   def change
     add_column :uphold_connection_for_channels, :uphold_id, :uuid
+    add_index :uphold_connection_for_channels, :uphold_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -518,6 +518,7 @@ ActiveRecord::Schema.define(version: 2019_08_28_175151) do
     t.index ["channel_identifier"], name: "index_uphold_connection_for_channels_on_channel_identifier"
     t.index ["currency"], name: "index_uphold_connection_for_channels_on_currency"
     t.index ["uphold_connection_id"], name: "index_uphold_connection_for_channels_on_uphold_connection_id"
+    t.index ["uphold_id"], name: "index_uphold_connection_for_channels_on_uphold_id"
   end
 
   create_table "uphold_connections", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_30_162819) do
+ActiveRecord::Schema.define(version: 2019_08_28_175151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -512,6 +512,7 @@ ActiveRecord::Schema.define(version: 2019_07_30_162819) do
     t.string "channel_identifier"
     t.string "card_id"
     t.string "address"
+    t.uuid "uphold_id"
     t.index ["channel_id"], name: "index_uphold_connection_for_channels_on_channel_id"
     t.index ["channel_identifier", "currency", "uphold_connection_id"], name: "unique_uphold_connection_for_channels", unique: true
     t.index ["channel_identifier"], name: "index_uphold_connection_for_channels_on_channel_identifier"

--- a/test/jobs/create_uphold_channel_card_job_test.rb
+++ b/test/jobs/create_uphold_channel_card_job_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+require 'webmock/minitest'
+require 'minitest/spec'
+
+class CreateUpholdChannelCardTest < ActiveJob::TestCase
+
+  describe 'when a user creates uphold cards for the first time' do
+    let(:uphold_connection) { uphold_connections(:details_connection) }
+    let(:channel) { channels(:uphold_connected_details) }
+    let(:card_id) { '123e4567-e89b-12d3-a456-426655440000' }
+
+    subject { CreateUpholdChannelCardJob.perform_now(uphold_connection_id: uphold_connection.id, channel_id: channel.id) }
+
+    before do
+      stub_request(:get, /cards/).to_return(body: [].to_json)
+      stub_request(:post, /cards/).to_return(body: {id: card_id}.to_json)
+    end
+
+    it 'does not have an existing uphold connection' do
+      refute UpholdConnectionForChannel.find_by(
+        uphold_connection: uphold_connection,
+        currency: uphold_connection.default_currency,
+        channel_identifier: channel.details.channel_identifier
+      )
+    end
+
+    it 'creates an uphold card' do
+      subject
+
+      assert UpholdConnectionForChannel.find_by(
+        uphold_connection: uphold_connection,
+        currency: uphold_connection.default_currency,
+        channel_identifier: channel.details.channel_identifier,
+        uphold_id: uphold_connection.uphold_id,
+        card_id: card_id
+      )
+    end
+  end
+
+  describe 'when a user calls create uphold cards again' do
+    subject { CreateUpholdChannelCardJob.perform_now(uphold_connection_id: uphold_connection.id, channel_id: channel.id) }
+
+    let(:uphold_connection) { uphold_connections(:details_connection) }
+    let(:connection_for_channel) do
+      UpholdConnectionForChannel.find_by(
+        uphold_connection: uphold_connection,
+        currency: uphold_connection.default_currency,
+        channel_identifier: channel.details.channel_identifier
+      )
+    end
+
+
+    describe 'when the currency stays the same' do
+      let(:channel) { channels(:uphold_connected_twitch_details) }
+
+      before do
+        stub_request(:get, /card/).to_return(body: { id: connection_for_channel.card_id }.to_json)
+        stub_request(:get, /addresses/).to_return(body: [{ type: UpholdConnectionForChannel::NETWORK, formats: [{ 'value' => 'new' }]}].to_json)
+      end
+
+      it 'has an existing uphold connection' do
+        assert connection_for_channel
+      end
+
+
+      it 'updates the address' do
+        previous_address = connection_for_channel.address
+
+        subject
+
+        connection_for_channel.address.wont_be_same_as(previous_address)
+      end
+
+    end
+  end
+end

--- a/test/jobs/create_uphold_channel_card_job_test.rb
+++ b/test/jobs/create_uphold_channel_card_job_test.rb
@@ -68,7 +68,11 @@ class CreateUpholdChannelCardTest < ActiveJob::TestCase
 
         subject
 
-        connection_for_channel.address.wont_be_same_as(previous_address)
+        UpholdConnectionForChannel.find_by(
+          uphold_connection: uphold_connection,
+          currency: uphold_connection.default_currency,
+          channel_identifier: channel.details.channel_identifier
+        ).address.wont_be_same_as(previous_address)
       end
 
     end


### PR DESCRIPTION
## Fix error on homepage load


#### Features

Because we weren't tracking Uphold IDs on the card connections we ran into an issue where if someone tries and create new cards then there will be an error.