### PR TITLE
Reload uphold connection

### DIFF
--- a/app/services/payout/potential_payment/uphold_service.rb
+++ b/app/services/payout/potential_payment/uphold_service.rb
@@ -23,6 +23,8 @@ class Payout::PotentialPayment::UpholdService < BaseService
     uphold_connection.sync_from_uphold!
     if uphold_connection.missing_card?
       uphold_connection.create_uphold_cards
+      # Reload the connection because create_uphold_cards modifies the database records.
+      uphold_connection.reload
     end
 
     probi = wallet.referral_balance.amount_probi # probi = balance


### PR DESCRIPTION
## Reload uphold connection

### Features

🐛 Fixes bug where card address wasn't being reloaded once it was modified.

#### How To Test

✨ Unit tests pass
