### PR TITLE
Add params to transactions request

### DIFF
--- a/app/services/publisher_transactions_getter.rb
+++ b/app/services/publisher_transactions_getter.rb
@@ -21,6 +21,12 @@ class PublisherTransactionsGetter < BaseApiClient
     response = connection.get do |request|
       request.headers["Authorization"] = api_authorization_header
       request.url("v1/accounts/#{URI.encode_www_form_component(publisher.owner_identifier)}/transactions")
+      request.options.params_encoder = Faraday::FlatParamsEncoder
+      request.params['type'] = ['referral_settlement', 'contribution_settlement', 'fees']
+
+      # Set a timeout (seconds) so requests do not stall.
+      request.options[:timeout] = 15
+      request.options[:open_timeout] = 10
     end
 
     transactions = JSON.parse(response.body)

--- a/test/services/publisher_transactions_getter_test.rb
+++ b/test/services/publisher_transactions_getter_test.rb
@@ -9,7 +9,7 @@ class PublisherBalanceGetterTest < ActiveJob::TestCase
       publisher = publishers(:uphold_connected)
       @mocked_response = PublisherTransactionsGetter.new(publisher: publisher).perform_offline
 
-      stub_request(:get, "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/accounts/#{URI.encode_www_form_component(publisher.owner_identifier)}/transactions").
+      stub_request(:get, /v1\/accounts.*transactions.*/).
         to_return(status: 200, body: @mocked_response.to_json, headers: {})
 
       @transactions = PublisherTransactionsGetter.new(publisher: publisher).perform

--- a/test/test_helpers/eyeshade_helper.rb
+++ b/test/test_helpers/eyeshade_helper.rb
@@ -1,6 +1,6 @@
 module EyeshadeHelper
   def stub_eyeshade_transactions_response(publisher:, transactions: [])
-    stub_request(:get, "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/accounts/#{URI.encode_www_form_component(publisher.owner_identifier)}/transactions").
+    stub_request(:get, /v1\/accounts.*transactions.*/).
       to_return(status: 200, body: transactions.to_json, headers: {})
   end
 


### PR DESCRIPTION
## Add params to transactions request

Closes #2840

#### Features

✨ Add query params to only request the data we need from the Eyeshade Transactions Endpoint.

