### PR TITLE
Revert "fixed permission control for s3_rewards2"

### DIFF
--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -102,11 +102,7 @@ class Cache::BrowserChannels::ResponsesForPrefix
     Aws.config[:credentials] = Aws::Credentials.new(Rails.application.secrets[:s3_rewards2_access_key_id], Rails.application.secrets[:s3_rewards2_secret_access_key])
     s3 = Aws::S3::Resource.new(region: Rails.application.secrets[:s3_rewards2_bucket_region])
     obj = s3.bucket(Rails.application.secrets[:s3_rewards2_bucket_name]).object(PATH + prefix)
-    obj.put_object({
-      body: path,
-      grant_read: :s3_rewards2_bucket_grant_access,
-      grant_full_control: :s3_rewards2_bucket_grant_cloudfront_access
-    })
+    obj.upload_file(path)
   end
 
   def get_site_banner_details(site_banner_lookup)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -52,8 +52,6 @@ default: &default
   s3_rewards2_secret_access_key: <%= ENV["S3_REWARDS2_SECRET_ACCESS_KEY"] %>
   s3_rewards2_bucket_region: <%= ENV["S3_REWARDS2_BUCKET_REGION"] %>
   s3_rewards2_bucket_name: <%= ENV["S3_REWARDS2_BUCKET_NAME"] %>
-  s3_rewards2_bucket_grant_access: <%= ENV["PRIVATE_CDN_CANONICAL_ID"] %>
-  s3_rewards2_bucket_grant_cloudfront_access: <%= ENV["PRIVATE_CDN_CLOUDFRONT_CANONICAL_ID"] %>
   #SMTP Mailer settings
   smtp_server_port: <%= ENV["SENDGRID_SMTP_PORT"] %>
   smtp_server_address: <%= ENV["SENDGRID_SMTP_SERVER"] %>


### PR DESCRIPTION
I don't think we need this PR anymore, as the issues with getting the prefix uploaded no longer seems to result in an error as seen by the following curl:

`curl -v https://pcdn.bravesoftware.com/publishers/prefixes/ce55 > g.txt`

```
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< content-type: binary/octet-stream
< content-length: 2000
< date: Thu, 21 Jan 2021 04:32:43 GMT
< last-modified: Fri, 08 Jan 2021 08:30:08 GMT
< etag: "c6562e183b511bb632c5999f858551d3"
< accept-ranges: bytes
< server: AmazonS3
< x-cache: Miss from cloudfront
< via: 1.1 bdb686e41bd85ffb1c6e5b48947e5566.cloudfront.net (CloudFront)
< x-amz-cf-pop: SFO53-C1
< x-amz-cf-id: l3qGhuuX2kSxB7apjJS_V1GGDk6p7jrybq7fS4mcxRvsUJacj9qg6w==
<
{ [2000 bytes data]
100  2000  100  2000    0     0   6578      0 --:--:-- --:--:-- --:--:--  6578
* Connection #0 to host pcdn.bravesoftware.com left intact
* Closing connection 0
```

Reverts brave-intl/publishers#3003