### PR TITLE
Close the connection after setnx is called. 

### DIFF
--- a/app/controllers/concerns/browser_channels_dyno_caching.rb
+++ b/app/controllers/concerns/browser_channels_dyno_caching.rb
@@ -42,7 +42,9 @@ module BrowserChannelsDynoCaching
   end
 
   def set_lock_to_now
-    Redis.new.setnx(self.class::REDIS_THUNDERING_HERD_KEY, Time.now.to_i)
+    conn = Redis.new
+    conn.setnx(self.class::REDIS_THUNDERING_HERD_KEY, Time.now.to_i)
+    conn.quit
   end
 
   def dyno_cache_expired?


### PR DESCRIPTION
Related to https://github.com/redis/redis-rb/issues/524
