### PR TITLE
Fix unique card collision 

### DIFF
--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -11,18 +11,17 @@ class CreateUpholdChannelCardJob < ApplicationJob
       return
     end
 
-    upfc = UpholdConnectionForChannel.find_or_create_by(
+    upfc = UpholdConnectionForChannel.where(
       uphold_connection: uphold_connection,
       currency: uphold_connection.default_currency,
       channel_identifier: channel.details.channel_identifier
-    )
+    ).first_or_create(channel_id: channel_id)
 
     card_id = find_or_create_card(uphold_connection, channel, upfc)
 
     # If the channel was deleted and then recreated we should update this to be the new channel id
     upfc.update(
       address: get_address(uphold_connection, card_id),
-      channel_id: channel.id,
       card_id: card_id,
       uphold_id: uphold_connection.uphold_id
     )
@@ -46,7 +45,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
       ).id
     end
 
-   card_id
+    card_id
   end
 
   def card_exists?(uphold_connection, card_id)

--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -11,31 +11,29 @@ class CreateUpholdChannelCardJob < ApplicationJob
       return
     end
 
-    upfc = UpholdConnectionForChannel.find_by(
+    upfc = UpholdConnectionForChannel.find_or_create_by(
       uphold_connection: uphold_connection,
       currency: uphold_connection.default_currency,
       channel_identifier: channel.details.channel_identifier
     )
 
-    # In the past if a user disconnects and reconnects to a different uphold account then the connection for the channel might have an out of date card address
-    card_id = upfc.card_id if card_exists?(uphold_connection, upfc&.card_id)
-
-    if card_id.blank?
-      (card_id, upfc) = create_uphold_connection_for_channel(uphold_connection, channel)
-    end
+    card_id = find_or_create_card(uphold_connection, channel, upfc)
 
     # If the channel was deleted and then recreated we should update this to be the new channel id
     upfc.update(
       address: get_address(uphold_connection, card_id),
       channel_id: channel.id,
+      card_id: card_id,
       uphold_id: uphold_connection.uphold_id
     )
   end
 
-  def create_uphold_connection_for_channel(uphold_connection, channel)
-    card_label = "#{channel.type_display} - #{channel.details.publication_title} - Brave Rewards"
+  def find_or_create_card(uphold_connection, channel, upfc)
+    # In the past if a user disconnects and reconnects to a different uphold account then the connection for the channel might have an out of date card address
+    return upfc.card_id if card_exists?(uphold_connection, upfc.card_id)
 
     # If a user transfers their channel then we should try not to create duplicate uphold cards
+    card_label = "#{channel.type_display} - #{channel.details.publication_title} - Brave Rewards"
     cards = uphold_connection.uphold_client.card.where(uphold_connection: uphold_connection)
     card_id = cards.detect { |c| c.label.eql?(card_label) }&.id
 
@@ -48,16 +46,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
       ).id
     end
 
-    upfc = UpholdConnectionForChannel.create(
-      uphold_connection: uphold_connection,
-      uphold_id: uphold_connection.uphold_id,
-      channel: channel,
-      card_id: card_id,
-      currency: uphold_connection.default_currency,
-      channel_identifier: channel.details.channel_identifier
-    )
-
-    [card_id, upfc]
+   card_id
   end
 
   def card_exists?(uphold_connection, card_id)

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -42,7 +42,7 @@ class UpholdConnection < ActiveRecord::Base
   }
 
   # If the user became KYC'd let's create the uphold card for them
-  after_save :create_uphold_cards, if: -> { saved_change_to_is_member? && uphold_verified? }
+  after_commit :create_uphold_cards, if: -> { saved_change_to_is_member? && is_member? }
 
   # publishers that have access params that havent accepted by eyeshade
   # can be cleared after 2 hours

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -42,7 +42,7 @@ class UpholdConnection < ActiveRecord::Base
   }
 
   # If the user became KYC'd let's create the uphold card for them
-  after_commit :create_uphold_cards, if: -> { saved_change_to_is_member? && is_member? }
+  after_save :create_uphold_cards, if: -> { saved_change_to_is_member? && uphold_verified? }
 
   # publishers that have access params that havent accepted by eyeshade
   # can be cleared after 2 hours


### PR DESCRIPTION
## Fix card collision 

#### Features

Before this change if a user had a previous channel card created and the existing card_id was not found on their account. Then they would run into this duplicate collision. 

Here are the changes

- Moved the creation and find logic to the same place
- Put all the card id logic in one place 

This way anytime we try to create cards it will always either find the connection, or create a new one.

Then it will try to find the card id, if it can't find it, then tries to find one that aligns with the existing card data. Then if it can't find anything it creates a new one.

After that it tries to find or create the address on that card and updates the existing DB connection with the values. 