### PR TITLE
Create Payment Message for reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
     puma (4.3.1)
       nio4r (~> 2.0)
     raabro (1.1.6)
-    rack (2.0.8)
+    rack (2.1.1)
     rack-attack (5.4.2)
       rack (>= 1.0, < 3)
     rack-protection (2.0.7)

--- a/app/assets/stylesheets/admin/pages/publisher.scss
+++ b/app/assets/stylesheets/admin/pages/publisher.scss
@@ -170,3 +170,59 @@
     color: $braveGray-6;
   }
 }
+
+.payout-progress {
+  display: flex;
+  align-items: center;
+
+  .icon {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+
+    &.active {
+      background: $braveBrand;
+    }
+
+    &.inactive {
+      border: 1px solid $braveGray-8;
+    }
+
+    &.animated {
+      animation: colorchange 3s linear infinite;
+
+      @keyframes colorchange {
+        0% {
+          background: $braveBrand;
+        }
+        50% {
+          background: $braveBrand-Light;
+        }
+        100% {
+          background: $braveBrand;
+        }
+      }
+    }
+  }
+
+  progress {
+    width: auto;
+    flex-grow: 1;
+    height: 1px;
+    background: $braveGray-8;
+    -webkit-appearance: none;
+  }
+  progress::-webkit-progress-bar {
+    background: $braveGray-8;
+  }
+  progress::-webkit-progress-value {
+    background: $braveBrand;
+  }
+}
+
+
+.dashboard-panel--header {
+  font-size: 28px;
+  color: #5e6175;
+  font-weight: bold;
+}

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -50,6 +50,12 @@ class Admin::PublishersController < AdminController
     @potential_referral_payment = @publisher.most_recent_potential_referral_payment
     @referral_owner_status = PromoClient.owner_state.find(id: params[:id])
     @current_user = current_user
+
+    if true || payout_in_progress? || Date.today.day < 12 # Let's display the payout for 5 days after it should complete (on the 8th)
+      @payout_report = PayoutReport.where(final: true, manual: false).order(created_at: :desc).first
+      @payout_message = PayoutMessage.find_by(payout_report: @payout_report, publisher: @publisher)
+      @payout_message = PayoutMessage.first
+    end
   end
 
   def edit

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -51,7 +51,7 @@ class Admin::PublishersController < AdminController
     @referral_owner_status = PromoClient.owner_state.find(id: params[:id])
     @current_user = current_user
 
-    if true || payout_in_progress? || Date.today.day < 12 # Let's display the payout for 5 days after it should complete (on the 8th)
+    if payout_in_progress? || Date.today.day < 12 # Let's display the payout for 5 days after it should complete (on the 8th)
       @payout_report = PayoutReport.where(final: true, manual: false).order(created_at: :desc).first
       @payout_message = PayoutMessage.find_by(payout_report: @payout_report, publisher: @publisher)
       @payout_message = PayoutMessage.first

--- a/app/helpers/payout_helper.rb
+++ b/app/helpers/payout_helper.rb
@@ -48,8 +48,8 @@ module PayoutHelper
     100
   end
 
-  def payout_warning(payout_report)
-    found_payout = payout_report.potential_payments.where(publisher: current_publisher).first
+  def payout_warning(payout_report, publisher)
+    found_payout = payout_report.potential_payments.where(publisher: publisher).first
 
     return I18n.t(".publishers.payout_status.information.not_found") if found_payout.blank?
 
@@ -59,12 +59,14 @@ module PayoutHelper
       I18n.t(".publishers.payout_status.information.reauthorize_uphold")
     elsif found_payout.uphold_member.blank?
       I18n.t(".publishers.payout_status.information.kyc_required")
+    elsif found_payout.status.locked?
+      I18n.t(".publishers.payout_status.information.locked")
     end
   end
 
-  def payout_amount(payout_report)
+  def payout_amount(payout_report, publisher)
     amount = payout_report.potential_payments.
-      where(publisher: current_publisher).
+      where(publisher: publisher).
       select(&:amount).
       map { |x| x.amount.to_d }.
       sum

--- a/app/jobs/enqueue_publishers_for_payout_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_job.rb
@@ -29,7 +29,7 @@ class EnqueuePublishersForPayoutJob < ApplicationJob
                                                 payout_report: payout_report,
                                                 should_send_notifications: should_send_notifications).perform
       else
