### PR TITLE
Filter out email addresses for resend_authentication_email

### DIFF
--- a/app/controllers/publishers/registrations_controller.rb
+++ b/app/controllers/publishers/registrations_controller.rb
@@ -89,11 +89,21 @@ module Publishers
         MailerServices::PublisherLoginLinkEmailer.new(publisher: @publisher).perform
       end
 
+      @publisher_email = filter_email(@publisher_email)
+
       flash.now[:notice] = t(".done")
       render(:emailed_authentication_token)
     end
 
     private
+
+    def filter_email(email)
+      # Only keep first and last characters
+      range = 1...-1
+      identifier, provider = email.split('@')
+      identifier.tap { |x| x[range] = ("*" * x[range].length) }
+      "#{identifier}@#{provider}"
+    end
 
     def email_existing_publisher(publisher)
       @publisher = publisher

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,6 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+
+User-agent: *
+Disallow: /publishers/expired_auth_token


### PR DESCRIPTION
## Filter out email addresses for resend_authentication_email

Closes #2535 

#### Features

- Removes expired_auth_token from google search results
- Filters out email if someone gains access to a publisher id and accesses the page

![image](https://user-images.githubusercontent.com/5459225/73893691-fa6fec80-483f-11ea-8337-945df0fe0f2a.png)
