### PR TITLE
Show total amount during KYC emails

### DIFF
--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -121,11 +121,12 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
-  def uphold_kyc_incomplete(publisher)
+  def uphold_kyc_incomplete(publisher, total_amount)
     @publisher = publisher
+    @total_amount = total_amount
     mail(
       to: @publisher.email,
-      subject: default_i18n_subject
+      subject: default_i18n_subject(total_amount: total_amount)
     )
   end
 
@@ -285,9 +286,10 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
-  def wallet_not_connected(publisher)
+  def wallet_not_connected(publisher, total_amount)
     @publisher = publisher
     @publisher_log_in_url = log_in_publishers_url
+    @total_amount = total_amount
 
     connection = @publisher.uphold_connection
     if connection&.uphold_verified? && connection&.address.present?
@@ -300,7 +302,7 @@ class PublisherMailer < ApplicationMailer
     else
       mail(
         to: @publisher.email,
-        subject: default_i18n_subject
+        subject: default_i18n_subject(total_amount: total_amount)
       )
     end
   end

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -73,16 +73,16 @@ class PayoutReportPublisherIncluder < BaseService
 
     # Notify publishers that have money waiting, but will not will not receive funds
     if total_probi > PROBI_THRESHOLD && @should_send_notifications
-      send_emails(uphold_connection)
+      send_emails(uphold_connection, probi_to_bat(total_amount))
     end
   end
 
   private
 
-  def send_emails(uphold_connection)
+  def send_emails(uphold_connection, total_amount)
     if !uphold_connection.uphold_verified? || uphold_connection.status.blank?
       Rails.logger.info("Publisher #{@publisher.owner_identifier} will not be paid for their balance because they are disconnected from Uphold.")
-      PublisherMailer.wallet_not_connected(@publisher).deliver_later
+      PublisherMailer.wallet_not_connected(@publisher, total_amount).deliver_later
     end
 
     # eyeshade omits the wallet address if the status is not ok
@@ -95,11 +95,16 @@ class PayoutReportPublisherIncluder < BaseService
     # The wallet's uphold account status has to exist because otherwise their wallet is just not connected
     if uphold_connection.uphold_verified? && uphold_connection.status.present? && !uphold_connection.is_member?
       Rails.logger.info("Publisher #{@publisher.owner_identifier} will not be paid for their balance because they are not a verified member on Uphold")
-      PublisherMailer.uphold_kyc_incomplete(@publisher).deliver_later
+      PublisherMailer.uphold_kyc_incomplete(@publisher, total_amount).deliver_later
     end
   end
 
   def should_only_notify?
     @payout_report.nil?
+  end
+
+  # Converts Probi to BAT, original implementation Eyeshade::BaseBalance
+  def probi_to_bat(probi)
+    probi.to_d / 1E18
   end
 end

--- a/app/services/payout_report_publisher_includer.rb
+++ b/app/services/payout_report_publisher_includer.rb
@@ -73,7 +73,7 @@ class PayoutReportPublisherIncluder < BaseService
 
     # Notify publishers that have money waiting, but will not will not receive funds
     if total_probi > PROBI_THRESHOLD && @should_send_notifications
-      send_emails(uphold_connection, probi_to_bat(total_amount))
+      send_emails(uphold_connection, probi_to_bat(total_probi).round(1))
     end
   end
 

--- a/app/views/publisher_mailer/uphold_kyc_incomplete.html.slim
+++ b/app/views/publisher_mailer/uphold_kyc_incomplete.html.slim
@@ -1,6 +1,6 @@
 p.salutation= t "publisher_mailer.shared.salutation", name: @publisher.name
 
-p= t "publisher_mailer.uphold_kyc_incomplete.body_html"
+p= t "publisher_mailer.uphold_kyc_incomplete.body_html", total_amount: @total_amount
 
 div.btn-container= link_to(t(".button"), "https://uphold.com/dashboard/membership", class: "btn-primary btn-login")
 

--- a/app/views/publisher_mailer/wallet_not_connected.html.slim
+++ b/app/views/publisher_mailer/wallet_not_connected.html.slim
@@ -1,6 +1,6 @@
 p.salutation= t "publisher_mailer.shared.salutation", name: @publisher.name
 
-== t ".body_html"
+== t ".body_html", total_amount: @total_amount
 
 div.btn-container= link_to t(".button"), @publisher_log_in_url, class: "btn-primary btn-login"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,7 +352,8 @@ en:
     wallet_not_connected:
       subject: Connect a wallet to claim your %{total_amount} BAT.
       body_html: |
-        <p>Your <strong>%{total_amount} BAT</strong> worth of earnings from Brave Rewards are ready to be deposited. All you need to do is connect a wallet to your Brave Rewards account.</p> <p>Log in to Brave Rewards and connect your wallet from the dashboard to receive your funds.</p>
+        <p><span style="font-size: 18px">You've earned <strong>%{total_amount} BAT</strong> from Brave Rewards!</span></p>
+        <p>Your earnings from Brave Rewards are ready to be deposited. All you need to do is connect a wallet to your Brave Rewards account.</p> <p>Log in to Brave Rewards and connect your wallet from the dashboard to receive your funds.</p>
       button: Log in to Brave Rewards
     verify_email:
       subject: Verify your Brave Rewards email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,9 +332,11 @@ en:
         <br/>
         The Brave Rewards | Creator team
     uphold_kyc_incomplete:
