### PR TITLE
Fix Statement Bugs

### DIFF
--- a/app/javascript/locale/en.ts
+++ b/app/javascript/locale/en.ts
@@ -223,7 +223,7 @@ export default {
       statement: "Statement",
       title: "Statements",
       totalBraveSettled: "Total Brave Settled",
-      totalDeposited: "Total Deposited",
+      totalDeposited: "Net Deposited",
       totalEarned: "Total Earned",
       types: {
         contributionSettlement: "Brave Settled Contributions",

--- a/app/javascript/locale/en.ts
+++ b/app/javascript/locale/en.ts
@@ -196,7 +196,6 @@ export default {
       brand: "Brave Creators",
       braveSettledContributions: "Brave Settled Contributions",
       breakdown: "Breakdown",
-      confirmedEarning: "Confirmed Earning",
       depositAccount: "Deposit Account",
       depositDate: "Brave Settled Deposit Date",
       description: "Statements contain the details of deposit history.",

--- a/app/javascript/locale/en.ts
+++ b/app/javascript/locale/en.ts
@@ -231,6 +231,7 @@ export default {
         referralSettlement: "Referral Promo Earnings",
         upholdContributionSettlement: "Direct User Tips",
       },
+      upholdCardLink: "https://uphold.com/dashboard/cards/{cardId}/actvity",
       view: "View",
       viewMore: "View More"
     }

--- a/app/javascript/views/statements/Statements.tsx
+++ b/app/javascript/views/statements/Statements.tsx
@@ -1,6 +1,10 @@
 import * as moment from "moment";
 import * as React from "react";
-import { FormattedMessage, FormattedNumber, injectIntl } from "react-intl";
+import {
+  FormattedMessage,
+  FormattedNumber,
+  injectIntl,
+} from "react-intl";
 import ReactTooltip from "react-tooltip";
 
 import { DownloadIcon } from "brave-ui/components/icons";
@@ -80,23 +84,35 @@ export const DepositBreakdown = (props) => {
       <span data-tip data-for={id}>
         {props.children}
       </span>
+
       <ReactTooltip id={id}>
-        {Object.keys(props.results).map((type) => (
-          <React.Fragment key={type}>
-            <FormattedMessage id={`statements.overview.types.${type}`} />
-            {": "}
-            <FormattedNumber
-              value={props.results[type]}
-              maximumFractionDigits={2}
-            />
-            {" BAT"}
-            <br />
-          </React.Fragment>
-        ))}
+        <table className="table text-light m-0">
+          <tbody>
+            {Object.keys(props.results).map((type) => (
+              <tr key={type}>
+                <td className="border-0 text-right">
+                  <FormattedMessage id={`statements.overview.types.${type}`} />
+                  {":  "}
+                </td>
+                <td className="border-0 text-left">
+                  <CurrencyNumber value={props.results[type]} /> {props.name}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </ReactTooltip>
     </React.Fragment>
   );
 };
+
+export const CurrencyNumber = (props) => (
+  <FormattedNumber
+    value={props.value}
+    maximumFractionDigits={2}
+    minimumFractionDigits={2}
+  />
+);
 
 class Statements extends React.Component<any, IStatementsState> {
   public readonly state: IStatementsState = {
@@ -197,9 +213,8 @@ class Statements extends React.Component<any, IStatementsState> {
                   <td>{DisplayEarningPeriod(statement.earningPeriod)}</td>
                   <td>{DisplayPaymentDate(statement.paymentDate)}</td>
                   <td className="text-right">
-                    <FormattedNumber
+                    <CurrencyNumber
                       value={statement.totals.totalBraveSettled}
-                      maximumFractionDigits={2}
                     />
                     <small>
                       {" "}
@@ -207,9 +222,8 @@ class Statements extends React.Component<any, IStatementsState> {
                     </small>
                   </td>
                   <td className="text-right">
-                    <FormattedNumber
+                    <CurrencyNumber
                       value={statement.totals.upholdContributionSettlement}
-                      maximumFractionDigits={2}
                     />
                     <small>
                       {" "}
@@ -227,7 +241,7 @@ class Statements extends React.Component<any, IStatementsState> {
                         )}
                       >
                         <React.Fragment>
-                          <FormattedNumber
+                          <CurrencyNumber
                             value={statement.deposited[name]}
                             maximumFractionDigits={2}
                           />{" "}

--- a/app/javascript/views/statements/Statements.tsx
+++ b/app/javascript/views/statements/Statements.tsx
@@ -1,6 +1,7 @@
 import * as moment from "moment";
 import * as React from "react";
 import { FormattedMessage, FormattedNumber, injectIntl } from "react-intl";
+import ReactTooltip from "react-tooltip";
 
 import { DownloadIcon } from "brave-ui/components/icons";
 
@@ -64,6 +65,37 @@ export const DisplayPaymentDate = (paymentDate: string) => {
     return moment(paymentDate).format("MMM DD, YYYY");
   }
   return "--";
+};
+
+export const GetParameterCaseInsensitive = (object, key) => {
+  return object[
+    Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase())
+  ];
+};
+
+export const DepositBreakdown = (props) => {
+  const id = props.name + "-" + Math.random();
+  return (
+    <React.Fragment>
+      <span data-tip data-for={id}>
+        {props.children}
+      </span>
+      <ReactTooltip id={id}>
+        {Object.keys(props.results).map((type) => (
+          <React.Fragment key={type}>
+            <FormattedMessage id={`statements.overview.types.${type}`} />
+            {": "}
+            <FormattedNumber
+              value={props.results[type]}
+              maximumFractionDigits={2}
+            />
+            {" BAT"}
+            <br />
+          </React.Fragment>
+        ))}
+      </ReactTooltip>
+    </React.Fragment>
+  );
 };
 
 class Statements extends React.Component<any, IStatementsState> {
@@ -138,7 +170,10 @@ class Statements extends React.Component<any, IStatementsState> {
                 <FormattedMessage id="statements.overview.paymentDate" />
               </TableHeader>
               <TableHeader className="text-right" style={{ minWidth: "150px" }}>
-                <FormattedMessage id="statements.overview.confirmedEarning" />
+                <FormattedMessage id="statements.overview.totalBraveSettled" />
+              </TableHeader>
+              <TableHeader className="text-right" style={{ minWidth: "150px" }}>
+                <FormattedMessage id="statements.overview.directUserTips" />
               </TableHeader>
               <TableHeader className="text-right" style={{ minWidth: "175px" }}>
                 <FormattedMessage id="statements.overview.amountDeposited" />
@@ -163,7 +198,17 @@ class Statements extends React.Component<any, IStatementsState> {
                   <td>{DisplayPaymentDate(statement.paymentDate)}</td>
                   <td className="text-right">
                     <FormattedNumber
-                      value={statement.batTotalDeposited}
+                      value={statement.totals.totalBraveSettled}
+                      maximumFractionDigits={2}
+                    />
+                    <small>
+                      {" "}
+                      <FormattedMessage id="bat" />
+                    </small>
+                  </td>
+                  <td className="text-right">
+                    <FormattedNumber
+                      value={statement.totals.upholdContributionSettlement}
                       maximumFractionDigits={2}
                     />
                     <small>
@@ -173,14 +218,23 @@ class Statements extends React.Component<any, IStatementsState> {
                   </td>
                   <td className="text-right">
                     {Object.keys(statement.deposited).map((name) => (
-                      <React.Fragment>
-                        <FormattedNumber
-                          value={statement.deposited[name]}
-                          maximumFractionDigits={2}
-                        />{" "}
-                        <small>{name}</small>
-                        <br />
-                      </React.Fragment>
+                      <DepositBreakdown
+                        name={name}
+                        key={name}
+                        results={GetParameterCaseInsensitive(
+                          statement.depositedTypes,
+                          name
+                        )}
+                      >
+                        <React.Fragment>
+                          <FormattedNumber
+                            value={statement.deposited[name]}
+                            maximumFractionDigits={2}
+                          />{" "}
+                          <small>{name}</small>
+                          <br />
+                        </React.Fragment>
+                      </DepositBreakdown>
                     ))}
                   </td>
                   <td>

--- a/app/javascript/views/statements/Statements.tsx
+++ b/app/javascript/views/statements/Statements.tsx
@@ -45,6 +45,7 @@ export interface IStatementOverview {
   batTotalDeposited: number;
   rawTransactions: any;
   showRateCards: boolean;
+  settlementDestination: string;
 }
 
 export const DisplayEarningPeriod = (earningPeriod: IEarningPeriod) => {

--- a/app/javascript/views/statements/statements/StatementDetails.tsx
+++ b/app/javascript/views/statements/statements/StatementDetails.tsx
@@ -6,11 +6,12 @@ import {
   injectIntl,
   useIntl,
 } from "react-intl";
-import ReactTooltip from "react-tooltip";
 
 import {
+  DepositBreakdown,
   DisplayEarningPeriod,
   DisplayPaymentDate,
+  GetParameterCaseInsensitive,
   IStatementOverview,
   IStatementTotal,
 } from "../Statements";
@@ -124,7 +125,7 @@ class StatementDetails extends React.Component<IStatementProps, any> {
                     </Amount>
                     <DepositBreakdown
                       name={name}
-                      results={getParameterCaseInsensitive(
+                      results={GetParameterCaseInsensitive(
                         this.props.statement.depositedTypes,
                         name
                       )}
@@ -229,29 +230,6 @@ class StatementDetails extends React.Component<IStatementProps, any> {
   }
 }
 
-function getParameterCaseInsensitive(object, key) {
-  return object[
-    Object.keys(object).find((k) => k.toLowerCase() === key.toLowerCase())
-  ];
-}
-
-const DepositBreakdown = (props) => (
-  <ReactTooltip id={props.name}>
-    {Object.keys(props.results).map((type) => (
-      <React.Fragment key={type}>
-        <FormattedMessage id={`statements.overview.types.${type}`} />
-        {": "}
-        <FormattedNumber
-          value={props.results[type]}
-          maximumFractionDigits={2}
-        />
-        {" BAT"}
-        <br />
-      </React.Fragment>
-    ))}
-  </ReactTooltip>
-);
-
 const TotalSubTable = (props) => (
   <React.Fragment>
     <tr>
@@ -280,7 +258,7 @@ const TotalSubTable = (props) => (
       </TotalCell>
       <TotalCell textRight>
         <Total>
-          -
+          { props.fees !== 0 && "-" }
           <FormattedNumber value={props.fees} maximumFractionDigits={2} />{" "}
           <FormattedMessage id="bat" />
         </Total>
@@ -314,7 +292,9 @@ const TotalSubTable = (props) => (
       </TotalCell>
       <TotalCell hasBorder textRight>
         <Total isDark>
-          <SettlementDestinationLink settlementDestination={props.settlementDestination}>
+          <SettlementDestinationLink
+            settlementDestination={props.settlementDestination}
+          >
             <FormattedNumber
               value={props.totalBraveSettled}
               maximumFractionDigits={2}
@@ -344,7 +324,6 @@ const TotalSubTable = (props) => (
     </tr>
   </React.Fragment>
 );
-
 
 export const SettlementDestinationLink = (props) => {
   const intl = useIntl();

--- a/app/javascript/views/statements/statements/StatementDetails.tsx
+++ b/app/javascript/views/statements/statements/StatementDetails.tsx
@@ -1,6 +1,11 @@
 import * as moment from "moment";
 import * as React from "react";
-import { FormattedMessage, FormattedNumber, injectIntl } from "react-intl";
+import {
+  FormattedMessage,
+  FormattedNumber,
+  injectIntl,
+  useIntl,
+} from "react-intl";
 import ReactTooltip from "react-tooltip";
 
 import {
@@ -148,7 +153,12 @@ class StatementDetails extends React.Component<IStatementProps, any> {
                 </tr>
 
                 {/* Subsection for totals */}
-                <TotalSubTable {...this.props.statement.totals} />
+                <TotalSubTable
+                  {...this.props.statement.totals}
+                  settlementDestination={
+                    this.props.statement.settlementDestination
+                  }
+                />
 
                 <tr>
                   <td colSpan={2}>
@@ -242,7 +252,7 @@ const DepositBreakdown = (props) => (
   </ReactTooltip>
 );
 
-const TotalSubTable = (props: IStatementTotal) => (
+const TotalSubTable = (props) => (
   <React.Fragment>
     <tr>
       <TotalCell />
@@ -304,11 +314,13 @@ const TotalSubTable = (props: IStatementTotal) => (
       </TotalCell>
       <TotalCell hasBorder textRight>
         <Total isDark>
-          <FormattedNumber
-            value={props.totalBraveSettled}
-            maximumFractionDigits={2}
-          />{" "}
-          <FormattedMessage id="bat" />
+          <SettlementDestinationLink settlementDestination={props.settlementDestination}>
+            <FormattedNumber
+              value={props.totalBraveSettled}
+              maximumFractionDigits={2}
+            />{" "}
+            <FormattedMessage id="bat" />
+          </SettlementDestinationLink>
         </Total>
       </TotalCell>
     </tr>
@@ -332,5 +344,24 @@ const TotalSubTable = (props: IStatementTotal) => (
     </tr>
   </React.Fragment>
 );
+
+
+export const SettlementDestinationLink = (props) => {
+  const intl = useIntl();
+  if (props.settlementDestination) {
+    return (
+      <a
+        href={intl.formatMessage(
+          { id: "statements.overview.upholdCardLink" },
+          { cardId: props.settlementDestination }
+        )}
+      >
+        {props.children}
+      </a>
+    );
+  }
+
+  return props.children;
+};
 
 export default injectIntl(StatementDetails);

--- a/app/javascript/views/statements/statements/StatementDetails.tsx
+++ b/app/javascript/views/statements/statements/StatementDetails.tsx
@@ -1,13 +1,9 @@
 import * as moment from "moment";
 import * as React from "react";
-import {
-  FormattedMessage,
-  FormattedNumber,
-  injectIntl,
-  useIntl,
-} from "react-intl";
+import { FormattedMessage, injectIntl, useIntl } from "react-intl";
 
 import {
+  CurrencyNumber,
   DepositBreakdown,
   DisplayEarningPeriod,
   DisplayPaymentDate,
@@ -123,9 +119,8 @@ class StatementDetails extends React.Component<IStatementProps, any> {
                       )}
                     >
                       <Amount>
-                        <FormattedNumber
+                        <CurrencyNumber
                           value={this.props.statement.deposited[name]}
-                          maximumFractionDigits={2}
                         />{" "}
                         <small>{name}</small>
                         <br />
@@ -138,22 +133,19 @@ class StatementDetails extends React.Component<IStatementProps, any> {
 
             <table className="table ml-4 border-bottom statement-table">
               <tbody>
-                {/* Total Earned Section */}
                 <tr>
                   <td colSpan={2}>
                     <strong>
-                      <FormattedMessage id="statements.overview.totalEarned" />
+                      <FormattedMessage id="statements.overview.totalDeposited" />
                     </strong>
                   </td>
                   <td className="text-right">
-                    <FormattedNumber
-                      value={this.props.statement.totalEarned}
-                      maximumFractionDigits={2}
+                    <CurrencyNumber
+                      value={this.props.statement.batTotalDeposited}
                     />{" "}
                     <FormattedMessage id="bat" />
                   </td>
                 </tr>
-
                 {/* Subsection for totals */}
                 <TotalSubTable
                   {...this.props.statement.totals}
@@ -162,20 +154,6 @@ class StatementDetails extends React.Component<IStatementProps, any> {
                   }
                 />
 
-                <tr>
-                  <td colSpan={2}>
-                    <strong>
-                      <FormattedMessage id="statements.overview.totalDeposited" />
-                    </strong>
-                  </td>
-                  <td className="text-right">
-                    <FormattedNumber
-                      value={this.props.statement.batTotalDeposited}
-                      maximumFractionDigits={2}
-                    />{" "}
-                    <FormattedMessage id="bat" />
-                  </td>
-                </tr>
                 <tr>
                   <td colSpan={2}>
                     <strong>
@@ -242,25 +220,7 @@ const TotalSubTable = (props) => (
       </TotalCell>
       <TotalCell textRight>
         <Total>
-          <FormattedNumber
-            value={props.contributionSettlement}
-            maximumFractionDigits={2}
-          />{" "}
-          <FormattedMessage id="bat" />
-        </Total>
-      </TotalCell>
-    </tr>
-    <tr>
-      <TotalCell />
-      <TotalCell>
-        <Total>
-          <FormattedMessage id="statements.overview.fees" />
-        </Total>
-      </TotalCell>
-      <TotalCell textRight>
-        <Total>
-          {props.fees !== 0 && "-"}
-          <FormattedNumber value={props.fees} maximumFractionDigits={2} />{" "}
+          <CurrencyNumber value={props.contributionSettlement} />{" "}
           <FormattedMessage id="bat" />
         </Total>
       </TotalCell>
@@ -275,10 +235,7 @@ const TotalSubTable = (props) => (
       </TotalCell>
       <TotalCell textRight>
         <Total>
-          <FormattedNumber
-            value={props.referralSettlement}
-            maximumFractionDigits={2}
-          />{" "}
+          <CurrencyNumber value={props.referralSettlement} />{" "}
           <FormattedMessage id="bat" />
         </Total>
       </TotalCell>
@@ -296,10 +253,7 @@ const TotalSubTable = (props) => (
           <SettlementDestinationLink
             settlementDestination={props.settlementDestination}
           >
-            <FormattedNumber
-              value={props.totalBraveSettled}
-              maximumFractionDigits={2}
-            />{" "}
+            <CurrencyNumber value={props.totalBraveSettled} />{" "}
             <FormattedMessage id="bat" />
           </SettlementDestinationLink>
         </Total>
@@ -315,10 +269,7 @@ const TotalSubTable = (props) => (
       </TotalCell>
       <TotalCell textRight>
         <Total isDark>
-          <FormattedNumber
-            value={props.upholdContributionSettlement}
-            maximumFractionDigits={2}
-          />{" "}
+          <CurrencyNumber value={props.upholdContributionSettlement} />{" "}
           <FormattedMessage id="bat" />
         </Total>
       </TotalCell>

--- a/app/javascript/views/statements/statements/StatementDetails.tsx
+++ b/app/javascript/views/statements/statements/StatementDetails.tsx
@@ -115,21 +115,22 @@ class StatementDetails extends React.Component<IStatementProps, any> {
               <div>
                 {Object.keys(this.props.statement.deposited).map((name) => (
                   <React.Fragment key={name}>
-                    <Amount data-tip data-for={name}>
-                      <FormattedNumber
-                        value={this.props.statement.deposited[name]}
-                        maximumFractionDigits={2}
-                      />{" "}
-                      <small>{name}</small>
-                      <br />
-                    </Amount>
                     <DepositBreakdown
                       name={name}
                       results={GetParameterCaseInsensitive(
                         this.props.statement.depositedTypes,
                         name
                       )}
-                    />
+                    >
+                      <Amount>
+                        <FormattedNumber
+                          value={this.props.statement.deposited[name]}
+                          maximumFractionDigits={2}
+                        />{" "}
+                        <small>{name}</small>
+                        <br />
+                      </Amount>
+                    </DepositBreakdown>
                   </React.Fragment>
                 ))}
               </div>
@@ -258,7 +259,7 @@ const TotalSubTable = (props) => (
       </TotalCell>
       <TotalCell textRight>
         <Total>
-          { props.fees !== 0 && "-" }
+          {props.fees !== 0 && "-"}
           <FormattedNumber value={props.fees} maximumFractionDigits={2} />{" "}
           <FormattedMessage id="bat" />
         </Total>

--- a/app/javascript/views/statements/statements/statementDetails/DetailSection.tsx
+++ b/app/javascript/views/statements/statements/statementDetails/DetailSection.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { FormattedMessage, FormattedNumber, injectIntl } from "react-intl";
 
 import { TableHeader } from "../../StatementsStyle";
+import { SettlementDestinationLink } from "../StatementDetails";
 import {
   Amount,
   ChannelHeader,
@@ -55,11 +56,15 @@ const DetailSection = (props) => (
               </HideOverflow>
             </TableCell>
             <TableCell className="text-right">
-              <FormattedNumber
-                value={transaction.amount}
-                maximumFractionDigits={2}
-              />{" "}
-              <FormattedMessage id="bat" />
+              <SettlementDestinationLink
+                settlementDestination={transaction.settlementDestination}
+              >
+                <FormattedNumber
+                  value={transaction.amount}
+                  maximumFractionDigits={2}
+                />{" "}
+                <FormattedMessage id="bat" />
+              </SettlementDestinationLink>
             </TableCell>
           </tr>
         ))}

--- a/app/javascript/views/statements/statements/statementDetails/DetailSection.tsx
+++ b/app/javascript/views/statements/statements/statementDetails/DetailSection.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import { FormattedMessage, FormattedNumber, injectIntl } from "react-intl";
+import { FormattedMessage, injectIntl } from "react-intl";
 
+import { CurrencyNumber } from "../../Statements";
 import { TableHeader } from "../../StatementsStyle";
 import { SettlementDestinationLink } from "../StatementDetails";
 import {
@@ -16,77 +17,80 @@ import {
   TotalCell,
 } from "../StatementDetailsStyle";
 
+const DetailSection = (props) => {
+  let settlementDestination;
+  const foundDestination = props.detail.transactions.find(
+    (x) => x.settlementDestination
+  );
+  if (foundDestination) {
+    settlementDestination = foundDestination.settlementDestination;
+  }
 
-const DetailSection = (props) => (
-  <div
-    style={{
-      background: props.index % 2 === 0 ? "#F3F3F6" : "",
-      borderRadius: "6px",
-    }}
-    className="px-5 py-4"
-  >
-    <div className="">
-      <ChannelHeader>{props.detail.title}</ChannelHeader>
-      <Description>{props.detail.description}</Description>
-    </div>
-    <Table className="table m-0">
-      <thead>
-        <tr>
-          <TableHeader>
-            <strong className="text-uppercase">
-              <FormattedMessage id="statements.overview.details.description" />
-            </strong>
-          </TableHeader>
-          <TableHeader className="text-right">
-            <strong className="text-uppercase">
-              <FormattedMessage id="statements.overview.details.amount" />
-            </strong>
-          </TableHeader>
-        </tr>
-      </thead>
-      <tbody>
-        {props.detail.transactions.map((transaction) => (
-          <tr key={`${transaction.amount} ${Math.random()}`}>
-            <TableCell>
-              <HideOverflow>
-                {transaction.transactionType === "fees" && (
-                  <FormattedMessage id="statements.overview.details.fee" />
-                )}{" "}
-                {transaction.channel}
-              </HideOverflow>
-            </TableCell>
-            <TableCell className="text-right">
-              <SettlementDestinationLink
-                settlementDestination={transaction.settlementDestination}
-              >
-                <FormattedNumber
-                  value={transaction.amount}
-                  maximumFractionDigits={2}
-                />{" "}
-                <FormattedMessage id="bat" />
-              </SettlementDestinationLink>
-            </TableCell>
+  return (
+    <div
+      style={{
+        background: props.index % 2 === 0 ? "#F3F3F6" : "",
+        borderRadius: "6px",
+      }}
+      className="px-5 py-4"
+    >
+      <div className="">
+        <ChannelHeader>{props.detail.title}</ChannelHeader>
+        <Description>{props.detail.description}</Description>
+      </div>
+      <Table className="table m-0">
+        <thead>
+          <tr>
+            <TableHeader>
+              <strong className="text-uppercase">
+                <FormattedMessage id="statements.overview.details.description" />
+              </strong>
+            </TableHeader>
+            <TableHeader className="text-right">
+              <strong className="text-uppercase">
+                <FormattedMessage id="statements.overview.details.amount" />
+              </strong>
+            </TableHeader>
           </tr>
-        ))}
-        <tr>
-          <td>
-            <strong>
-              <FormattedMessage id="statements.overview.details.total" />
-            </strong>
-          </td>
-          <td className="text-right">
-            <strong>
-              <FormattedNumber
-                value={props.detail.amount}
-                maximumFractionDigits={2}
-              />{" "}
-              <FormattedMessage id="bat" />
-            </strong>
-          </td>
-        </tr>
-      </tbody>
-    </Table>
-  </div>
-);
+        </thead>
+        <tbody>
+          {props.detail.transactions.map((transaction) => (
+            <tr key={`${transaction.amount} ${Math.random()}`}>
+              <TableCell>
+                <HideOverflow>
+                  {transaction.transactionType === "fees" && (
+                    <FormattedMessage id="statements.overview.details.fee" />
+                  )}{" "}
+                  {transaction.channel}
+                </HideOverflow>
+              </TableCell>
+              <TableCell className="text-right">
+                <CurrencyNumber value={transaction.amount} />{" "}
+                <FormattedMessage id="bat" />
+              </TableCell>
+            </tr>
+          ))}
+          <tr>
+            <td>
+              <strong>
+                <FormattedMessage id="statements.overview.details.total" />
+              </strong>
+            </td>
+            <td className="text-right">
+              <SettlementDestinationLink
+                settlementDestination={settlementDestination}
+              >
+                <strong>
+                  <CurrencyNumber value={props.detail.amount} />{" "}
+                  <FormattedMessage id="bat" />
+                </strong>
+              </SettlementDestinationLink>
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+    </div>
+  );
+};
 
 export default injectIntl(DetailSection);

--- a/app/jobs/cache_uphold_tips.rb
+++ b/app/jobs/cache_uphold_tips.rb
@@ -16,6 +16,9 @@ class CacheUpholdTips < ApplicationJob
     return if transactions.blank?
 
     transactions.each do |transaction|
+       # Filter out transactions that weren't made by Brave Browser
+      next unless transaction.anonymous_origin?
+
       cached_tip = CachedUpholdTip.find_or_initialize_by(uphold_transaction_id: transaction.id)
       cached_tip.update(
         uphold_connection_for_channel: upfc,

--- a/app/models/cached_uphold_tip.rb
+++ b/app/models/cached_uphold_tip.rb
@@ -12,6 +12,7 @@ class CachedUpholdTip < ApplicationRecord
       amount: amount&.to_d,
       settlement_currency: settlement_currency,
       settlement_amount: settlement_amount&.to_d,
+      settlement_destination: uphold_connection_for_channel.card_id,
       created_at: uphold_created_at,
     )
   end

--- a/app/models/views/user/statement_overview.rb
+++ b/app/models/views/user/statement_overview.rb
@@ -11,7 +11,7 @@ module Views
 
       attr_accessor :earning_period, :payment_date, :destination, :totals, :deposited, :deposited_types, :total_earned,
                     :currency, :details, :settled_transactions, :raw_transactions, :name, :email, :total_fees, :bat_total_deposited,
-                    :publisher_id
+                    :publisher_id, :settlement_destination
 
       def initialize(attributes = {})
         super

--- a/app/models/views/user/statement_overview.rb
+++ b/app/models/views/user/statement_overview.rb
@@ -106,7 +106,6 @@ module Views
               channels.each_with_index do |settlement, index|
                 # Since the transactions are sorted we should be able to use the same index as the contribution settlement
                 # For every contribution_settlement there will always be an associated fee transaction type
-                # binding.pry if channel_fees[index].blank?
                 settlement.amount += channel_fees[index].amount
               end
             end

--- a/app/models/views/user/statements.rb
+++ b/app/models/views/user/statements.rb
@@ -54,7 +54,7 @@ module Views
               # It is shown in a tooltip in the Statement
               overview.deposited_types[payout_entry.settlement_currency] ||= {}
               overview.deposited_types[payout_entry.settlement_currency][payout_entry.transaction_type] ||= 0
-              overview.deposited_types[payout_entry.settlement_currency][payout_entry.transaction_type] += payout_entry.amount.abs
+              overview.deposited_types[payout_entry.settlement_currency][payout_entry.transaction_type] += payout_entry.settlement_amount.abs
             end
 
             # Here we sum up (in BAT) all the different transaction types

--- a/app/models/views/user/statements.rb
+++ b/app/models/views/user/statements.rb
@@ -37,9 +37,11 @@ module Views
           )
 
           total_brave_settled = 0
+          settlement_destination = nil
 
           payout_entries.each do |payout_entry|
             total_brave_settled += payout_entry.amount.abs if payout_entry.eyeshade_settlement?
+            settlement_destination ||= payout_entry.settlement_destination
 
             # Not all payout entries have settlement currency / amount information so on the statement
             # we should only show the entries which have been settled with the currency information
@@ -62,6 +64,8 @@ module Views
 
             overview.total_earned += payout_entry.amount.abs
           end
+
+          overview.settlement_destination = settlement_destination
 
           overview.totals[:total_brave_settled] = total_brave_settled
           overview.bat_total_deposited = overview.total_earned - overview.totals[:fees]

--- a/app/models/views/user/statements.rb
+++ b/app/models/views/user/statements.rb
@@ -65,7 +65,7 @@ module Views
             overview.total_earned += payout_entry.amount.abs
           end
 
-          overview.settlement_destination = settlement_destination
+          overview.settlement_destination = settlement_destination # Assume that settlement_destination doesn't change
 
           overview.totals[:total_brave_settled] = total_brave_settled
           overview.bat_total_deposited = overview.total_earned - overview.totals[:fees]

--- a/app/services/publisher_statement_getter.rb
+++ b/app/services/publisher_statement_getter.rb
@@ -25,7 +25,7 @@ class PublisherStatementGetter < BaseApiClient
     def earning_period
       # If the transaction_type is from Eyeshade this means the period was for the previous month
       if eyeshade_settlement? || fee?
-        created_at.prev_month.at_beginning_of_month
+        created_at.prev_month.at_beginning_of_month.to_date
       else
         created_at.at_beginning_of_month.to_date
       end

--- a/app/services/uphold/models/transaction.rb
+++ b/app/services/uphold/models/transaction.rb
@@ -48,7 +48,7 @@ module Uphold
 
           break if ending_index > total_items
           # Break if all the previously_cached values have been found in our transaction array
-          break if previously_cached.all? { |e| transaction_ids.include?(e) }
+          break if previously_cached.present? && previously_cached.all? { |e| transaction_ids.include?(e) }
 
           page_index += 1
         end
@@ -66,6 +66,13 @@ module Uphold
         response = get(path.expand(id: id), {}, authorization(@uphold_connection))
 
         Uphold::Models::Transaction.new(parse_response(response))
+      end
+
+      # A transaction will have an anonymous origin if it came from another Uphold User
+      # And that uphold user sent the funds through their anonymous card address.
+      # This is functionality that realistically only the Browser uses to send tips.
+      def anonymous_origin?
+        origin.dig('node','type') == "anonymous"
       end
 
       def authorization(uphold_connection)

--- a/app/services/uphold/models/transaction.rb
+++ b/app/services/uphold/models/transaction.rb
@@ -72,7 +72,7 @@ module Uphold
       # And that uphold user sent the funds through their anonymous card address.
       # This is functionality that realistically only the Browser uses to send tips.
       def anonymous_origin?
-        origin.dig('node','type') == "anonymous"
+        origin.dig('node', 'type') == "anonymous"
       end
 
       def authorization(uphold_connection)

--- a/db/migrate/20200510205028_change_cached_uphold_tips_to_uuid.rb
+++ b/db/migrate/20200510205028_change_cached_uphold_tips_to_uuid.rb
@@ -1,0 +1,6 @@
+class ChangeCachedUpholdTipsToUuid < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :cached_uphold_tips, :uphold_connection_for_channel_id
+    add_column :cached_uphold_tips, :uphold_connection_for_channel_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_194824) do
+ActiveRecord::Schema.define(version: 2020_05_10_205028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,7 +38,6 @@ ActiveRecord::Schema.define(version: 2020_05_08_194824) do
   end
 
   create_table "cached_uphold_tips", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.bigint "uphold_connection_for_channel_id"
     t.uuid "uphold_transaction_id"
     t.string "amount"
     t.string "settlement_currency"
@@ -46,8 +45,7 @@ ActiveRecord::Schema.define(version: 2020_05_08_194824) do
     t.datetime "uphold_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["uphold_connection_for_channel_id", "uphold_created_at"], name: "cached_uphold_tips_created_at"
-    t.index ["uphold_connection_for_channel_id"], name: "index_cached_uphold_tips_on_uphold_connection_for_channel_id"
+    t.uuid "uphold_connection_for_channel_id"
     t.index ["uphold_transaction_id"], name: "index_cached_uphold_tips_on_uphold_transaction_id"
   end
 


### PR DESCRIPTION
## Fix Statement Bugs

#### Features

🐛 UpholdConnectionForChannel was `BigInt` rather than `UUID`
🐛 Fix issue where only the first page would be returned if there weren't any previously cached values
🐛 Fix grouping of Statements due to DateTime vs Date mismatch
🐛 Only return and display transactions that were made from the browser to the uphold card
✨ Provide a link to the Uphold card that the deposits were made on. 
✨ Fix overview page to show more specifically the total brave deposited and Uphold tips
