### PR TITLE
Create Internal API for Uphold Transactions

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::TransactionsController < Api::BaseController
+  class GetTransactionError < StandardError; end
+
+  def show
+    channel = get_merchant!(params[:merchant])
+    uphold_client = Uphold::Client.new(uphold_connection: channel.publisher.uphold_connection)
+
+    render json: uphold_client.transaction.find(id: params[:id])
+  rescue GetTransactionError => e
+    render json: { errors: e.message }, status: 404
+  rescue Faraday::ResourceNotFound
+    render json: { errors: "Could not find the specified transaction under the publishers account" }, status: 400
+  end
+
+  def get_merchant!(merchant)
+    channel = Channel.site_channels.verified.find_by(site_channel_details: { brave_publisher_id: merchant })
+
+    raise GetTransactionError.new("Could not find merchant") if channel.blank?
+    raise GetTransactionError.new("Merchant does not have connected Uphold account") if channel.publisher&.uphold_connection.blank?
+    channel
+  end
+end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::TransactionsController < Api::BaseController
   class GetTransactionError < StandardError; end
 
   def show
-    channel = get_merchant!(params[:merchant])
+    channel = get_merchant!(params[:channel])
     uphold_client = Uphold::Client.new(uphold_connection: channel.publisher.uphold_connection)
 
     render json: uphold_client.transaction.find(id: params[:id])
@@ -12,11 +12,13 @@ class Api::V1::TransactionsController < Api::BaseController
     render json: { errors: "Could not find the specified transaction under the publishers account" }, status: 400
   end
 
-  def get_merchant!(merchant)
-    channel = Channel.site_channels.verified.find_by(site_channel_details: { brave_publisher_id: merchant })
+  def get_merchant!(channel)
+    raise GetTransactionError.new("Missing channel query parameter.") if channel.blank?
 
-    raise GetTransactionError.new("Could not find merchant") if channel.blank?
-    raise GetTransactionError.new("Merchant does not have connected Uphold account") if channel.publisher&.uphold_connection.blank?
+    channel = Channel.find_by_channel_identifier(channel)
+
+    raise GetTransactionError.new("Could not find channel. Did you encode the identifier?") if channel.blank?
+    raise GetTransactionError.new("Channel does not have connected Uphold account") if channel.publisher&.uphold_connection.blank?
     channel
   end
 end

--- a/app/services/uphold/models/transaction.rb
+++ b/app/services/uphold/models/transaction.rb
@@ -53,6 +53,18 @@ module Uphold
         transactions.flatten
       end
 
+      # Gets a specified transaction given an id
+      #
+      # id: The id for the uphold transaction
+      #
+      # Returns an Uphold Transaction
+      def find(id:)
+        path = Addressable::Template.new("/v0/me/transactions/{id}")
+        response = get(path.expand(id: id), {}, authorization(@uphold_connection))
+
+        Uphold::Models::Transaction.new(parse_response(response))
+      end
+
       def authorization(uphold_connection)
         token = JSON.parse(uphold_connection.uphold_access_parameters || "{}").try(:[], "access_token")
         "Authorization: Bearer #{token}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,8 @@ Rails.application.routes.draw do
       resources :publishers, defaults: { format: :json } do
         post "publisher_status_updates"
       end
+      resources :transactions, only: [:show]
+
       # /api/v1/stats/
       namespace :stats, defaults: { format: :json } do
         namespace :channels, defaults: { format: :json } do


### PR DESCRIPTION
## Create Internal API for Uphold Transactions

Closes #2491

#### Features

For user funded auto-contribute we need to verify that a given transaction happened for a given a channel identifier. 

This gets the amount that was verified and ensures the transaction happened for the right channel.