### PR TITLE
Fastly trusted_proxies list

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,7 @@ module Publishers
 #    config.i18n.load_path += Dir["#{Rails.root.to_s}/config/locales/**/*.{rb,yml}"]
 #    config.i18n.default_locale = :en
 
+    config.services = config_for(:services)
 
     # Let's ensure that our generators make a UUID as default
     config.generators do |generator|

--- a/config/initializers/fastly.rb
+++ b/config/initializers/fastly.rb
@@ -1,0 +1,14 @@
+FASTLY_API = "https://api.fastly.com/public-ip-list".freeze
+proxy_list = []
+
+begin
+  puts "⬇️  Pulling trusted_proxy list from Fastly"
+  response = Faraday.get(FASTLY_API)
+  list = JSON.parse(response.body)
+  proxy_list = list.dig("addresses")
+rescue StandardError => e
+  puts "Failed to load trusted_proxies from Fastly. Error: #{e.message}"
+end
+
+Rails.application.config.action_dispatch.trusted_proxies = proxy_list.map { |proxy| IPAddr.new(proxy) }
+puts "✅ Set trusted_proxies list"

--- a/config/initializers/fastly.rb
+++ b/config/initializers/fastly.rb
@@ -1,8 +1,8 @@
-FASTLY_API = "https://api.fastly.com/public-ip-list".freeze
+FASTLY_API = Rails.application.config.services.fastly
 proxy_list = []
 
 begin
-  puts "⬇️  Pulling trusted_proxy list from Fastly"
+  puts "⬇️  Pulling trusted_proxies list from Fastly"
   response = Faraday.get(FASTLY_API)
   list = JSON.parse(response.body)
   proxy_list = list.dig("addresses")

--- a/config/services.yml
+++ b/config/services.yml
@@ -1,0 +1,8 @@
+default: &default
+  fastly: <%= ENV["FASTLY_API"] || "https://api.fastly.com/public-ip-list" %>
+
+development:
+  <<: *default
+
+production:
+  <<: *default


### PR DESCRIPTION
## Fastly trusted_proxies list

#### Features

Support Fastly being fronted by publishers by adding the list of proxy IPs to Rails trusted proxies list 

#### How To Test

1. Deploy to staging
2. Ensure you can access the rails admin console using the brave VPN
