### PR TITLE
Contest token should always be present, but it seems like a weird sta…

### DIFF
--- a/app/helpers/channels_helper.rb
+++ b/app/helpers/channels_helper.rb
@@ -115,7 +115,7 @@ module ChannelsHelper
   end
 
   def time_until_transfer(channel)
-    return unless channel.verification_pending? || channel.contest_token.present?
+    return unless channel.verification_pending? || channel.contesting_channel.contest_token.present?
     contest_timesout_at = channel.contest_timesout_at || channel.contesting_channel.contest_timesout_at
     contest_already_timed_out = (contest_timesout_at - Time.now) < 0
 

--- a/app/views/publishers/_channel.html.slim
+++ b/app/views/publishers/_channel.html.slim
@@ -56,7 +56,7 @@
               = link_to(t(".try_again"), channel_next_step_path(channel), class: "btn btn-primary try-again")
 
 
-          - if channel.verification_pending?
+          - if channel.verification_pending? && channel.contesting_channel.present?
             span.channel-contested= t("shared.channel_contested", time_until_transfer: time_until_transfer(channel))
           - elsif channel.verification_awaiting_admin_approval?
             = t("helpers.channels.verification_awaiting_admin_approval")


### PR DESCRIPTION
…te from

possibly YouTube auth is causing a failure which might result in a bad state.
Longer term solution might be changing how state will get managed.

Closes https://github.com/brave-intl/publishers/issues/2943