### PR TITLE
Symbolize keys from Eyeshade response

### DIFF
--- a/app/services/eyeshade/referrals.rb
+++ b/app/services/eyeshade/referrals.rb
@@ -14,7 +14,7 @@ class Eyeshade::Referrals < Eyeshade::BaseApiClient
       }
     end
 
-    JSON.parse(response.body)
+    JSON.parse(response.body).map(&:symbolize_keys)
   end
 
   def statement(publisher:, start_date:, end_date:)
@@ -29,7 +29,7 @@ class Eyeshade::Referrals < Eyeshade::BaseApiClient
       }
     end
 
-    JSON.parse(response.body)
+    JSON.parse(response.body).map(&:symbolize_keys)
   end
 
   private


### PR DESCRIPTION
## Symbolize keys from Eyeshade response

![image](https://user-images.githubusercontent.com/5459225/69940620-54eb7600-14a8-11ea-8a2e-1ee174b1fabe.png)

#### Features

Since the keys on this endpoint weren't symbolize the calculations for the referral codes aren't displaying properly in the following code.

https://github.com/brave-intl/publishers/blob/40f0ab2b4c5175bfa1da5daf0cd3c0cf2634f729/app/controllers/publishers/promo_registrations_controller.rb#L27-L29

When the keys are properly symbolized this logic will be able to function correctly.

### How to test

Log into production via Heroku
Copy / paste change
Run the linked code above
Counts are properly going for codes.