### PR TITLE
Remove Eyeshade Call when uploading Invoices

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -54,8 +54,6 @@ class Admin::PayoutReportsController < AdminController
     content = File.read(params[:file].tempfile)
     json = JSON.parse(content)
 
-    EyeshadeClient.publishers.create_settlement(body: json)
-
     not_found = []
 
     json.each do |entry|


### PR DESCRIPTION
## Remove Eyeshade call when uploading settlements

#### Features

This removes the call to Eyeshade when marking Invoices as paid or not.

#### How To Test

1. Create an invoice
1. Upload a settlement report with the invoice information
1. Go and load the Publishers page
1. See that the invoice was marked paid
