### PR TITLE
Fix promo status for existing users

### DIFF
--- a/app/controllers/publishers/promo_registrations_controller.rb
+++ b/app/controllers/publishers/promo_registrations_controller.rb
@@ -21,11 +21,16 @@ class Publishers::PromoRegistrationsController < ApplicationController
 
   def index
     @publisher = current_publisher
-    @publisher_promo_status = @publisher.promo_status(promo_running?)
     @promo_enabled_channels = @publisher.channels.joins(:promo_registration)
+    if Rails.env.development?
+      @publisher_promo_status = @publisher.promo_status(promo_running?)
+    else
+      @publisher_promo_status = :over
+    end
   end
 
   def create
+    return unless Rails.env.development?
     @publisher = current_publisher
     @publisher.promo_enabled_2018q1 = true
     @publisher.save!

--- a/app/controllers/publishers/promo_registrations_controller.rb
+++ b/app/controllers/publishers/promo_registrations_controller.rb
@@ -22,7 +22,7 @@ class Publishers::PromoRegistrationsController < ApplicationController
   def index
     @publisher = current_publisher
     @promo_enabled_channels = @publisher.channels.joins(:promo_registration)
-    if Rails.env.development?
+    if Rails.env.development? || Rails.env.test?
       @publisher_promo_status = @publisher.promo_status(promo_running?)
     else
       @publisher_promo_status = :over
@@ -30,7 +30,7 @@ class Publishers::PromoRegistrationsController < ApplicationController
   end
 
   def create
-    return unless Rails.env.development?
+    return unless Rails.env.development? || Rails.env.test?
     @publisher = current_publisher
     @publisher.promo_enabled_2018q1 = true
     @publisher.save!

--- a/app/models/concerns/referral_promo.rb
+++ b/app/models/concerns/referral_promo.rb
@@ -31,9 +31,6 @@ module ReferralPromo
   #
   # Returns true or false depending on if the country is included.
   def valid_promo_country?
-    # Disallow new signups in prod and staging
-    return false if Rails.env.production? || Rails.env.staging?
-
     PromoRegistration::RESTRICTED_COUNTRIES.exclude?(country)
   end
 

--- a/app/views/publishers/_promo_panel.html.slim
+++ b/app/views/publishers/_promo_panel.html.slim
@@ -7,16 +7,12 @@
         #promo-referring-fans= t("promo.activate.sub_header_two")
 
       .promo-panel-item.promo-panel-item-button
-        - if @publisher.may_register_promo? && !@publisher.promo_lockout_time_passed?
-          = link_to t("promo.activate.button-dashboard").upcase, promo_registrations_path, class: 'btn btn-primary', id: "activate-promo-dashboard-button"
-        - elsif !@publisher.valid_promo_country?
-          .promo-panel-item-alert
-            #promo-panel-alert
-              = t('promo.dashboard.signups_disabled')
-        - else
-          .promo-panel-item-alert
-            #promo-panel-alert
-              = t('promo.dashboard.unpayable_notice')
+        - if Rails.env.development?
+          = link_to "[Development Only] Activate", promo_registrations_path, class: 'btn btn-primary', id: "activate-promo-dashboard-button"
+
+        .promo-panel-item-alert
+          #promo-panel-alert
+            = t('promo.dashboard.signups_disabled')
 
 - elsif current_publisher.only_user_funds?
   .col class="#{current_publisher.no_grants? ? 'col-md-5 mb-4' : 'mb-4' }"
@@ -26,7 +22,7 @@
           == t("promo.dashboard.violation")
 
 - elsif current_publisher.has_verified_channel?
-  - if @publisher.may_register_promo? && !@publisher.promo_lockout_time_passed?
+  - if !@publisher.promo_lockout_time_passed?
     .col class="#{current_publisher.no_grants? ? 'col-md-5 mb-4' : 'mb-4' }"
       .promo-panel.h-100
         .h-100

--- a/app/views/publishers/_promo_panel.html.slim
+++ b/app/views/publishers/_promo_panel.html.slim
@@ -22,7 +22,7 @@
           == t("promo.dashboard.violation")
 
 - elsif current_publisher.has_verified_channel?
-  - if !@publisher.promo_lockout_time_passed?
+  - if @publisher.may_register_promo? && !@publisher.promo_lockout_time_passed?
     .col class="#{current_publisher.no_grants? ? 'col-md-5 mb-4' : 'mb-4' }"
       .promo-panel.h-100
         .h-100


### PR DESCRIPTION
## Fix promo status for existing users


#### Features

:bug: Fix promo status for existing users

In many places in the code we use the `may_register_promo?` which shows or hides the existing promo logic based on the users' status. 

When we introduced the `return false` on `valid_promo_country?` we disabled the promos site-wide. 

This change removes that logic, allowing the existing referral program to continue to function but disables all new signups except in development mode. 
