### PR TITLE
Fix dev dependency being required

### DIFF
--- a/lib/tasks/expire_promo_codes.rake
+++ b/lib/tasks/expire_promo_codes.rake
@@ -1,5 +1,3 @@
-require 'pry'
-
 task :expire_promo_codes => :environment do
   puts "Expiring promo codes for the following countries"
 


### PR DESCRIPTION
## Fix dev dependency being required

`pry` is a dependency used for setting breakpoints. The gem is only required in development and test mode. https://github.com/brave-intl/publishers/blob/staging/Gemfile#L177

As part of the application loading this rake task it fails to find the gem causing the deployment to fail.
