### PR TITLE
Show error screen when user isn't logged in

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,6 +3,10 @@ class AdminController < ApplicationController
   helper_method :sort_column, :sort_direction
   include PublishersHelper
 
+  rescue_from CanCan::AccessDenied do |e|
+    render "admin/errors/not_authorized", layout: false
+  end
+
   # Override this value to specify the number of elements to display at a time
   # on index pages. Defaults to 20.
   def records_per_page

--- a/app/views/admin/errors/not_authorized.html.slim
+++ b/app/views/admin/errors/not_authorized.html.slim
@@ -13,8 +13,8 @@ html lang="en"
     content.page
       .container
         .box
-          =render("./admin/errors/construction.svg")
+          img src="https://brave.com/wp-content/uploads/2018/12/sadcloud-1.png"
         .box
-          h1 Check your IP Address
+          h1 Not authorized
         .box
-          h2 You might have forgotten to connect to a VPN or a secure connection.
+          h2 Maybe your session expired? Try <a href="/log-in" target="_blank">logging in</a> and refreshing this page.

--- a/app/views/admin/errors/not_authorized.html.slim
+++ b/app/views/admin/errors/not_authorized.html.slim
@@ -5,7 +5,7 @@ html lang="en"
     meta content="width=device-width, initial-scale=1.0" name="viewport" /
     meta content="ie=edge" http-equiv="X-UA-Compatible" /
     = stylesheet_link_tag "admin/main"
-    title Check your IP Address
+    title Not authorized
   body
     header.header
       .logo

--- a/test/controllers/admin/channels_controller_test.rb
+++ b/test/controllers/admin/channels_controller_test.rb
@@ -8,9 +8,8 @@ class Admin::ChannelsControllerTest < ActionDispatch::IntegrationTest
     publisher = publishers(:completed)
     sign_in publisher
 
-    assert_raises(CanCan::AccessDenied) do
-      get admin_publishers_path
-    end
+    get admin_publishers_path
+    assert_select 'title', "Not authorized"
   end
 
   test "filters correctly" do

--- a/test/controllers/admin/faq_categories_controller_test.rb
+++ b/test/controllers/admin/faq_categories_controller_test.rb
@@ -4,15 +4,6 @@ require "webmock/minitest"
 class Admin::FaqCategoriesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test "regular users cannot access" do
-    publisher = publishers(:completed)
-    sign_in publisher
-
-    assert_raises(CanCan::AccessDenied) {
-      get admin_faq_categories_path
-    }
-  end
-
   test "admin can access" do
     admin = publishers(:admin)
     sign_in admin

--- a/test/controllers/admin/payout_reports_controller_test.rb
+++ b/test/controllers/admin/payout_reports_controller_test.rb
@@ -38,15 +38,6 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "#create raises error for non-admin" do
-    publisher = publishers(:default)
-    sign_in publisher
-
-    assert_raises do
-      post admin_payout_reports_path
-    end
-  end
-
   test "#create doesn't send email or set final if no params are present in POST" do
     admin = publishers(:admin)
     sign_in admin

--- a/test/controllers/admin/publishers_controller_test.rb
+++ b/test/controllers/admin/publishers_controller_test.rb
@@ -30,9 +30,8 @@ class Admin::PublishersControllerTest < ActionDispatch::IntegrationTest
     publisher = publishers(:completed)
     sign_in publisher
 
-    assert_raises(CanCan::AccessDenied) {
-      get admin_publishers_path
-    }
+    get admin_publishers_path
+    assert_select 'title', "Not authorized"
   end
 
   test "admin can access" do


### PR DESCRIPTION
## Show error screen when user isn't logged in

<img width="835" alt="Screen Shot 2020-07-10 at 1 52 56 PM" src="https://user-images.githubusercontent.com/5459225/87188709-eb8cda80-c2b4-11ea-853a-a7f577fe6212.png">

#### Features

🐛 Don't show a 500 when a user who isn't signed in tries to access the admin workflow

#### How To Test

1. Don't sign in
`http://localhost:3000/admin/publishers`
2. See the following 
