### PR TITLE
strip newline from git sha used in asset compilation

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -11,7 +11,7 @@ namespace :assets do
     webpack_manifest = Rails.root.join("public", "packs", "manifest.json")
     sprockets_manifest = Dir[Rails.root.join("public", "assets", ".*.json")].first
 
-    sha = ENV['SOURCE_VERSION'] || `git rev-parse HEAD`
+    sha = ENV['SOURCE_VERSION'] || `git rev-parse HEAD`.strip()
     WebpackManifest.new(file: webpack_manifest, sha: sha).execute!
     SprocketsManifest.new(file: sprockets_manifest, sha: sha).execute!
 


### PR DESCRIPTION
```
[user@work:~/source/publishers]% irb
irb(main):001:0> sha = `git rev-parse HEAD`
irb(main):002:0> sha
=> "18ff828bfb6c463f4ef7909997d800ea02268a1b\n"
irb(main):004:0> sha = `git rev-parse HEAD`.strip()
irb(main):005:0> sha
=> "18ff828bfb6c463f4ef7909997d800ea02268a1b"
```