### PR TITLE
Hide Referral Links on Channels

### DIFF
--- a/app/views/publishers/_channel.html.slim
+++ b/app/views/publishers/_channel.html.slim
@@ -25,7 +25,7 @@
               small= t(".channel_balance_period")
 
           / Show the promo registration if the promo is running
-          - if current_publisher.promo_status(promo_running?) == :active && channel.promo_enabled? && !current_publisher.only_user_funds?
+          - if current_publisher.promo_status(promo_running?) == :active && channel.promo_enabled? && !current_publisher.only_user_funds? && current_publisher.may_register_promo?
             .d-flex.channel--promo-info-container.ml-3
               .d-none.d-sm-block
                 = link_to("", tweet_url(channel.promo_registration.referral_code), target: :_blank, class: "promo-share-button promo-share-button-twitter")


### PR DESCRIPTION
## Hide referral links on Channels

#### Features

Looking at when a user has not completed their KYC but previously had referral codes enabled they are still able to see a referral code

#### How To Test

1. Register for a channel 
1. Sign up for the promo program
1. Connect your Uphold account
1. Disconnect your Uphold account
1. See that there is no referral link shown for your attached channel