### PR TITLE
Limit number of channels rendered per page down to 20. This isn't the

### DIFF
--- a/app/assets/stylesheets/pages/home.scss
+++ b/app/assets/stylesheets/pages/home.scss
@@ -132,6 +132,35 @@
   }
 }
 
+.pagination {
+  padding: 3px;
+  margin: 3px;
+}
+.pagination a {
+  padding: 2px 5px 2px 5px;
+  margin: 2px;
+  border: 1px solid #dfdfe8;
+  text-decoration: none;
+  color: #131525;
+}
+.pagination a:hover,
+.pagination a:active {
+  border: 1px solid #131525;
+}
+.pagination em.current {
+  padding: 2px 5px 2px 5px;
+  margin: 2px;
+  border: 1px solid #dfdfe8;
+  font-weight: bold;
+  font-style: normal;
+}
+.pagination span.disabled {
+  padding: 2px 5px 2px 5px;
+  margin: 2px;
+  border: 1px solid #eee;
+  color: #ddd;
+}
+
 .dashboard {
   max-width: 1140px;
   margin: auto;

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -58,6 +58,7 @@ class Admin::PublishersController < AdminController
       @payout_report = PayoutReport.where(final: true, manual: false).order(created_at: :desc).first
       @payout_message = PayoutMessage.find_by(payout_report: @payout_report, publisher: @publisher)
     end
+    @channels = @publisher.channels.paginate(page: params[:page], per_page: 20)
   end
 
   def wallet_info

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -139,6 +139,7 @@ class PublishersController < ApplicationController
     end
 
     @possible_currencies = []
+    @channels = @publisher.channels.visible.paginate(page: params[:page], per_page: 20)
 
     if uphold_connection.uphold_details.present?
       @possible_currencies = uphold_connection.uphold_details&.currencies

--- a/app/views/admin/publishers/show.html.slim
+++ b/app/views/admin/publishers/show.html.slim
@@ -33,10 +33,9 @@ hr
   .c-4.shadow-sm.bg-white.rounded.p-3.my-4
     h3.text-dark Channels
     #channels-section
-      - @publisher.channels.each do |channel|
+      - @channels.each do |channel|
         = render partial: 'channel', locals: { channel: channel }
-        - unless channel == @publisher.channels.last
-          hr
+      = will_paginate @channels
 
   .c-4.shadow-sm.bg-white.rounded.p-3.my-4
     .accordion

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -62,8 +62,9 @@ noscript
         && !@publisher.promo_lockout_time_passed?
       = render "publishers/referral_charts", current_publisher: @publisher
 
-    - @publisher.channels.visible.each do |channel|
+    - @channels.each do |channel|
       = render partial: 'channel', locals: { channel: channel }
+    = will_paginate(@channels)
 
     .row id="add_channel_placeholder"
       .col.mb-4


### PR DESCRIPTION
most elegant solution, as it causes a full page reload when going from
page to page, but the current impression is that the vast majority of
users have less than 20 channels.

Loading the channels could also be improved by figuring out a way
to join the data across multiple tables, but I have not figured out
how to get this to work with partials.