### PR TITLE
Handle cases where there isn't an uphold_connection for a channel

### DIFF
--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -25,7 +25,7 @@ class Cache::BrowserChannels::ResponsesForPrefix
         if site_banner_lookup.publisher.uphold_connection.present?
           wallet = PublishersPb::Wallet.new
           uphold_wallet = PublishersPb::UpholdWallet.new
-          uphold_wallet.address = site_banner_lookup.channel.uphold_connection.address
+          uphold_wallet.address = site_banner_lookup.channel.uphold_connection&.address || ""
           uphold_wallet.wallet_state = get_uphold_wallet_state(uphold_connection: site_banner_lookup.publisher.uphold_connection)
           wallet.uphold_wallet = uphold_wallet
           channel_response.wallets.push(wallet)


### PR DESCRIPTION
Seems odd, but this is what we do in V3: https://github.com/brave-intl/publishers/blob/staging/app/models/json_builders/channels_json_builder_v3.rb#L73