### PR TITLE
Warn when settlement report can't be uploaded

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -78,8 +78,10 @@ class Admin::PayoutReportsController < AdminController
     redirect_to admin_payout_reports_path, flash: { notice: "Successfully uploaded settlement report" }
   rescue JSON::ParserError => e
     redirect_to admin_payout_reports_path, flash: { alert: "Could not parse JSON. #{e.message}" }
-  rescue Faraday::ClientError => eyeshade_error
+  rescue Faraday::ClientError
     redirect_to admin_payout_reports_path, flash: { alert: "Eyeshade responded with a 400 🤷‍️" }
+  rescue StandardError
+    redirect_to admin_payout_reports_path, flash: { alert: "Something bad happened!" }
   end
 
   def toggle_payout_in_progress

--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -80,7 +80,7 @@ class Admin::PayoutReportsController < AdminController
     redirect_to admin_payout_reports_path, flash: { alert: "Could not parse JSON. #{e.message}" }
   rescue Faraday::ClientError
     redirect_to admin_payout_reports_path, flash: { alert: "Eyeshade responded with a 400 🤷‍️" }
-  rescue StandardError
+  rescue StandardError => e
     redirect_to admin_payout_reports_path, flash: { alert: "Something bad happened!" }
   end
 

--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -81,7 +81,9 @@ class Admin::PayoutReportsController < AdminController
   rescue Faraday::ClientError
     redirect_to admin_payout_reports_path, flash: { alert: "Eyeshade responded with a 400 🤷‍️" }
   rescue StandardError => e
-    redirect_to admin_payout_reports_path, flash: { alert: "Something bad happened!" }
+    redirect_to admin_payout_reports_path, flash: { alert: "Something bad happened! Please check Sentry for more details" }
+    require "sentry-raven"
+    Raven.capture_exception(e)
   end
 
   def toggle_payout_in_progress


### PR DESCRIPTION
## Warn when payout report can't be uploaded

#### Features

Last payout cycle when the final settlement report was uploaded the file wasn't able to be uploaded for some reason and so we need to warn when this happens