### PR TITLE
Upgrade Sidekiq to 6.1.0, prevent logs from being polluted Redis#exists(key)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ gem "sendgrid-ruby", "~> 6.2.1"
 gem "sentry-raven", "~> 2.11.2", require: false
 
 # Async job processing
-gem "sidekiq", "~> 6.0.7"
+gem "sidekiq", "~> 6.1.0"
 
 gem "sidekiq-scheduler", "~> 3.0.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,8 +314,6 @@ GEM
     rack (2.2.3)
     rack-attack (5.4.2)
       rack (>= 1.0, < 3)
-    rack-protection (2.0.8.1)
-      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -426,11 +424,10 @@ GEM
       ruby_http_client (~> 3.4)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
-    sidekiq (6.0.7)
+    sidekiq (6.1.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     sidekiq-scheduler (3.0.1)
       e2mmap
       redis (>= 3, < 5)
@@ -573,7 +570,7 @@ DEPENDENCIES
   selenium-webdriver (~> 3.142.0)
   sendgrid-ruby (~> 6.2.1)
   sentry-raven (~> 2.11.2)
-  sidekiq (~> 6.0.7)
+  sidekiq (~> 6.1.0)
   sidekiq-scheduler (~> 3.0.1)
   simplecov
   slim-rails (~> 3.1)


### PR DESCRIPTION
## Upgrade Sidekiq to 6.1.0, prevent logs from being polluted Redis#exists(key)

#### Features

Updates to Sidekiq 6.1.0