### PR TITLE
Fix rate limit on registration

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -113,7 +113,6 @@ class Rack::Attack
     # In JS we specify that the format is application/json by writing /publishers/registrations.json
     path = req.path.sub('.json', '')
     if (path == "/publishers" || path == "/publishers/registrations") && (req.post? || req.patch?)
-      puts '🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨'
       req.ip
     end
   end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -110,7 +110,10 @@ class Rack::Attack
   # In PublishersController we'll check the annotated request object
   # to apply additional Recaptcha.
   throttle("registrations/ip", limit: 60, period: 1.hour) do |req|
-    if (req.path == "/publishers" || req.path == "/publishers/registrations") && (req.post? || req.patch?)
+    # In JS we specify that the format is application/json by writing /publishers/registrations.json
+    path = req.path.sub('.json', '')
+    if (path == "/publishers" || path == "/publishers/registrations") && (req.post? || req.patch?)
+      puts '🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨'
       req.ip
     end
   end


### PR DESCRIPTION
## Fix rate limit on registration

Closes #2515 

#### Features

🐛 Fixes a bug where path 

#### How To Test

1. Run `rails dev:cache`
2. Hit the registrations controller about 60 times 
3. Should get a http code `420`