### PR TITLE
Decrease the number of pings we use for site channel verifications.

### DIFF
--- a/app/models/site_channel_details.rb
+++ b/app/models/site_channel_details.rb
@@ -26,7 +26,7 @@ class SiteChannelDetails < BaseChannelDetails
   # clear/register domain errors as appropriate
   before_validation :clear_brave_publisher_id_error, if: -> { brave_publisher_id_unnormalized.present? && brave_publisher_id_unnormalized_changed? }
 
-  scope :recent_unverified_site_channels, -> (max_age: 6.weeks) {
+  scope :recent_unverified_site_channels, -> (max_age: 1.weeks) {
     SiteChannelDetails.unscoped.joins(:channel).
       where.not(brave_publisher_id: SiteChannelDetails.unscoped.joins(:channel).select(:brave_publisher_id).distinct.where("channels.verified": true)).
       where("channels.created_at": max_age.ago..Time.now)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,7 +10,7 @@
 :enabled: <%= !(ENV["RAILS_ENV"] == 'development') %>
 :schedule:
   EnqueueSiteChannelVerifications:
-    cron: "42 * * * *"
+    cron: "42 1 * * *"
     decription: "For Site Channels created within the past week, enqueue jobs to verify the domain of each unique brave_publisher_id."
     queue: scheduler
   CleanStaleUpholdDataJob:


### PR DESCRIPTION
It seems ridiculous to ping every hour for 6 weeks. This is cutting into running other jobs.