### PR TITLE
Upgrade Twitch Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,8 +279,8 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
-    omniauth-twitch (1.0.0)
-      omniauth-oauth2 (~> 1.1)
+    omniauth-twitch (1.1.0)
+      omniauth-oauth2 (~> 1.6)
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack


### PR DESCRIPTION
## Upgrade Twitch Gem

Currently users aren't able to connect their Twitch accounts due to a "Client id" not being passed in via headers