### PR TITLE
SiteBannerLookup reads from other database

### DIFF
--- a/app/models/site_banner_lookup.rb
+++ b/app/models/site_banner_lookup.rb
@@ -1,6 +1,9 @@
 class SiteBannerLookup < ActiveRecord::Base
   belongs_to :channel
   belongs_to :publisher
+
+  connects_to database: { writing: :primary, reading: :secondary }
+
   def set_sha2_base16
     self.sha2_base16 = Digest::SHA2.hexdigest(channel_identifier)
   end


### PR DESCRIPTION
## SiteBannerLookup reads from other database

#### Features

Uses the guide from [Rails](https://edgeguides.rubyonrails.org/active_record_multiple_databases.html) to connect to the secondary follower database to read and reduce load from the primary database.

<img width="1495" alt="Screen Shot 2020-10-06 at 1 59 31 PM" src="https://user-images.githubusercontent.com/5459225/95248065-5bd7c900-07dc-11eb-8296-fbcd590669f9.png">

