### PR TITLE
Add API to suspend publishers by referral_code

### DIFF
--- a/app/controllers/api/v1/promo_registrations_controller.rb
+++ b/app/controllers/api/v1/promo_registrations_controller.rb
@@ -1,0 +1,54 @@
+class Api::V1::PromoRegistrationsController < Api::BaseController
+  class InvalidNote < StandardError; end
+  class InvalidAdmin < StandardError; end
+
+  def publisher_status_updates
+    referral_code = params[:referral_code]
+    publisher = Publisher.joins(:promo_registrations).where(promo_registrations: {referral_code: referral_code}).first
+    raise ActiveRecord::RecordNotFound if publisher.nil?
+
+    admin = Publisher.find_by_email(params[:admin])
+    status = params[:status]
+    note = params[:note]
+
+    raise InvalidNote if note.blank?
+    raise InvalidAdmin if admin.blank?
+
+    status_update = PublisherStatusUpdate.create!(publisher: publisher, status: status)
+    PublisherNote.create!(note: note, publisher: publisher, created_by: admin)
+
+    render(status: 200, json: { publisher_status_updates_id: status_update.id }) and return
+
+  rescue ActiveRecord::RecordInvalid
+    error_response = {
+      error: "Status Invalid",
+      detail: "Status #{params[:status]} is not valid, please use one of the following: #{PublisherStatusUpdate::ALL_STATUSES.join(", ")}",
+    }
+
+    render(status: 404, json: error_response) and return
+
+  rescue InvalidNote
+    error_response = {
+      error: "Note Invalid",
+      detail: "Note cannot be null, please provide justification for status update",
+    }
+
+    render(status: 404, json: error_response) and return
+
+  rescue InvalidAdmin
+    error_response = {
+      error: "Admin Invalid",
+      detail: "Admin field cannot be null, please provide e-mail of an admin",
+    }
+
+    render(status: 404, json: error_response) and return
+
+  rescue ActiveRecord::RecordNotFound
+    error_response = {
+      error: "Not Found",
+      detail: "Publisher with id #{params[:publisher_id]} not found",
+    }
+
+    render(status: 404, json: error_response) and return
+  end
+end

--- a/app/controllers/api/v1/promo_registrations_controller.rb
+++ b/app/controllers/api/v1/promo_registrations_controller.rb
@@ -1,9 +1,11 @@
 class Api::V1::PromoRegistrationsController < Api::BaseController
   class InvalidNote < StandardError; end
   class InvalidAdmin < StandardError; end
+  class InvalidEmail < StandardError; end
 
   def publisher_status_updates
     referral_code = params[:referral_code]
+    email = params[:email]
     publisher = Publisher.joins(:promo_registrations).where(promo_registrations: {referral_code: referral_code}).first
     raise ActiveRecord::RecordNotFound if publisher.nil?
 
@@ -13,6 +15,14 @@ class Api::V1::PromoRegistrationsController < Api::BaseController
 
     raise InvalidNote if note.blank?
     raise InvalidAdmin if admin.blank?
+
+    if email == "brand_bidding"
+      PublisherMailer.suspend_publisher_for_brand_bidding(@publisher).deliver_later
+    elsif email == "brand_bidding_and_impersonation"
+      PublisherMailer.suspend_publisher_for_brand_bidding_and_impersonation(@publisher).deliver_later
+    elsif not email.nil?
+      raise InvalidEmail
+    end
 
     status_update = PublisherStatusUpdate.create!(publisher: publisher, status: status)
     PublisherNote.create!(note: note, publisher: publisher, created_by: admin)
@@ -39,6 +49,14 @@ class Api::V1::PromoRegistrationsController < Api::BaseController
     error_response = {
       error: "Admin Invalid",
       detail: "Admin field cannot be null, please provide e-mail of an admin",
+    }
+
+    render(status: 404, json: error_response)
+
+  rescue InvalidEmail
+    error_response = {
+      error: "Email Invalid",
+      detail: "Cannot send invalid email #{email}.",
     }
 
     render(status: 404, json: error_response)

--- a/app/controllers/api/v1/promo_registrations_controller.rb
+++ b/app/controllers/api/v1/promo_registrations_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::PromoRegistrationsController < Api::BaseController
     status_update = PublisherStatusUpdate.create!(publisher: publisher, status: status)
     PublisherNote.create!(note: note, publisher: publisher, created_by: admin)
 
