### PR TITLE
Fix Sidekiq UI

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,3 +7,8 @@ end
 Sidekiq.configure_client do |config|
   config.redis = { url: Rails.application.secrets[:redis_url], size: 40, network_timeout: 5 }
 end
+
+# Prevent user's sessions from being overwritten so you can be logged in and also have the Sidekiq UI open.
+# https://github.com/mperham/sidekiq/wiki/Monitoring#sessions-being-lost
+require 'sidekiq/web'
+Sidekiq::Web.set :sessions, false


### PR DESCRIPTION
## Fix Sidekiq UI

In production we currently get a `TypeError` which shows as an HTTP 500. By removing Sidekiq saving sessions this fixes the error and also fixes being logged out from Publisher's when you have both the UI and are logged in 