### PR TITLE
Be more selective about which payout jobs to enqueue

### DIFF
--- a/app/jobs/enqueue_publishers_for_payout_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_job.rb
@@ -57,10 +57,12 @@ class EnqueuePublishersForPayoutJob < ApplicationJob
       publisher_ids: publisher_ids
     )
     Payout::GeminiJob.perform_later(
-      payout_report_id: payout_report.id
+      payout_report_id: payout_report.id,
+      publisher_ids: publisher_ids
     )
     Payout::PaypalJob.perform_later(
-      payout_report_id: payout_report.id
+      payout_report_id: payout_report.id,
+      publisher_ids: publisher_ids
     )
   end
 

--- a/app/jobs/payout/gemini_job.rb
+++ b/app/jobs/payout/gemini_job.rb
@@ -4,11 +4,11 @@ module Payout
 
     def perform(should_send_notifications: false, payout_report_id: nil, publisher_ids: [])
       if publisher_ids.present?
-        publishers = Publisher.where(selected_wallet_provider_type: [nil, 'GeminiConnection'])
-                              .joins(:gemini_connection).where(id: publisher_ids)
+        publishers = Publisher.where(selected_wallet_provider_type: [nil, 'GeminiConnection']).
+          joins(:gemini_connection).where(id: publisher_ids)
       else
-        publishers = Publisher.where(selected_wallet_provider_type: [nil, 'GeminiConnection'])
-                              .joins(:gemini_connection).with_verified_channel
+        publishers = Publisher.where(selected_wallet_provider_type: [nil, 'GeminiConnection']).
+          joins(:gemini_connection).with_verified_channel
       end
 
       publishers.find_each do |publisher|

--- a/app/jobs/payout/paypal_job.rb
+++ b/app/jobs/payout/paypal_job.rb
@@ -5,7 +5,7 @@ class Payout::PaypalJob < ApplicationJob
     if publisher_ids.present?
       publishers = Publisher.where(selected_wallet_provider_type: [nil, 'PaypalConnection']).
         joins(:paypal_connection).
-        where(id: publisher_ids)
+        where(id: publisher_ids, paypal_connections: { country: "JP" })
     else
       publishers = Publisher.where(selected_wallet_provider_type: [nil, 'PaypalConnection']).
         joins(:paypal_connection).

--- a/app/jobs/payout/paypal_job.rb
+++ b/app/jobs/payout/paypal_job.rb
@@ -3,14 +3,14 @@ class Payout::PaypalJob < ApplicationJob
 
   def perform(should_send_notifications: false, payout_report_id: nil, publisher_ids: [])
     if publisher_ids.present?
-      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'PaypalConnection'])
-                            .joins(:paypal_connection)
-                            .where(id: publisher_ids)
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'PaypalConnection']).
+        joins(:paypal_connection).
+        where(id: publisher_ids)
     else
-      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'PaypalConnection'])
-                            .joins(:paypal_connection)
-                            .with_verified_channel
-                            .where(paypal_connections: { country: "JP" })
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'PaypalConnection']).
+        joins(:paypal_connection).
+        with_verified_channel.
+        where(paypal_connections: { country: "JP" })
     end
 
     publishers.find_each do |publisher|

--- a/app/jobs/payout/uphold_job.rb
+++ b/app/jobs/payout/uphold_job.rb
@@ -3,14 +3,14 @@ class Payout::UpholdJob < ApplicationJob
 
   def perform(should_send_notifications: false, manual: false, payout_report_id: nil, publisher_ids: [])
     if publisher_ids.present?
-      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection'])
-                            .joins(:uphold_connection).where(id: publisher_ids)
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection']).
+        joins(:uphold_connection).where(id: publisher_ids)
     elsif manual
-      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection'])
-                            .joins(:uphold_connection).invoice
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection']).
+        joins(:uphold_connection).invoice
     else
-      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection'])
-                            .joins(:uphold_connection).with_verified_channel
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection']).
+        joins(:uphold_connection).with_verified_channel
     end
 
     if payout_report_id.present?

--- a/app/jobs/payout/uphold_job.rb
+++ b/app/jobs/payout/uphold_job.rb
@@ -3,11 +3,14 @@ class Payout::UpholdJob < ApplicationJob
 
   def perform(should_send_notifications: false, manual: false, payout_report_id: nil, publisher_ids: [])
     if publisher_ids.present?
-      publishers = Publisher.joins(:uphold_connection).where(id: publisher_ids)
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection'])
+                            .joins(:uphold_connection).where(id: publisher_ids)
     elsif manual
-      publishers = Publisher.joins(:uphold_connection).invoice
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection'])
+                            .joins(:uphold_connection).invoice
     else
-      publishers = Publisher.joins(:uphold_connection).with_verified_channel
+      publishers = Publisher.where(selected_wallet_provider_type: [nil, 'UpholdConnection'])
+                            .joins(:uphold_connection).with_verified_channel
     end
 
     if payout_report_id.present?


### PR DESCRIPTION
For each provider payout job, only enqueue publishers that have that
wallet provider as their selected wallet provider, or have no wallet
provider selected.