### PR TITLE
Change when jobs get enqueued

### DIFF
--- a/app/services/uphold_request_access_parameters.rb
+++ b/app/services/uphold_request_access_parameters.rb
@@ -51,7 +51,6 @@ class UpholdRequestAccessParameters < BaseService
     response.body
   rescue Faraday::ClientError => e
     Rails.logger.warn("UpholdRequestAccessParameters ClientError: #{e}")
-    p e.response
     if e.response && e.response[:status] == 400 && e.response[:body] == '{"error":"invalid_grant"}'
       # The Code was invalid and could not be used to retrieve access parameters. Raise an exception so this
       # can be handled externally

--- a/app/services/uphold_request_access_parameters.rb
+++ b/app/services/uphold_request_access_parameters.rb
@@ -51,6 +51,7 @@ class UpholdRequestAccessParameters < BaseService
     response.body
   rescue Faraday::ClientError => e
     Rails.logger.warn("UpholdRequestAccessParameters ClientError: #{e}")
+    p e.response
     if e.response && e.response[:status] == 400 && e.response[:body] == '{"error":"invalid_grant"}'
       # The Code was invalid and could not be used to retrieve access parameters. Raise an exception so this
       # can be handled externally

--- a/config/heavy_sidekiq.yml
+++ b/config/heavy_sidekiq.yml
@@ -33,11 +33,11 @@
     description: "Syncs the channel stats via youtube and twitch apis"
     queue: low
   CacheBrowserChannelsJsonJob:
-    cron: "0 */2 * * *"
+    cron: "0 3 * * *"
     description: "Refreshes the redis cache for browser channel json"
     queue: heavy
   CacheBrowserChannelsJsonJobV2:
-    cron: "0 */2 * * *"
+    cron: "0 8 * * *"
     description: "Refreshes the redis cache for browser channel json V2"
     queue: heavy
   Cache::Metrics::UpholdKycByCountryJob:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -24,7 +24,7 @@
     cron: "0 8 * * *"
     description: "Complete transfer of channels that have exceeded their timeout time without being rejected"
   Sync::ChannelPromoRegistrationsStatsJob:
-    cron: "0 * * * *"
+    cron: "0 */2 * * *"
     description: "Sync stats for channel owned referral codes with the promo server every hour."
   TwoFactorAuthenticationRemovalJob:
     cron: "0 12 * * *"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -34,7 +34,7 @@
     description: "Syncs referral stats for unattached codes every 12 hours."
     queue: low
   Sync::ChannelStatsJob:
-    cron: "0 1 * * *"
+    cron: "0 23 * * *"
     description: "Syncs the channel stats via youtube and twitch apis"
     queue: low
   Sync::Zendesk::StartJob:


### PR DESCRIPTION
(1) I don't think we really use V1 or V2 though it seems someone is still hitting the API. Let's enqueue it only daily
(2) We're hitting Youtube quota limits, so this will be one fix to allow people to signup without issue.