### PR TITLE
Fix Getting Started Page

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -118,8 +118,11 @@ html
       / The postfix is available for all three flash names and for rendering
       / below the navigation bar or in a panel.
       /
-      .main-content#main-content
-        = content_for?(:content) ? yield(:content) : yield
+      -if content_for?(:headless)
+        = yield(:headless)
+      - else
+        .main-content#main-content
+          = content_for?(:content) ? yield(:content) : yield
 
 
       = render("footer")

--- a/app/views/layouts/promo_registrations.html.slim
+++ b/app/views/layouts/promo_registrations.html.slim
@@ -5,7 +5,7 @@
   .nav.nav--promo
 
 
-- content_for(:content) do
+- content_for(:headless) do
   .promo-content--background
     #content.container
       = yield

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -735,7 +735,7 @@ en:
       promo_period: "Promo period:"
       promo_period_description: "Jan 1 - Feb 1"
       reward: "Reward:"
-      reward_description: "about 5 USD per referral"
+      reward_description: "Up to $7.50 USD in Basic Attention Tokens."
       referral_links: "Share the link to increase referrals"
       referral_link: "Referral Link"
       copy: "Copy"


### PR DESCRIPTION
## Fix Getting Started Page

<img width="925" alt="Screen Shot 2019-10-23 at 1 15 18 PM" src="https://user-images.githubusercontent.com/5459225/67422002-3cc63400-f597-11e9-94a7-b5b2154b806a.png">

#### Features

- Removes the whitespace
- Updates the page with correct info