-    render(status: 200, json: { publisher_status_updates_id: status_update.id }) and return
+    render(status: 200, json: { publisher_status_updates_id: status_update.id })
 
   rescue ActiveRecord::RecordInvalid
     error_response = {
@@ -25,7 +25,7 @@ class Api::V1::PromoRegistrationsController < Api::BaseController
       detail: "Status #{params[:status]} is not valid, please use one of the following: #{PublisherStatusUpdate::ALL_STATUSES.join(", ")}",
     }
 
-    render(status: 404, json: error_response) and return
+    render(status: 404, json: error_response)
 
   rescue InvalidNote
     error_response = {
@@ -33,7 +33,7 @@ class Api::V1::PromoRegistrationsController < Api::BaseController
       detail: "Note cannot be null, please provide justification for status update",
     }
 
-    render(status: 404, json: error_response) and return
+    render(status: 404, json: error_response)
 
   rescue InvalidAdmin
     error_response = {
@@ -41,7 +41,7 @@ class Api::V1::PromoRegistrationsController < Api::BaseController
       detail: "Admin field cannot be null, please provide e-mail of an admin",
     }
 
-    render(status: 404, json: error_response) and return
+    render(status: 404, json: error_response)
 
   rescue ActiveRecord::RecordNotFound
     error_response = {
@@ -49,6 +49,6 @@ class Api::V1::PromoRegistrationsController < Api::BaseController
       detail: "Publisher with id #{params[:publisher_id]} not found",
     }
 
-    render(status: 404, json: error_response) and return
+    render(status: 404, json: error_response)
   end
 end

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -144,6 +144,22 @@ class PublisherMailer < ApplicationMailer
     )
   end
 
+  def suspend_publisher_for_brand_bidding(publisher)
+    @publisher = publisher
+    mail(
+      to: @publisher.email,
+      subject: default_i18n_subject
+    )
+  end
+
+  def suspend_publisher_for_brand_bidding_and_impersonation(publisher)
+    @publisher = publisher
+    mail(
+      to: @publisher.email,
+      subject: default_i18n_subject
+    )
+  end
+
   def two_factor_authentication_removal_cancellation(publisher)
     @publisher = publisher
     @publisher_private_two_factor_cancellation_url = publisher_private_two_factor_cancellation_url(publisher: @publisher)

--- a/app/views/publisher_mailer/suspend_publisher_for_brand_bidding.slim
+++ b/app/views/publisher_mailer/suspend_publisher_for_brand_bidding.slim
@@ -1,0 +1,5 @@
+p.salutation= t "publisher_mailer.shared.salutation", name: @publisher.name || name_from_email(@publisher.email)
+
+p= t "publisher_mailer.suspend_publisher_for_brand_bidding.body_html"
+
+.notice= t "shared.support_note_html"

--- a/app/views/publisher_mailer/suspend_publisher_for_brand_bidding_and_impersonation.slim
+++ b/app/views/publisher_mailer/suspend_publisher_for_brand_bidding_and_impersonation.slim
@@ -1,0 +1,5 @@
+p.salutation= t "publisher_mailer.shared.salutation", name: @publisher.name || name_from_email(@publisher.email)
+
+p= t "publisher_mailer.suspend_publisher_for_brand_bidding_and_impersonation.body_html"
+
+.notice= t "shared.support_note_html"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,37 @@ en:
       body_html: We have noticed some unusual or suspicious contributions to your Brave Rewards account. As a result we have temporarily frozen payments made to your account.<br /><br />Suspicious contributions can include unreasonably large contributions for small channels and/or contribution that solely originate from the user growth pool.<br /><br />Please contact us at <a href="support+publishers@basicattentiontoken.org">support+publishers@basicattentiontoken.org</a>.
       closing_html: Thank you.<br/>The Brave Rewards Team
       contact_support: If you did not make this change yourself, please contact support ASAP
