### PR TITLE
Lock down gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "activejob-traffic_control"
 gem "active_model_serializers", "~> 0.10.0"
 
 # ActiveRecord Session store for server side storage of session data
-gem 'activerecord-session_store'
+gem 'activerecord-session_store', '~> 1.1', '>= 1.1.3'
 
 # Allowing for URI templates, for HTTP clients
 gem 'addressable', '~> 2.6'
@@ -27,20 +27,15 @@ gem 'aws-sdk-s3', require: false
 
 gem "bootstrap", ">= 4.3.1"
 
-# browser details
-gem 'browser'
-
 gem 'brotli', "~> 0.2.3"
 
 # Authorization
-gem 'cancancan'
+gem 'cancancan',  "~> 3.1.0"
 
 # Authentication
 gem "devise", "~> 4.7.1"
 
 gem "dnsruby", "~> 1.60.0", require: false
-
-gem 'e2mmap'
 
 # HTTP library wrapper
 gem "faraday", "~> 0.17.3"
@@ -53,13 +48,13 @@ gem 'google-protobuf', "~> 3.12.0"
 gem "lograge", "~> 0.4"
 
 # Dependency for rails
-gem "nokogiri"
+gem "nokogiri", "~> 1.10.9"
 
 # Open Graph tag
-gem "meta-tags"
+gem "meta-tags", "~> 2.13.0"
 
 # Image conversion library
-gem 'mini_magick'
+gem 'mini_magick', "~> 4.10.1"
 
 gem "newrelic_rpm", "~> 6.7.0.359"
 
@@ -68,19 +63,19 @@ gem 'omniauth-rails_csrf_protection', '~> 0.1.2'
 gem "omniauth-google-oauth2", "~> 0.8.0"
 
 # Oauth client for twitch
-gem "omniauth-twitch"
+gem "omniauth-twitch", "~> 1.1.0"
 
 # Oauth client for twitter
-gem "omniauth-twitter"
+gem "omniauth-twitter", "~> 1.4.0"
 
 # OAuth client for Vimeo
-gem "omniauth-vimeo"
+gem "omniauth-vimeo", "~> 2.0.1"
 
 # OAuth client for Reddit
 gem 'omniauth-reddit', :git => 'https://github.com/dlipeles/omniauth-reddit.git', :branch => "master"
 
 # OAuth client for GitHub
-gem "omniauth-github"
+gem "omniauth-github", "~> 1.4.0"
 
 # Model record auditing
 gem "paper_trail", "~> 10.3.1"
@@ -118,20 +113,18 @@ gem "rqrcode", "~> 0.10"
 gem "sass-rails", "~> 5.0"
 
 # Sendgrid mail service
-gem "sendgrid-ruby"
+gem "sendgrid-ruby", "~> 6.2.1"
 
 # Exception logging
 gem "sentry-raven", "~> 2.11.2", require: false
 
 # Async job processing
-gem "sidekiq"
+gem "sidekiq", "~> 6.0.7"
 
-gem "sidekiq-scheduler", "~> 2.2.2"
+gem "sidekiq-scheduler", "~> 3.0.1"
 
 # slim for view templates
 gem "slim-rails", "~> 3.1"
-
-gem 'thwait'
 
 # U2F for 2-factor auth
 gem "u2f", "~> 1.0"
@@ -145,10 +138,10 @@ gem 'webpacker', '~> 4.0.7'
 gem "will_paginate"
 
 # YouTube API client
-gem 'yt'
+gem 'yt', "~> 0.33.0"
 
 gem "zeitwerk", '~> 2.3.0'
-gem "zendesk_api"
+gem "zendesk_api", "~> 1.26.0"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,6 @@ GEM
       sassc-rails (>= 2.0.0)
     brakeman (4.8.2)
     brotli (0.2.3)
-    browser (4.1.0)
     builder (3.2.4)
     bullet (6.1.0)
       activesupport (>= 3.0.0)
@@ -185,9 +184,9 @@ GEM
     ffi (1.12.2)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
