### PR TITLE
Limit the length of a name

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -77,6 +77,7 @@ class PublishersController < ApplicationController
     update_params = publisher_update_params
 
     # If user enters current email address delete the pending email attribute
+    update_params[:pending_email] = update_params[:pending_email]&.downcase
     update_params[:pending_email] = nil if update_params[:pending_email] == current_publisher.email
 
     success = current_publisher.update(update_params)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -53,6 +53,7 @@ class PublishersController < ApplicationController
       session[:publisher_created_through_youtube_auth] = nil
       redirect_to publisher_next_step_path(@publisher)
     else
+      flash[:alert] = @publisher.errors.full_messages.join(', ')
       render(:email_verified)
     end
   end

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -56,7 +56,7 @@ class Publisher < ApplicationRecord
   validate :pending_email_must_be_a_change, unless: -> { deleted? || browser_user? }
   validate :pending_email_can_not_be_in_use, unless: -> { deleted? || browser_user? }
 
-  validates :name, presence: true, allow_blank: true
+  validates :name, presence: true, allow_blank: true, length: { maximum: 64 }
 
   validates_inclusion_of :role, in: ROLES
 


### PR DESCRIPTION
## Limit the length of a name

#### Features

Users shouldn't be able to enter a really long name as it messes with the styling and formatting of the website.