### PR TITLE
Fix perf issue when looking up contested_by_channel_id

### DIFF
--- a/db/migrate/20200527071037_add_index_contested_by_channel_id.rb
+++ b/db/migrate/20200527071037_add_index_contested_by_channel_id.rb
@@ -1,0 +1,5 @@
+class AddIndexContestedByChannelId < ActiveRecord::Migration[6.0]
+  def change
+    add_index :channels, :contested_by_channel_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_13_201529) do
+ActiveRecord::Schema.define(version: 2020_05_27_071037) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
@@ -111,6 +112,7 @@ ActiveRecord::Schema.define(version: 2020_05_13_201529) do
     t.uuid "contested_by_channel_id"
     t.string "contest_token"
     t.datetime "contest_timesout_at"
+    t.index ["contested_by_channel_id"], name: "index_channels_on_contested_by_channel_id"
     t.index ["details_type", "details_id"], name: "index_channels_on_details_type_and_details_id", unique: true
     t.index ["publisher_id"], name: "index_channels_on_publisher_id"
   end


### PR DESCRIPTION
Details in https://rpm.newrelic.com/accounts/2604309/applications/592980707_h592981222/datastores#/overview/All/drilldown?metric=Datastore%252Fstatement%252FPostgres%252FChannel%252Ffind