### PR TITLE
Fix .rubocop.yml Warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,9 @@
 inherit_from:
   - .rubocop_airbnb.yml
 
-AlignParameters:
+Layout/AlignParameters:
   Enabled: false
-Documentation:
+Style/Documentation:
   Enabled: false
 AllCops:
   Include:
@@ -33,7 +33,7 @@ AllCops:
     - bin/**/*
     - db/**/*
     - vendor/**/*
-LineLength:
+Metrics/LineLength:
   Max: 400
 Airbnb/SimpleModifierConditional:
   Enabled: false


### PR DESCRIPTION
## Fix .rubocop.yml Warnings

#### Features

When running rubocop we were seeing seeing the following errors

```
~/r/publishers ❯❯❯ bundle exec rubocop
/Users/cory/repos/publishers/.rubocop.yml: Warning: no department given for AlignParameters.
/Users/cory/repos/publishers/.rubocop.yml: Warning: no department given for Documentation.
/Users/cory/repos/publishers/.rubocop.yml: Warning: no department given for LineLength.
```

After this change we get the following result.

```
~/r/publishers ❯❯❯ bundle exec rubocop      
Inspecting 93 files
.............................................................................................

93 files inspected, no offenses detected
``