### PR TITLE
Simplify deploy by using commit hash as digest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .dockerignore
-.git
 .gitignore
 logs/
 tmp/

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,59 @@
+Rake::Task["assets:precompile"].enhance do
+  Rake::Task["assets:postcompile"].execute
+end
+
+namespace :assets do
+  task postcompile: :environment do
+    puts "Running postcompile"
+
+    # To maintain parity between the different deployments
+    # We're going to replace the assets digest with the SHA of the Git commit
+    webpack_manifest = Rails.root.join("public", "packs", "manifest.json")
+    sprockets_manifest = Dir[Rails.root.join("public", "assets", ".*.json")].first
+
+    sha = `git rev-parse HEAD`
+    WebpackManifest.new(file: webpack_manifest, sha: sha).execute!
+    SprocketsManifest.new(file: sprockets_manifest, sha: sha).execute!
+
+    puts "Postcompile complete"
+  end
+end
+
+class Manifest
+  attr_reader :data, :sha, :file, :directory
+
+  DIGEST_REGEX = /-[A-Fa-f0-9].*\./.freeze
+
+  def initialize(file:, sha:)
+    @file = file
+    @directory = File.dirname(file).sub("/packs", "")
+    @data = JSON.parse(File.read(file))
+    @sha = sha
+  end
+
+  def manifest_entry
+    Proc.new do |value|
+      new_value = value
+      if value =~ DIGEST_REGEX
+        new_value = new_value.gsub(DIGEST_REGEX, "-#{sha}.")
+        FileUtils.copy("#{directory}/#{value}", "#{directory}/#{new_value}")
+      end
+
+      new_value
+    end
+  end
+end
+
+class WebpackManifest < Manifest
+  def execute!
+    data = self.data.deep_transform_values(&manifest_entry)
+    File.write(file, JSON.pretty_generate(data))
+  end
+end
+
+class SprocketsManifest < Manifest
+  def execute!
+    data["assets"] = data["assets"].deep_transform_values(&manifest_entry)
+    File.write(file, JSON.pretty_generate(data))
+  end
+end

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "lint-js-css": "stylelint --config '.stylelintrc-jsx.json' 'app/**/*.{ts,tsx}'",
     "lint-ts": "tslint --project tsconfig.json 'app/javascript/**/*.{ts,tsx}'",
     "prettier": "prettier --check 'app/javascript/**/*.{ts,tsx}'",
-    "build": "cd public/creators-landing && yarn install && yarn build && cd - && yarn install",
     "test": "jest"
   },
   "husky": {

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -35,5 +35,5 @@ workbox.precaching.precacheAndRoute(self.__precacheManifest, {});
 
 workbox.routing.registerNavigationRoute(workbox.precaching.getCacheKeyForURL("/index.html"), {
   
-  blacklist: [/^\/_/,/\/[^/?]+\.[^/]+$/],
+  blacklist: [/^\/_/,/\/[^\/?]+\.[^\/]+$/],
 });


### PR DESCRIPTION
## Simplify deploy by using commit hash as digest

#### Features

* Remove the `yarn build` step. 

We don't technically need this right now. This was originally added so that if a change is made on the public site but "yarn build" isn't run then the latest changes will still be deployed.

* Reverse engineer the Rails Webpacker and Sprockets pipeline so that we can use an arbitrary digest. 
