### PR TITLE
add wallet provider to generated payout report json

### DIFF
--- a/app/models/json_builders/manual_payout_report_json_builder.rb
+++ b/app/models/json_builders/manual_payout_report_json_builder.rb
@@ -22,6 +22,7 @@ class JsonBuilders::ManualPayoutReportJsonBuilder
           address: potential_payment.address,
           upholdId: potential_payment.uphold_id,
           documentId: potential_payment.invoice_id,
+          walletProvider: potential_payment.wallet_provider,
         }
       )
     end

--- a/app/models/json_builders/payout_report_json_builder.rb
+++ b/app/models/json_builders/payout_report_json_builder.rb
@@ -18,6 +18,7 @@ class JsonBuilders::PayoutReportJsonBuilder
           "type" => PotentialPayment::REFERRAL,
           "address" => "#{potential_payment.address}",
           "upholdId" => "#{potential_payment.uphold_id}",
+          "walletProvider" => "#{potential_payment.wallet_provider}",
         })
       else
         channel = Channel.find_by(id: potential_payment.channel_id)
@@ -35,6 +36,7 @@ class JsonBuilders::PayoutReportJsonBuilder
             "URL" => "#{Channel.find(potential_payment.channel_id).details.url}",
             "address" => "#{potential_payment.address}",
             "upholdId" => "#{potential_payment.uphold_id}",
+            "walletProvider" => "#{potential_payment.wallet_provider}",
           })
         end
       end


### PR DESCRIPTION
## Add wallet provider to payout report json

#### Features

This adds the wallet provider as a field to our JSON formatted payout reports.

#### How To Test

1. Generate a payout report
2. Download it and ensure `walletProvider` is a field in the payout entries

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
