### PR TITLE
1. Add connection pooling option to Publishers App. One can use a

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'brotli', "~> 0.2.3"
 # Authorization
 gem 'cancancan',  "~> 3.1.0"
 
+gem 'connection_pool', "~> 2.2.3"
+
 # Authentication
 gem "devise", "~> 4.7.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,6 +529,7 @@ DEPENDENCIES
   cancancan (~> 3.1.0)
   capybara
   chromedriver-helper
+  connection_pool (~> 2.2.3)
   database_cleaner
   devise (~> 4.7.1)
   dnsruby (~> 1.60.0)

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -15,9 +15,6 @@ class HealthChecksController < ActionController::Base
     [
       { name: "cache", healthy: cache_connected? },
       { name: "database", healthy: database_connected? },
-      { name: "migrations", healthy: database_migrations_updated? },
-      { name: "sidekiq", healthy: sidekiq_connected? },
-      { name: "sidekiq_workers", healthy: sidekiq_workers?, optional: true },
     ]
   end
 
@@ -26,7 +23,9 @@ class HealthChecksController < ActionController::Base
   end
 
   def cache_connected?
-    Rails.cache.redis.ping == "PONG"
+    REDIS.with do |conn|
+      conn.ping == "PONG"
+    end
   rescue StandardError
     false
   end
@@ -34,30 +33,6 @@ class HealthChecksController < ActionController::Base
   def database_connected?
     ApplicationRecord.connection
     ApplicationRecord.connected?
-  rescue
-    false
-  end
-
-  def database_migrations_updated?
-    return false unless database_connected?
-
-    !ApplicationRecord.connection.migration_context.needs_migration?
-  end
-
-  def sidekiq_connected?
-    Sidekiq.redis do |r|
-      res = r.ping
-      res == 'PONG'
-    end
-  rescue
-    false
-  end
-
-  def sidekiq_workers?
-    return false unless sidekiq_connected?
-
-    ps = Sidekiq::ProcessSet.new
-    ps.size.positive?
   rescue
     false
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  require 'connection_pool'
+  REDIS = ConnectionPool.new(size: 5) { Redis.new }
+
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,9 @@ Rails.application.configure do
     }
   }
 
+  require 'connection_pool'
+  REDIS = ConnectionPool.new(size: 5) { Redis.new }
+
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "publishers_#{Rails.env}"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -74,6 +74,9 @@ Rails.application.configure do
     }
   }
 
+  require 'connection_pool'
+  REDIS = ConnectionPool.new(size: 5) { Redis.new }
+
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "publishers_#{Rails.env}"


### PR DESCRIPTION
connection object like the following:

REDIS.with do |conn|
  conn.set('a', 'b')
end

result = REDIS.with do |conn|
  conn.get('a')
end

2. Also change the health_checks_controller by getting rid of the
migration checks, as it seems that if a migration is occurring, then
Kubernetes pods will be thrown into a boot loop.

Closes https://github.com/brave-intl/publishers/issues/3006
