### PR TITLE
Reject transfer for deleting channels undergoing transfer

### DIFF
--- a/app/jobs/delete_publisher_channel_job.rb
+++ b/app/jobs/delete_publisher_channel_job.rb
@@ -15,7 +15,8 @@ class DeletePublisherChannelJob < ApplicationJob
       Channels::ApproveChannelTransfer.new(channel: @channel).perform
     elsif Channel.find_by(contested_by_channel: @channel)
       # Reject the transfer if the account which is having their 2fa removed has channels transferring to their account
-      Channels::RejectChannelTransfer.new(channel: @channel).perform
+      contested_channel = Channel.find_by(contested_by_channel: @channel)
+      Channels::RejectChannelTransfer.new(channel: contested_channel).perform
     else
       @channel.destroy!
     end

--- a/app/jobs/delete_publisher_channel_job.rb
+++ b/app/jobs/delete_publisher_channel_job.rb
@@ -13,6 +13,9 @@ class DeletePublisherChannelJob < ApplicationJob
     # If channel is being contested, approve the channel which will also delete
     if @channel.contested_by_channel.present?
       Channels::ApproveChannelTransfer.new(channel: @channel).perform
+    elsif Channel.find_by(contested_by_channel: @channel)
+      # Reject the transfer if the account which is having their 2fa removed has channels transferring to their account
+      Channels::RejectChannelTransfer.new(channel: @channel).perform
     else
       @channel.destroy!
     end


### PR DESCRIPTION
## Reject transfer for deleting channels undergoing transfer

We've been seeing users report that the 2fa removal job is failing. This is due to one of the publishers channels being transferred to the account which is having the 2fa removed. 

Closes #2289