### PR TITLE
[Bug] Fix an reading dyno cache error

### DIFF
--- a/app/controllers/concerns/browser_channels_dyno_caching.rb
+++ b/app/controllers/concerns/browser_channels_dyno_caching.rb
@@ -18,7 +18,7 @@ module BrowserChannelsDynoCaching
   def clear_if_old_lock
     past_time = Rails.cache.fetch(self.class::REDIS_THUNDERING_HERD_KEY)
     # It's about 55 MB, which should only take 10 seconds to transmit from endpoint to browser.
-    if past_time.present? && 5.minutes.ago > Time.at(past_time)
+    if past_time.present? && 5.minutes.ago > Time.at(past_time.to_i)
       Rails.cache.delete(self.class::REDIS_THUNDERING_HERD_KEY)
     end
   end


### PR DESCRIPTION
Fix #2592, which `Time.at` is trying to be run against a string instead of an int.