### PR TITLE
Fix country exclusions from start

### DIFF
--- a/app/services/payout/potential_payment/uphold_service.rb
+++ b/app/services/payout/potential_payment/uphold_service.rb
@@ -31,25 +31,23 @@ class Payout::PotentialPayment::UpholdService < BaseService
     total_probi = probi
 
     # Create the referral payment for the owner
-    if @publisher.may_register_promo? && !@publisher.promo_lockout_time_passed?
-      potential_payments << PotentialPayment.new(
-        payout_report_id: @payout_report&.id,
-        name: @publisher.name,
-        amount: "#{probi}",
-        fees: "0",
-        publisher_id: @publisher.id,
-        kind: PotentialPayment::REFERRAL,
-        address: "#{uphold_connection.address}",
-        uphold_status: uphold_connection.status,
-        reauthorization_needed: uphold_connection.uphold_access_parameters.blank?,
-        uphold_member: uphold_connection.is_member?,
-        uphold_id: uphold_connection.uphold_id,
-        wallet_provider_id: uphold_connection.uphold_id,
-        wallet_provider: PotentialPayment.wallet_providers['uphold'],
-        suspended: @publisher.suspended?,
-        status: @publisher.last_status_update&.status
-      )
-    end
+    potential_payments << PotentialPayment.new(
+      payout_report_id: @payout_report&.id,
+      name: @publisher.name,
+      amount: "#{probi}",
+      fees: "0",
+      publisher_id: @publisher.id,
+      kind: PotentialPayment::REFERRAL,
+      address: "#{uphold_connection.address}",
+      uphold_status: uphold_connection.status,
+      reauthorization_needed: uphold_connection.uphold_access_parameters.blank?,
+      uphold_member: uphold_connection.is_member?,
+      uphold_id: uphold_connection.uphold_id,
+      wallet_provider_id: uphold_connection.uphold_id,
+      wallet_provider: PotentialPayment.wallet_providers['uphold'],
+      suspended: @publisher.suspended?,
+      status: @publisher.last_status_update&.status
+    )
 
     # Create potential payments for channel contributions
     @publisher.channels.verified.each do |channel|

--- a/test/services/payout/potential_payment/uphold_service_test.rb
+++ b/test/services/payout/potential_payment/uphold_service_test.rb
@@ -433,39 +433,6 @@ class UpholdServiceTest < ActiveJob::TestCase
             end
           end
 
-          describe 'when REFERRAL_KYC_REQUIRED is true' do
-            let(:publisher) { publishers(:promo_not_registered) }
-
-            before do
-              Rails.application.secrets[:api_eyeshade_offline] = false
-              stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
-              subject
-            end
-
-            it 'only creates contribution payments' do
-              PotentialPayment.where(payout_report_id: @payout_report.id, publisher_id: publisher.id).each do |payment|
-                assert_equal "contribution", payment.kind
-              end
-            end
-          end
-
-          describe 'when the promo lockout time has expired' do
-            let(:publisher) { publishers(:promo_lockout) }
-
-            before do
-              publisher.update(feature_flags: { UserFeatureFlags::PROMO_LOCKOUT_TIME => 2.days.ago } )
-              Rails.application.secrets[:api_eyeshade_offline] = false
-              stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
-              subject
-            end
-
-            it 'only creates contribution payments' do
-              PotentialPayment.where(payout_report_id: @payout_report.id, publisher_id: publisher.id).each do |payment|
-                assert_equal "contribution", payment.kind
-              end
-            end
-          end
-
           describe 'when the promo lockout time has not expired' do
             let(:publisher) { publishers(:promo_lockout) }
 


### PR DESCRIPTION
## Fix country exclusions from start

We should filter these countries out in the anti-fraud stage rather than preventing them from being included at the beginning.