### PR TITLE
Update assets regex

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -22,7 +22,7 @@ end
 class Manifest
   attr_reader :data, :sha, :file, :directory
 
-  DIGEST_REGEX = /-[A-Fa-f0-9].*\./.freeze
+  DIGEST_REGEX = /-[A-Fa-f0-9]{8}.*\./.freeze
 
   def initialize(file:, sha:)
     @file = file


### PR DESCRIPTION
## Update assets regex

We were seeing some weirdness with some of the assets being replicated. This was because the hex regex improperly matched assets that were structured like `choose-channel-1a2b3e4c.svg`. Where the first character was like a hex. 

To fix this I've updated the regex that 8 characters must match a hex, up to the `.`