### PR TITLE
Update Channel ID when a channel is being transferred

### DIFF
--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -23,6 +23,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
     upfc.update(
       address: get_address(uphold_connection, card_id),
       card_id: card_id,
+      # It's possible a channel can be removed, so this covers re-linking an existing UCFC to the re-added channel.
       channel_id: channel_id,
       uphold_id: uphold_connection.uphold_id
     )

--- a/app/jobs/create_uphold_channel_card_job.rb
+++ b/app/jobs/create_uphold_channel_card_job.rb
@@ -23,6 +23,7 @@ class CreateUpholdChannelCardJob < ApplicationJob
     upfc.update(
       address: get_address(uphold_connection, card_id),
       card_id: card_id,
+      channel_id: channel_id,
       uphold_id: uphold_connection.uphold_id
     )
   end


### PR DESCRIPTION
## Update Channel ID when a channel is being transferred

If a channel is deleted or re-added like in the case of Uphold.com we need to update the reference to the new channel_id