### PR TITLE
Use owner identifier for Eyeshade call

### DIFF
--- a/app/services/eyeshade/referrals.rb
+++ b/app/services/eyeshade/referrals.rb
@@ -22,7 +22,7 @@ class Eyeshade::Referrals < Eyeshade::BaseApiClient
 
     response = connection.get do |request|
       request.headers["Authorization"] = api_authorization_header
-      request.url(PATH + "/statement/#{publisher.id}")
+      request.url(PATH + "/statement/#{URI.escape(publisher.owner_identifier)}")
       request.params = {
         start: start_date,
         until: end_date,


### PR DESCRIPTION
## Use owner identifier for Eyeshade call

Closes #2404

#### Features

Our call to Eyeshade is not returning any valid data due to an incorrect id that is being passed in.