### PR TITLE
Use end_date instead of start_date

### DIFF
--- a/app/services/promo/registration_stats_report_generator.rb
+++ b/app/services/promo/registration_stats_report_generator.rb
@@ -145,7 +145,7 @@ class Promo::RegistrationStatsReportGenerator < BaseService
     Promo::RegistrationsGeoStatsFetcher.new(
       referral_codes: @referral_codes,
       start_date: @start_date,
-      end_date: @start_date,
+      end_date: @end_date,
       interval: @reporting_interval
     ).perform
   end


### PR DESCRIPTION
## Use end_date instead of start_date

Minor copy/paste mistake when referring to end_date