### PR TITLE
Eliminate rack-attack limits for public API. We protect against thund…

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -121,17 +121,6 @@ class Rack::Attack
     end
   end
 
-  if Rails.env.production?
-    # Throttle requests to public api, /api/public
-    throttle("public-api-request/ip", limit: 5, period: 1.hour) do |req|
-      req.ip if ["/api/v1/public", "api/v2/public", "api/v3/public"].any? { |endpoint| req.path.start_with?(endpoint) }
-    end
-  else
-    throttle("public-api-request/ip", limit: 60, period: 1.hour) do |req|
-      req.ip if ["/api/v1/public", "api/v2/public", "api/v3/public"].any? { |endpoint| req.path.start_with?(endpoint) }
-    end
-  end
-
   ### Custom Throttle Response ###
   self.throttled_response = lambda do |env|
     [


### PR DESCRIPTION
…ering herd by limiting the number of requests that can try to access publishers