### PR TITLE
Change http to https on meta og:url tag

### DIFF
--- a/public/creators-landing/public/index.html
+++ b/public/creators-landing/public/index.html
@@ -21,7 +21,7 @@
     />
     <meta property="og:image" content="%PUBLIC_URL%/preview.png" />
     <meta property="og:type" content="website" />
-    <meta property="og:secure_url" content="https://creators.brave.com" />
+    <meta property="og:url" content="http://creators.brave.com" />
   </head>
 
   <body>

--- a/public/creators-landing/public/index.html
+++ b/public/creators-landing/public/index.html
@@ -21,7 +21,7 @@
     />
     <meta property="og:image" content="%PUBLIC_URL%/preview.png" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://creators.brave.com" />
+    <meta property="og:secure_url" content="https://creators.brave.com" />
   </head>
 
   <body>

--- a/public/creators-landing/public/index.html
+++ b/public/creators-landing/public/index.html
@@ -21,7 +21,7 @@
     />
     <meta property="og:image" content="%PUBLIC_URL%/preview.png" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="http://creators.brave.com" />
+    <meta property="og:url" content="https://creators.brave.com" />
   </head>
 
   <body>


### PR DESCRIPTION
Our SEO consultant flagged the `og:url` meta tag on creators.brave.com as being an SEO concern due to using `http` instead of `https`.