### PR TITLE
Payout reports quick fix

### DIFF
--- a/app/services/payout/gemini_service.rb
+++ b/app/services/payout/gemini_service.rb
@@ -8,10 +8,6 @@ module Payout
       potential_payments = []
 
       connection = @publisher.gemini_connection
-      if connection.blank?
-        connection = @publisher.gemini_connection
-      end
-
       # Sync the connection
       connection.sync_connection!
 

--- a/app/services/payout/gemini_service.rb
+++ b/app/services/payout/gemini_service.rb
@@ -7,7 +7,7 @@ module Payout
 
       potential_payments = []
 
-      connection = @publisher.selected_wallet_provider
+      connection = @publisher.gemini_connection
       if connection.blank?
         connection = @publisher.gemini_connection
       end

--- a/app/services/payout/service.rb
+++ b/app/services/payout/service.rb
@@ -54,7 +54,7 @@ module Payout
       # Checking these classes will be removed once the following issue is addressed
       # https://github.com/brave-intl/publishers/issues/2858
 
-      if self.class == Payout::UpholdService && @publisher.gemini_connection.present?
+      if self.class == Payout::UpholdService && @publisher.gemini_connection.present? && @publisher.selected_wallet_provider_type != 'UpholdConnection'
         # A publisher can have a gemini_connection and uphold_connection.
         # We don't want to include users who have a GeminiConnection on the Uphold Payout
         create_message("Publisher has a gemini connection and is not paid out through this job")


### PR DESCRIPTION
This handles an edge case in which a publisher has an UpholdConnection and a GeminiConnection, but the Uphold connection is the selected connection. 

Currently in this case the code will attempt to create a Gemini payment, but it will fail since the `selected_wallet_provider` (removed on line 10) will return an Uphold connection, and the UpholdConnection does not have the field `recipient_id`, used later.

The current code will also not create an Uphold payment because (even though it is active), since there exists a gemini connection.

This PR does two things:
* It removes the assumption that the `selected_wallet_provider` has to be a GeminiConnection in the Gemini payout service
* It allows the creation of Uphold payments even if there exists a GeminiConnection for the publisher if the `selected_wallet_provider_type` is UpholdConnection