### PR TITLE
Fix links for admin publisher notes

### DIFF
--- a/app/views/admin/publishers/_note.html.slim
+++ b/app/views/admin/publishers/_note.html.slim
@@ -35,7 +35,7 @@
 
       / Actual content of the note
       div id="content_#{note.id}" class="#{condense ? "" : "my-3" }"
-        = simple_format(set_mentions(note.note), sanitize: true)
+        = simple_format(set_mentions(note.note&.gsub(URI.regexp, '<a href="\0">\0</a>')&.html_safe), sanitize: true)
 
       .links
         / Reply button

--- a/app/views/admin/publishers/index.html.slim
+++ b/app/views/admin/publishers/index.html.slim
@@ -35,7 +35,7 @@ div.row
                   td = publisher.name
                   td.small = publisher.id
                   td = publisher_status(publisher)
-                  td = publisher.notes.order(created_at: :desc).first&.note
+                  td = publisher.notes.order(created_at: :desc).first&.note&.gsub(URI.regexp, '<a href="\0">\0</a>')&.html_safe
                   td = publisher.created_at.strftime('%B %d, %Y')
                   td = distance_of_time_in_words(publisher.last_sign_in_at, Time.now) if publisher.last_sign_in_at.present?
           = will_paginate @publishers


### PR DESCRIPTION
Closes https://github.com/brave-intl/publishers/issues/2960

This PR allows hyperlinks to appear due to the String object being marked HTML safe. 