### PR TITLE
Fail gracefully when we don't have access to uphold transactions

### DIFF
--- a/app/services/publisher_statement_getter.rb
+++ b/app/services/publisher_statement_getter.rb
@@ -87,6 +87,9 @@ class PublisherStatementGetter < BaseApiClient
     end
 
     uphold
+  rescue Faraday::ClientError
+    Rails.logger.info("Couldn't access publisher #{@publisher.id} Uphold Transaction History")
+    []
   end
 
   def channel_name(identifier)


### PR DESCRIPTION
## Fail gracefully when we don't have access to uphold transactions

While pulling the statements if the account doesn't have the correct scope then they will get an exception. We should rescue and ensure that they can still view their normal Eyeshade-based transaction. 

Closes #2299 