### PR TITLE
Add Imagemagick to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update -qq && apt-get install -y build-essential
 RUN apt-get install -y nodejs \
   libpq-dev \
   git \
-  curl
+  curl \
+  imagemagick
 
 SHELL [ "/bin/bash", "-l", "-c" ]
 


### PR DESCRIPTION
## Add Imagemagick to Dockerfile

We were seeing this error on the creators.bsg.brave.com page when uploading an image 

<img width="580" alt="Screen Shot 2020-09-28 at 1 19 07 PM" src="https://user-images.githubusercontent.com/5459225/94471868-7b914080-018f-11eb-81e6-1bd9d6e5779f.png">

This adds the `imagemagick` to the Dockerfile to support image resizing

#### Features

🐛 Fixes the Imagemagick dependency on creators.bsg.brave.com


#### How To Test

✅  Tests pass / `make docker` works.