### PR TITLE
Copyable link embedded in login url

### DIFF
--- a/app/views/publisher_mailer/login_email.html.slim
+++ b/app/views/publisher_mailer/login_email.html.slim
@@ -8,5 +8,6 @@ p= t ".body_html"
 
 div.btn-container= link_to(t(".button"), @private_reauth_url, class: "btn-primary btn-login")
 
-.notice= t "shared.warning_note_html"
-  
+.notice
+  p= t ".explicit_url", url: @private_reauth_url
+  p= t "shared.warning_note_html"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,6 +288,7 @@ en:
       body_html: |
         Click the button below to log in to your Brave Rewards account. This email contains a private access link that can only be used once.
       button: Log in to Brave Rewards
+      explicit_url: If the above button doesn't work, paste this link in your browser %{url}
     login_partner_email:
       salutation: Howdy %{name},
       subject: You've been added as a partner on Brave Rewards


### PR DESCRIPTION
Closes #2399
<img width="799" alt="Screen Shot 2019-11-25 at 9 22 06 AM" src="https://user-images.githubusercontent.com/8647607/69562960-15cb9b00-0f65-11ea-94f4-8cd24bd914b5.png">