-      subject: Please verify your Uphold identity
+      subject: Please verify your Uphold identity to claim your %{total_amount} BAT
       body_html: |
-        <p>To improve the security of Brave Rewards and protect against fraud, we require that creators verify their identity with Uphold.</p> <p>Your earnings will be paid out in the next payment cycle after you verify your identity with Uphold. In the meantime, your earnings will be safely held in your account.</p> <p>Thank you for being a Brave Creator and helping us improve the integrity of the payout system.</p>
+        <p>You have <strong>%{total_amount} BAT</strong> worth of earnings waiting for you to verify your identity with Uphold.
+        <p>To improve the security of Brave Rewards and protect against fraud, we require that creators verify their identity with Uphold.</p>
+        <p>Your earnings will be paid out in the next payment cycle after you verify your identity with Uphold. In the meantime, your earnings will be safely held in your account.</p> <p>Thank you for being a Brave Creator and helping us improve the integrity of the payout system.</p>
       button: Verify wallet
     uphold_member_restricted:
       subject: Uphold account unable to receive funds
@@ -348,9 +350,9 @@ en:
         <p>Congratulations! You are now a verified Brave Rewards creator.</p> <p>Ready to claim your funds? Visit your Brave Rewards dashboard to submit your payment information using the button below.</p>
       button: Log in to Brave Rewards
     wallet_not_connected:
-      subject: Connect a wallet to claim your funds
+      subject: Connect a wallet to claim your %{total_amount} BAT.
       body_html: |
-        <p>Your earnings from Brave Rewards are ready to be deposited. All you need to do is connect a wallet to your Brave Rewards account.</p> <p>Log in to Brave Rewards and connect your wallet from the dashboard to receive your funds.</p>
+        <p>Your <strong>%{total_amount} BAT</strong> worth of earnings from Brave Rewards are ready to be deposited. All you need to do is connect a wallet to your Brave Rewards account.</p> <p>Log in to Brave Rewards and connect your wallet from the dashboard to receive your funds.</p>
       button: Log in to Brave Rewards
     verify_email:
       subject: Verify your Brave Rewards email address

--- a/test/mailers/previews/publisher_mailer_preview.rb
+++ b/test/mailers/previews/publisher_mailer_preview.rb
@@ -24,13 +24,12 @@ class PublisherMailerPreview < ActionMailer::Preview
     PublisherMailer.verification_done(Channel.first)
   end
 
-
   def wallet_not_connected
-    PublisherMailer.wallet_not_connected(Publisher.first)
+    PublisherMailer.wallet_not_connected(Publisher.first, 232.43179)
   end
 
   def uphold_kyc_incomplete
-    PublisherMailer.uphold_kyc_incomplete(Publisher.first)
+    PublisherMailer.uphold_kyc_incomplete(Publisher.first, 232.43179)
   end
 
   def uphold_member_restricted

--- a/test/mailers/previews/publisher_mailer_preview.rb
+++ b/test/mailers/previews/publisher_mailer_preview.rb
@@ -25,11 +25,11 @@ class PublisherMailerPreview < ActionMailer::Preview
   end
 
   def wallet_not_connected
-    PublisherMailer.wallet_not_connected(Publisher.first, 232.43179)
+    PublisherMailer.wallet_not_connected(Publisher.first, 232.4)
   end
 
   def uphold_kyc_incomplete
-    PublisherMailer.uphold_kyc_incomplete(Publisher.first, 232.43179)
+    PublisherMailer.uphold_kyc_incomplete(Publisher.first, 232.4)
   end
 
   def uphold_member_restricted

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -12,7 +12,7 @@ class PublisherMailerTest < ActionMailer::TestCase
 
   test "wallet_not_connected" do
     publisher = publishers(:youtube_initial)
-    email = PublisherMailer.wallet_not_connected(publisher)
+    email = PublisherMailer.wallet_not_connected(publisher, 750.0)
 
     assert_emails 1 do
       email.deliver_now

--- a/test/services/payout_report_publisher_includer_test.rb
+++ b/test/services/payout_report_publisher_includer_test.rb
@@ -247,7 +247,7 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
 
       it "sends email to connect uphold" do
         email = ActionMailer::Base.deliveries.last
-        assert_equal email&.subject, I18n.t("publisher_mailer.wallet_not_connected.subject")
+        assert_equal email&.subject, I18n.t("publisher_mailer.wallet_not_connected.subject", total_amount: 975.0)
       end
     end
   end


### PR DESCRIPTION
## Show total amount during KYC emails
Closes #2346

#### Features

- Put the total amount of BAT that a user will be paid if they verify their Uphold account