### PR TITLE
Fix ClientError

### DIFF
--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -188,6 +188,10 @@ class UpholdConnection < ActiveRecord::Base
     card&.currency.eql?(default_currency)
   rescue Faraday::ResourceNotFound
     false
+  rescue Faraday::ClientError
+    # We'll get an HTTP Status 403 when the User doesn't have access to create cards
+    # or the access_token has expired.
+    false
   end
 
   # Makes an HTTP Request to Uphold and sychronizes


### PR DESCRIPTION
## Fix ClientError

Closes  #2793

#### Features

:bug: Fixes error when `valid_card?` returns Faraday::ClientError

#### How To Test

1. Sign into Uphold
1. Sign into Publishers 
1. Connect your uphold account. **DON'T SET DEFAULT CURRENCY**
1. Change you password on Uphold
1. On your Publishers account set default Currency
1. Page reloads and works as intended. 