+    suspend_publisher_for_brand_bidding:
+      subject: Your Brave Rewards account has been temporarily frozen
+      body_html:
+        We've received reports that you are bidding on Brave branded keywords when running ad campaigns to promote your Brave Referral Code.
+        <br/><br/>
+        Please stop bidding on the terms "Brave", "Brave Browser" or any other Brave branded terms when targeting your campaigns, and use negative keyword tools to ensure none of your ads accidentally appear on these keywords searches.
+        <br/><br/>
+        These terms are off limits on all ads platforms, as described in our Terms of Service - Section 19.
+        <br/><br/>
+        We have temporarily suspended your account until you are in compliance.
+        <br/><br/>
+        Thank you.
+    suspend_publisher_for_brand_bidding_and_impersonation:
+      subject: Your Brave Rewards account has been temporarily frozen
+      body_html:
+        We've received reports that you are bidding on Brave branded keywords when running ad campaigns to promote your Brave Referral Code, as well as directing traffic to a site impersonating Brave.
+        <br/><br/>
+        Please stop bidding on the terms "Brave", "Brave Browser" or any other Brave branded terms when targeting your campaigns, and use negative keyword tools to ensure none of your ads accidentally appear on these keywords searches. These terms are off limits on all ads platforms, as described in our Terms of Service - Section 19. 
+        <br/><br/>
+        Further, you are not permitted to earn through the Referral Program using a site that impersonates brave.com. If you would like to continue in the Referral Program, you will need to
+        <ul>
+          <li>Change your site's domain name to not include the word "Brave".</li>
+          <li>Provide a visible, clear statement at the top of the page stating that you are not affiliated with Brave </li>
+        </ul>
+        You can choose not to change your domain name, but you would have to change the download button to direct users to brave.com and not your Referral Code. You cannot earn through the Referral Program while impersonating Brave.
+        <br/><br/>
+        Please carefully review our Terms of Service, as another violation will result in a ban from the Referral Program. 
+        <br/><br/>
+        We have temporarily suspended your account until you are in compliance.
+        <br/><br/>
+        Thank you.
     submit_appeal:
       subject: Brave Rewards Appeal — Under Review
       body: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,12 @@ Rails.application.routes.draw do
       resources :publishers, defaults: { format: :json } do
         post "publisher_status_updates"
       end
+
+      # /api/v1/promo_registrations
+      namespace :promo_registrations do
+        post "/:referral_code/publisher_status_updates", action: "publisher_status_updates"
+      end
+
       resources :transactions, only: [:show]
 
       # /api/v1/stats/

--- a/test/controllers/api/v1/promo_registrations_controller_test.rb
+++ b/test/controllers/api/v1/promo_registrations_controller_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class Api::V1::PromoRegistrationsControllerTest < ActionDispatch::IntegrationTest
+  test "/api/v1/promo_registrations/:referral_code/publisher_status_updates updates a publisher status via referral code" do
+    promo_registration = promo_registrations(:site_promo_registration)
+    post "/api/v1/promo_registrations/" + promo_registration.referral_code + "/publisher_status_updates",
+      headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" },
+      params: { status: "suspended", note: "yolo", admin: "hello@brave.com"}
+    status = promo_registration.publisher.last_status_update.status
+    assert_equal("suspended", status)
+  end
+end

--- a/test/controllers/api/v1/promo_registrations_controller_test.rb
+++ b/test/controllers/api/v1/promo_registrations_controller_test.rb
@@ -8,5 +8,16 @@ class Api::V1::PromoRegistrationsControllerTest < ActionDispatch::IntegrationTes
       params: { status: "suspended", note: "yolo", admin: "hello@brave.com"}
     status = promo_registration.publisher.last_status_update.status
     assert_equal("suspended", status)
+    assert_enqueued_emails 0
+  end
+
+  test "/api/v1/promo_registrations/:referral_code/publisher_status_updates sends an email" do
+    promo_registration = promo_registrations(:site_promo_registration)
+    post "/api/v1/promo_registrations/" + promo_registration.referral_code + "/publisher_status_updates",
+      headers: { "HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token" },
+      params: { status: "suspended", note: "yolo", admin: "hello@brave.com", email: "brand_bidding"}
+    status = promo_registration.publisher.last_status_update.status
+    assert_equal("suspended", status)
+    assert_enqueued_emails 1
   end
 end


### PR DESCRIPTION
POST /api/v1/promo_registrations/:referral_code/publisher_status_updates

The endpoint is the same as the existing publisher_status_updates
endpoint (a note, status, and admin are required) except a referral
code is supplied in the url param.  The controller action looks up
the publisher associated with that code, then updates the publisher's
status.

## Pull Request Name

[Add screenshot if applicable]

#### Features

Enter a brief summary of the Pull Request - Features, motivations, and issues it #closes

#### How To Test

1. Step one
2. Step two
3. Step three

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