-        IncludePublisherInPayoutReportJob.perform_later(payout_report_id: payout_report.id,
+        IncludePublisherInPayoutReportJob.perform_async(payout_report_id: payout_report.id,
                                                         publisher_id: publisher.id,
                                                         should_send_notifications: should_send_notifications)
       end

--- a/app/jobs/enqueue_publishers_for_payout_notification_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_notification_job.rb
@@ -11,9 +11,11 @@ class EnqueuePublishersForPayoutNotificationJob < ApplicationJob
     end
 
     publishers.find_each do |publisher|
-      IncludePublisherInPayoutReportJob.perform_async(payout_report_id: nil,
-                                                      publisher_id: publisher.id,
-                                                      should_send_notifications: true)
+      IncludePublisherInPayoutReportJob.perform_async(
+        payout_report_id: nil,
+        publisher_id: publisher.id,
+        should_send_notifications: true
+      )
     end
     Rails.logger.info("Enuqueued #{publishers.count} publishers for payment notifications.")
   end

--- a/app/jobs/enqueue_publishers_for_payout_notification_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_notification_job.rb
@@ -9,9 +9,9 @@ class EnqueuePublishersForPayoutNotificationJob < ApplicationJob
     else
       publishers = Publisher.with_verified_channel.not_suspended
     end
-    
+
     publishers.find_each do |publisher|
-      IncludePublisherInPayoutReportJob.perform_later(payout_report_id: nil,
+      IncludePublisherInPayoutReportJob.perform_async(payout_report_id: nil,
                                                       publisher_id: publisher.id,
                                                       should_send_notifications: true)
     end

--- a/app/jobs/include_publisher_in_payout_report_job.rb
+++ b/app/jobs/include_publisher_in_payout_report_job.rb
@@ -2,9 +2,13 @@ class IncludePublisherInPayoutReportJob
   include Sidekiq::Worker
   sidekiq_options queue: 'scheduler'
 
-  def perform(payout_report_id:, publisher_id:, should_send_notifications:)
+  def perform(arguments = {})
     # If payout_report_id is not present, we only want to send notifications
     # not create payments
+    payout_report_id = arguments["payout_report_id"]
+    publisher_id = arguments["publisher_id"]
+    should_send_notifications = arguments["should_send_notifications"]
+
     if payout_report_id.present?
       payout_report = PayoutReport.find(payout_report_id)
     else

--- a/app/jobs/include_publisher_in_payout_report_job.rb
+++ b/app/jobs/include_publisher_in_payout_report_job.rb
@@ -1,5 +1,6 @@
 class IncludePublisherInPayoutReportJob
   include Sidekiq::Worker
+  sidekiq_options queue: 'scheduler'
 
   def perform(payout_report_id:, publisher_id:, should_send_notifications:)
     # If payout_report_id is not present, we only want to send notifications

--- a/app/jobs/include_publisher_in_payout_report_job.rb
+++ b/app/jobs/include_publisher_in_payout_report_job.rb
@@ -1,8 +1,7 @@
-class IncludePublisherInPayoutReportJob < ApplicationJob
-  queue_as :scheduler
+class IncludePublisherInPayoutReportJob
+  include Sidekiq::Worker
 
   def perform(payout_report_id:, publisher_id:, should_send_notifications:)
-
     # If payout_report_id is not present, we only want to send notifications
     # not create payments
     if payout_report_id.present?

--- a/app/models/payout_message.rb
+++ b/app/models/payout_message.rb
@@ -1,0 +1,4 @@
+class PayoutMessage < ApplicationRecord
+  belongs_to :payout_report
+  belongs_to :publisher
+end

--- a/app/models/payout_report.rb
+++ b/app/models/payout_report.rb
@@ -10,6 +10,7 @@ class PayoutReport < ApplicationRecord
   attr_encrypted :contents, key: :encryption_key, marshal: true
 
   has_many :potential_payments
+  has_many :payout_messages
 
   validates_presence_of :expected_num_payments
 

--- a/app/services/publisher_wallet_getter.rb
+++ b/app/services/publisher_wallet_getter.rb
@@ -4,8 +4,11 @@ require "eyeshade/wallet"
 class PublisherWalletGetter < BaseApiClient
   attr_reader :publisher
 
-  def initialize(publisher:)
+  RATES_CACHE_KEY = "rates_cache".freeze
+
+  def initialize(publisher:, include_transactions: true)
     @publisher = publisher
+    @include_transactions = include_transactions
   end
 
   def perform
@@ -17,9 +20,9 @@ class PublisherWalletGetter < BaseApiClient
     end
 
     Eyeshade::Wallet.new(
-      rates: Ratio::Ratio.new.relative(currency: "BAT"),
+      rates: rates,
       accounts: accounts,
-      transactions: PublisherTransactionsGetter.new(publisher: @publisher).perform,
+      transactions: transactions,
       uphold_connection: publisher.uphold_connection
     )
 
@@ -29,6 +32,18 @@ class PublisherWalletGetter < BaseApiClient
   end
 
   private
+
+  def rates
+    # Cache the ratios every minute. Rates are used for display purposes only.
+    Rails.cache.fetch("RATES_CACHE_KEY", expires_in: 1.minute) do
+      Ratio::Ratio.new.relative(currency: "BAT")
+    end
+  end
+
+  def transactions
+    return [] unless @include_transactions
+    PublisherTransactionsGetter.new(publisher: @publisher).perform
+  end
 
   def api_base_uri
     Rails.application.secrets[:api_eyeshade_base_uri]

--- a/app/services/uphold_request_access_parameters.rb
+++ b/app/services/uphold_request_access_parameters.rb
@@ -12,7 +12,7 @@ class UpholdRequestAccessParameters < BaseService
   def connection
     @connection ||= begin
       Faraday.new(url: api_base_uri) do |faraday|
-        faraday.proxy(proxy_url) if proxy_url.present?
+        faraday.proxy = proxy_url if proxy_url.present?
         # Log level info: Brief summaries
         # Log level debug: Detailed bodies and headers
         faraday.response(:logger, Rails.logger, bodies: true, headers: true)

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -96,6 +96,16 @@ hr
               .db-field = "Approx. amount"
               .db-value = "#{@potential_referral_payment.amount.to_d * 1/1E18} BAT"
 
+
+  - if @payout_report.present?
+    .c-4.shadow-sm.bg-white.rounded.p-3.my-4
+      = render partial: 'publishers/payout_status', locals: { payout_report: @payout_report, publisher: @publisher }
+      - if @payout_message.present?
+        .mt-4
+        h5.text-dark Payout Message
+        .alert.alert-dark
+          = @payout_message.message
+
   .c-4.shadow-sm.bg-white.rounded.p-3.my-4
     = render partial: 'uphold'
 

--- a/app/views/publishers/_payout_status.html.slim
+++ b/app/views/publishers/_payout_status.html.slim
@@ -1,5 +1,5 @@
 .dashboard-panel--wrapper
-  - payout_warning = payout_warning(payout_report)
+  - payout_warning = payout_warning(payout_report, publisher)
   .dashboard-panel--header= t('.heading')
   - if Rails.cache.fetch("payout_report_generating")
     .alert.alert-info
@@ -16,7 +16,7 @@
         = t('.amount')
         small *
       h4.font-weight-light
-        span= payout_amount(payout_report)
+        span= payout_amount(payout_report, publisher)
         small.font-weight-light= " " + I18n.t(".bat_in_locale")
 
       / We're going to do some magic to make the user feel like things are actually happening
@@ -36,6 +36,7 @@
 
       .pt-2
         = t('.description')
-      .mt-4
-        small=t('.amount_description', time: payout_report.created_at.strftime("%Y-%m-%d"))
+
+    .mt-4
+      small=t('.amount_description', time: payout_report.created_at.strftime("%Y-%m-%d"))
 

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -101,7 +101,7 @@ script type="text/html" id="confirm_default_currency_modal_wrapper"
     - if @payout_report.present?
       .row
        .col-md.mb-4
-         = render partial: 'payout_status', locals: { payout_report: @payout_report }
+         = render partial: 'payout_status', locals: { payout_report: @payout_report, publisher: @publisher }
     .row
       .col-md.mb-4
         - if !(@publisher.excluded_from_payout? || @publisher.paypal_locale?(params[:locale]) || @publisher.uphold_connection&.japanese_account?)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# https://github.com/mperham/sidekiq/wiki/Using-Redis#using-an-initializer
+Sidekiq.configure_server do |config|
+  config.redis = { url: Rails.application.secrets[:redis_url], network_timeout: 5 }
+end
+
+# Must define both configure_server and configure_client
+Sidekiq.configure_client do |config|
+  config.redis = { url: Rails.application.secrets[:redis_url], network_timeout: 5 }
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -455,6 +455,7 @@ en:
         reauthorize_uphold: At the time we generated the payout report, your Uphold account needed to be reconnected.
         kyc_required: At the time we generated the payout report, your identity was not yet verified through Uphold.
         no_payment: You will not be able to receive payment for this cycle.
+        locked: At the time we generated the payout report your account was in locked status from removing your 2FA.
         generating: The payout report is currently generating. Please check back later.
     change_email:
       login_email: Login Email

--- a/db/migrate/20200114024815_create_payout_messages.rb
+++ b/db/migrate/20200114024815_create_payout_messages.rb
@@ -1,0 +1,12 @@
+class CreatePayoutMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :payout_messages, id: :uuid, default: -> {"uuid_generate_v4()"} do |t|
+        t.references :payout_report, type: :uuid, null: false
+        t.references :publisher, type: :uuid, index: true, null: false
+
+        t.text :message
+
+        t.timestamps
+    end
+  end
+end

--- a/test/controllers/admin/payout_reports_controller_test.rb
+++ b/test/controllers/admin/payout_reports_controller_test.rb
@@ -281,7 +281,9 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
     assert_difference("PayoutReport.count", 0) do # Ensure no payout report is created
       assert_difference("ActionMailer::Base.deliveries.count", 1) do # ensure notification is sent
         perform_enqueued_jobs do
-          post notify_admin_payout_reports_path
+          Sidekiq::Testing.inline! do
+            post notify_admin_payout_reports_path
+          end
         end
       end
     end

--- a/test/jobs/enqueue_publishers_for_payout_notification_job_test.rb
+++ b/test/jobs/enqueue_publishers_for_payout_notification_job_test.rb
@@ -1,19 +1,21 @@
 require 'test_helper'
 
 class EnqueuePublishersForPayoutNotificationJobTest < ActiveJob::TestCase
+  before do
+    IncludePublisherInPayoutReportJob.clear
+  end
+
   test "launches 1 job per publisher" do
     assert_difference -> { PayoutReport.count } do
-      assert_enqueued_jobs(Publisher.joins(:uphold_connection).with_verified_channel.count) do
-        EnqueuePublishersForPayoutJob.perform_now
-      end
+      EnqueuePublishersForPayoutJob.perform_now
+      assert_equal Publisher.joins(:uphold_connection).with_verified_channel.count, IncludePublisherInPayoutReportJob.jobs.size
     end
   end
 
   test "can supply a list of publisher ids" do
     publishers = Publisher.where.not(email: "priscilla@potentiallypaid.org")
 
-    assert_enqueued_jobs(publishers.joins(:uphold_connection).count) do
-      EnqueuePublishersForPayoutJob.perform_now(publisher_ids: publishers.pluck(:id))
-    end
+    EnqueuePublishersForPayoutJob.perform_now(publisher_ids: publishers.pluck(:id))
+    assert_equal publishers.joins(:uphold_connection).count, IncludePublisherInPayoutReportJob.jobs.size
   end
 end

--- a/test/services/payout_report_publisher_includer_test.rb
+++ b/test/services/payout_report_publisher_includer_test.rb
@@ -255,7 +255,9 @@ class PayoutReportPublisherIncluderTest < ActiveJob::TestCase
   describe "for a paypal user" do
     let(:should_send_notifications) { true }
     let(:publisher) { publishers(:paypal_connected) }
+
     before do
+      @payout_report = PayoutReport.create(fee_rate: 0.05, expected_num_payments: PayoutReport.expected_num_payments(Publisher.all))
       perform_enqueued_jobs do
         PayoutReportPublisherIncluder.new(payout_report: @payout_report,
                                           publisher: publisher,


### PR DESCRIPTION
## Create Payment Message for reporting

#### Features

It's currently very hard to debug why a publisher might not have been included in a payout. We introduce a new table to help diagnose and debug reasons why a publisher might not have been included. 

- Introduce PayoutMessage
- Introduce a field for `include_transactions` on PublisherWalletGetter. Transactions are not needed during payout report.
