### PR TITLE
Revert "Set a Content-Security-Policy (#2580)"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,21 +10,8 @@ Rails.application.configure do
     'Access-Control-Request-Method' => "GET",
     'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Accept, Authorization',
     'Access-Control-Allow-Methods' => 'GET',
-    'X-Content-Type-Options' => 'nosniff',
-    'X-Frame-Options' => 'deny',
-    'X-XSS-Protection' => '1; mode=block',
+    'X-Frame-Options' => 'deny'
   }
-  config.content_security_policy do |policy|
-    policy.default_src :self, :https, :http
-    policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
-    policy.object_src  :none
-    policy.script_src  :self, :https
-    policy.style_src   :self, :https
-
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-  end
 
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -8,18 +8,8 @@ Rails.application.configure do
     'Access-Control-Request-Method' => "GET",
     'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Accept, Authorization',
     'Access-Control-Allow-Methods' => 'GET',
-    'X-Content-Type-Options' => 'nosniff',
-    'X-Frame-Options' => 'deny',
-    'X-XSS-Protection' => '1; mode=block',
+    'X-Frame-Options' => 'deny'
   }
-  config.content_security_policy do |policy|
-    policy.default_src :self, :https, :http
-    policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
-    policy.object_src  :none
-    policy.script_src  :self, :https
-    policy.style_src   :self, :https
-  end
 
   # Rate limiting
   config.middleware.use(Rack::Attack)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,7 +5,7 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 # Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https, :http
+#   policy.default_src :self, :https
 #   policy.font_src    :self, :https, :data
 #   policy.img_src     :self, :https, :data
 #   policy.object_src  :none


### PR DESCRIPTION
This reverts commit 4fc569e2a741f9cf4c888e599901ccfb19c73ef3.

The CSP policy was breaking due to an outdated `styled-components` in Brave-UI. https://github.com/brave/brave-ui/issues/128

I will be taking this on when I have capacity, but until then we need to revert this commit. 