### PR TITLE
Do not automatically move publishers out of only_user_funds

### DIFF
--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::PublishersController < Api::BaseController
 
     # We should not automatically move publishers out of this status.
     if user.only_user_funds?
-      render status: 200 and return
+      render(status: 200, json: { publisher_status_updates_id: user.last_status_update.id }) and return
     end
 
     raise InvalidNote if note.blank?

--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -35,6 +35,11 @@ class Api::V1::PublishersController < Api::BaseController
     status = params[:status]
     note = params[:note]
 
+    # We should not automatically move publishers out of this status.
+    if user.status == PublisherStatusUpdate::ONLY_USER_FUNDS
+      render status: 200 and return
+    end
+
     raise InvalidNote if note.blank?
     raise InvalidAdmin if admin.blank?
 

--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::PublishersController < Api::BaseController
     note = params[:note]
 
     # We should not automatically move publishers out of this status.
-    if user.status == PublisherStatusUpdate::ONLY_USER_FUNDS
+    if user. only_user_funds?
       render status: 200 and return
     end
 

--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::PublishersController < Api::BaseController
     note = params[:note]
 
     # We should not automatically move publishers out of this status.
-    if user. only_user_funds?
+    if user.only_user_funds?
       render status: 200 and return
     end
 


### PR DESCRIPTION
## Do not automatically move publishers out of only_user_funds

#### Features

If an API request is made to change a user out of only_user_funds we ignore it.