### PR TITLE
Don't include partners on the payout report

### DIFF
--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -6,7 +6,7 @@ class PayoutReportPublisherIncluder < BaseService
   end
 
   def perform
-    return if !@publisher.has_verified_channel? || @publisher.locked? || @publisher.excluded_from_payout? || @publisher.hold?
+    return if !@publisher.has_verified_channel? || @publisher.locked? || @publisher.excluded_from_payout? || @publisher.hold? || @publisher.partner?
 
     wallet = PublisherWalletGetter.new(publisher: @publisher).perform
     uphold_connection = @publisher.uphold_connection


### PR DESCRIPTION
## Don't include partners on the payout report

Partners who we manually create invoices for should not appear in the payout report