### PR TITLE
Prevent Duplicate Channels for same publishers

### DIFF
--- a/app/controllers/admin/channels_controller.rb
+++ b/app/controllers/admin/channels_controller.rb
@@ -19,14 +19,27 @@ module Admin
 
       case params[:type]
       when 'website'
-          @channels = @channels.site_channels
+        @channels = @channels.site_channels
       when 'youtube'
-          @channels = @channels.youtube_channels
+        @channels = @channels.youtube_channels
       when 'twitch'
-          @channels = @channels.twitch_channels
+        @channels = @channels.twitch_channels
       end
 
       @channels = @channels.paginate(page: params[:page])
+    end
+
+    def destroy
+      channel = Channel.find(params[:id])
+
+      PublisherNote.create(
+        publisher: channel.publisher,
+        created_by: channel.publisher,
+        note: "The channel #{channel.publication_title} at #{channel.details&.url} was deleted by #{current_user.email}"
+      )
+
+      @channel_id = channel.id
+      DeletePublisherChannelJob.perform_now(channel_id: @channel_id)
     end
 
     def duplicates

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -335,6 +335,10 @@ class Channel < ApplicationRecord
     end
 
     if duplicate_verified_channels.any?
+      duplicate_verified_channels.each do |channel|
+        errors.add(:base, "already exists on your account") if channel.publisher_id == publisher_id
+      end
+
       if duplicate_verified_channels.count > 1
         errors.add(:base, "can only contest one channel")
       end

--- a/app/views/admin/channels/destroy.js.erb
+++ b/app/views/admin/channels/destroy.js.erb
@@ -1,2 +1,1 @@
-console.log("<%= @channel_id %>")
 document.getElementById("<%= @channel_id %>").remove();

--- a/app/views/admin/channels/destroy.js.erb
+++ b/app/views/admin/channels/destroy.js.erb
@@ -1,0 +1,2 @@
+console.log("<%= @channel_id %>")
+document.getElementById("<%= @channel_id %>").remove();

--- a/app/views/admin/publishers/_channel.html.slim
+++ b/app/views/admin/publishers/_channel.html.slim
@@ -1,9 +1,9 @@
 
-.m-3 class=(channel.verified? ? '' : 'not-verified')
+.m-3 id=(channel.id) class=(channel.verified? ? '' : 'not-verified')
   / This is information for this
   div
     / Container for the title, contributions and referrals
-    div
+    div.mb-2
       / Title
       div
         small.text-muted TITLE
@@ -93,6 +93,9 @@
                       small.text-muted= "#{key.upcase.gsub("_", " ")}"
                       .font-weight-bold
                         = number_with_delimiter(channel.details.stats[key])
+
+    small.mr-3
+      = link_to(fa_icon("trash", text: "Remove Channel"), admin_channel_path(channel.id), method: :delete, remote: true, data: { confirm: 'WARNING. This will remove this channel. Please only do this if this is a duplicate channel.' })
 
     / When the channel is being contested
     - if channel.verification_pending?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,7 +175,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :channels, only: [:index] do
+    resources :channels, only: [:index, :destroy] do
       collection do
         get :duplicates
       end

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -250,6 +250,20 @@ class ChannelTest < ActionDispatch::IntegrationTest
     assert contested_by_channel.valid?
   end
 
+  test 'if the same channel is trying to be registered twice' do
+    channel = channels(:twitch_verified)
+
+    new_channel = Channel.new(publisher: publishers(:twitch_verified), verified: true)
+    new_channel.details = TwitchChannelDetails.new(
+      twitch_channel_id: channel.details.twitch_channel_id,
+      name: channel.details.name,
+      display_name: channel.details.display_name,
+    )
+
+    refute new_channel.valid?
+    assert_equal "already exists on your account", new_channel.errors.messages[:base][0]
+  end
+
   test "if channel is a duplicate of a verified channel it must be contested youtube" do
     channel = channels(:youtube_new)
     contested_by_channel = Channel.new(publisher: publishers(:small_media_group))


### PR DESCRIPTION
## Prevent Duplicate Channels for same publishers

Closes #2117

#### Features

- Adds ability for administrators to delete Publisher's channel (with record)
- Add additional validation to prevent duplicate channels
