### PR TITLE
Temporarily disable certain columns in PayoutReport#index until we setup follower db con…

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -2,6 +2,7 @@ class Admin::PayoutReportsController < AdminController
   MANUAL = "manual"
 
   def index
+    flash[:alert] = "To view (1) expected vs actual potential payments, (2) payouts to be paid and their amounts, (3) or payments missing Uphold addresses, message Albert Wang for a query on Metabase until follower database is setup"
     @payout_reports = PayoutReport.all.order(created_at: :desc).paginate(page: params[:page])
   end
 

--- a/app/views/admin/payout_reports/index.html.slim
+++ b/app/views/admin/payout_reports/index.html.slim
@@ -23,10 +23,10 @@ table.display.table.table-bordered.table-striped
     th ID
     th Type
     th Manual
-    th Expected - actual # of payments
-    th # Payments to be paid
-    th # Legit payments missing addresses
-    th Amount
+    /TODO: (Albert Wang): Re-enable these columns once we query follower or figure out a smart optimization th Expected - actual # of payments
+    / th # Payments to be paid
+    / th # Legit payments missing addresses
+    / th Amount
     th Refresh JSON
     th Download
   tbody
@@ -36,10 +36,10 @@ table.display.table.table-bordered.table-striped
         td = link_to report.id[0..6], admin_payout_report_path(report.id)
         td = "#{report.final ? "Final" : "Temp"}"
         td = report.manual ? "Yes" : "No"
-        td = "#{report.expected_num_payments} - #{report.num_payments}"
-        td = report.num_payments_to_be_paid
-        td = report.missing_addresses
-        td = "#{'%.2f' % (report.amount.to_d / 1E18)} BAT"
+        / TODO: Re-enable this once we can query follower or we figure out something longer term td = "#{report.expected_num_payments} - #{report.num_payments}"
+        / td = report.num_payments_to_be_paid
+        / td = report.missing_addresses
+        / td = "#{'%.2f' % (report.amount.to_d / 1E18)} BAT"
         td = form_tag refresh_admin_payout_report_path(report.id), method: :patch do
              = submit_tag "refresh", class: "btn btn-info"
         / (Albert Wang) Check encrypted_contents_iv since encrypted_contents is a large fetch.


### PR DESCRIPTION
…nection

Context: I've noticed that while a payout report is running and someone clicks on this page, Heroku might kill the thread if it takes too long to load. Since `count(*)` is a fairly expensive operation as it requires locking up the index and preventing insertions from happening. Additionally, `potential_payments` is the largest table we frequently query from.

Additional reading for alternative solutions can be found here: https://www.cybertec-postgresql.com/en/postgresql-count-made-fast/