-    fugit (1.3.5)
+    fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.1)
+      raabro (~> 1.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-protobuf (3.12.0)
@@ -438,10 +437,12 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
-    sidekiq-scheduler (2.2.2)
+    sidekiq-scheduler (3.0.1)
+      e2mmap
       redis (>= 3, < 5)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
+      thwait
       tilt (>= 1.4.0)
     simplecov (0.18.5)
       docile (~> 1.1)
@@ -522,7 +523,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   activejob-traffic_control
-  activerecord-session_store
+  activerecord-session_store (~> 1.1, >= 1.1.3)
   addressable (~> 2.6)
   attr_encrypted (~> 3.1.0)
   autometal-piwik!
@@ -532,37 +533,35 @@ DEPENDENCIES
   bootstrap (>= 4.3.1)
   brakeman
   brotli (~> 0.2.3)
-  browser
   bullet
   bundler-audit
   byebug
-  cancancan
+  cancancan (~> 3.1.0)
   capybara
   chromedriver-helper
   database_cleaner
   devise (~> 4.7.1)
   dnsruby (~> 1.60.0)
-  e2mmap
   faraday (~> 0.17.3)
   font-awesome-rails (~> 4.7.0.4)
   google-protobuf (~> 3.12.0)
   i18n-tasks (~> 0.9.12)
   listen (~> 3.2)
   lograge (~> 0.4)
-  meta-tags
-  mini_magick
+  meta-tags (~> 2.13.0)
+  mini_magick (~> 4.10.1)
   minitest
   minitest-rails
   mocha
   newrelic_rpm (~> 6.7.0.359)
-  nokogiri
-  omniauth-github
+  nokogiri (~> 1.10.9)
+  omniauth-github (~> 1.4.0)
   omniauth-google-oauth2 (~> 0.8.0)
   omniauth-rails_csrf_protection (~> 0.1.2)
   omniauth-reddit!
-  omniauth-twitch
-  omniauth-twitter
-  omniauth-vimeo
+  omniauth-twitch (~> 1.1.0)
+  omniauth-twitter (~> 1.4.0)
+  omniauth-vimeo (~> 2.0.1)
   paper_trail (~> 10.3.1)
   pg (~> 0.18)
   premailer-rails (~> 1.10.3)
@@ -583,14 +582,13 @@ DEPENDENCIES
   rubocop-airbnb
   sass-rails (~> 5.0)
   selenium-webdriver (~> 3.142.0)
-  sendgrid-ruby
+  sendgrid-ruby (~> 6.2.1)
   sentry-raven (~> 2.11.2)
-  sidekiq
-  sidekiq-scheduler (~> 2.2.2)
+  sidekiq (~> 6.0.7)
+  sidekiq-scheduler (~> 3.0.1)
   simplecov
   slim-rails (~> 3.1)
   temping
-  thwait
   tzinfo-data
   u2f (~> 1.0)
   vcr
@@ -598,9 +596,9 @@ DEPENDENCIES
   webmock (~> 3.0)
   webpacker (~> 4.0.7)
   will_paginate
-  yt
+  yt (~> 0.33.0)
   zeitwerk (~> 2.3.0)
-  zendesk_api
+  zendesk_api (~> 1.26.0)
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/app/models/login_activity.rb
+++ b/app/models/login_activity.rb
@@ -2,8 +2,4 @@ class LoginActivity < ApplicationRecord
   belongs_to :publisher
 
   default_scope { order(created_at: :asc) }
-
-  def browser
-    Browser.new(user_agent, accept_language: accept_language)
-  end
 end

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -608,7 +608,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert login
     assert_equal login.user_agent, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36"
     assert_equal login.accept_language, "en-US,en;q=0.9"
-    assert login.browser.chrome?
   end
 
   test "#confirm_default_currency redirects publisher w/o cards:write to uphold if confirmed a not available currency" do


### PR DESCRIPTION
## Lock down Gem versions

#### Features

Locks down the Gemfile with specific versions so that if `bundle update` is run we do not update dependencies with major version changes or breaking changes

#### How To Test

1. Running the Procfile works correctly
2. `bundle exec rails test` completes successfully
3. Build passes 