### PR TITLE
Partial fix before full deprecation of the 2018q1 flag

### DIFF
--- a/app/controllers/publishers/promo_registrations_controller.rb
+++ b/app/controllers/publishers/promo_registrations_controller.rb
@@ -32,8 +32,6 @@ class Publishers::PromoRegistrationsController < ApplicationController
   def create
     return unless Rails.env.development? || Rails.env.test?
     @publisher = current_publisher
-    @publisher.promo_enabled_2018q1 = true
-    @publisher.save!
     current_publisher.channels.find_each do |channel|
       channel.register_channel_for_promo # Callee does a check
     end
@@ -145,7 +143,7 @@ class Publishers::PromoRegistrationsController < ApplicationController
   end
 
   def require_publisher_promo_disabled
-    redirect_to promo_registrations_path, action: "index" if current_publisher.promo_enabled_2018q1
+    redirect_to promo_registrations_path, action: "index" if current_publisher.may_create_referrals?
   end
 
   def validate_publisher!

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -301,8 +301,11 @@ class Channel < ApplicationRecord
   private
 
   def should_register_channel_for_promo?
-    return false unless publisher.may_create_referrals? && publisher.may_register_promo?
-    saved_change_to_verified? && verified && !publisher.only_user_funds?
+    publisher.may_create_referrals? &&
+      publisher.may_register_promo? &&
+      saved_change_to_verified? &&
+      verified &&
+      !publisher.only_user_funds?
   end
 
   def clear_verified_at_if_necessary

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -302,9 +302,7 @@ class Channel < ApplicationRecord
 
   def should_register_channel_for_promo?
     return false unless publisher.may_create_referrals? && publisher.may_register_promo?
-    promo_running = Rails.application.secrets[:active_promo_id].present? # Could use PromosHelper#active_promo_id
-    publisher_enabled_promo = publisher.promo_enabled_2018q1?
-    promo_running && publisher_enabled_promo && saved_change_to_verified? && verified && !publisher.only_user_funds?
+    saved_change_to_verified? && verified && !publisher.only_user_funds?
   end
 
   def clear_verified_at_if_necessary

--- a/app/models/concerns/referral_promo.rb
+++ b/app/models/concerns/referral_promo.rb
@@ -12,7 +12,7 @@ module ReferralPromo
   def promo_status(promo_running)
     if !promo_running || promo_lockout_time_passed?
       :over
-    elsif promo_enabled_2018q1
+    elsif feature_flags[UserFeatureFlags::REFERRAL_ENABLED_OVERRIDE]
       :active
     else
       :inactive

--- a/app/models/concerns/referral_promo.rb
+++ b/app/models/concerns/referral_promo.rb
@@ -12,7 +12,7 @@ module ReferralPromo
   def promo_status(promo_running)
     if !promo_running || promo_lockout_time_passed?
       :over
-    elsif feature_flags[UserFeatureFlags::REFERRAL_ENABLED_OVERRIDE]
+    elsif may_create_referrals?
       :active
     else
       :inactive

--- a/app/views/admin/publishers/_wallet_info.html.slim
+++ b/app/views/admin/publishers/_wallet_info.html.slim
@@ -33,7 +33,7 @@
       .db-field = "Created by:"
       .db-value = link_to @publisher.created_by, admin_publisher_path(@publisher.created_by)
   - ActiveRecord::Base.connected_to(role: :reading)
-    - if @publisher.promo_enabled_2018q1
+    - if @publisher.feature_flags[UserFeatureFlags::REFERRAL_KYC_REQUIRED]
       .db-info-row
         .db-field = "Referral downloads:"
         .db-value = publisher_referral_totals(@publisher)[PromoRegistration::RETRIEVALS]

--- a/app/views/admin/publishers/_wallet_info.html.slim
+++ b/app/views/admin/publishers/_wallet_info.html.slim
@@ -33,7 +33,7 @@
       .db-field = "Created by:"
       .db-value = link_to @publisher.created_by, admin_publisher_path(@publisher.created_by)
   - ActiveRecord::Base.connected_to(role: :reading)
-    - if @publisher.feature_flags[UserFeatureFlags::REFERRAL_KYC_REQUIRED]
+    - if @publisher.may_create_referrals?
       .db-info-row
         .db-field = "Referral downloads:"
         .db-value = publisher_referral_totals(@publisher)[PromoRegistration::RETRIEVALS]
@@ -77,4 +77,3 @@
       .db-info-row
         .db-field = "Approx. amount"
         .db-value = "#{@potential_referral_payment.amount.to_d * 1/1E18} BAT"
-

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -80,7 +80,7 @@ noscript
 
     .row.tos-row
       .col.mb-4
-        - if @publisher.promo_enabled_2018q1
+        - if @publisher.may_create_referrals?
           .promo--tos
             = t("promo.shared.tos_2_html")
         - else

--- a/test/controllers/publishers/promo_registrations_controller_test.rb
+++ b/test/controllers/publishers/promo_registrations_controller_test.rb
@@ -2,10 +2,6 @@ require "test_helper"
 require "webmock/minitest"
 require "shared/mailer_test_helper"
 
-# (Albert Wang): Because we disabled referrals, users can't create referrals for themselves
-# The controller's create function only runs in tests and in development.
-# Although it's unlikely, we retain this in case we need to turn back on the referral program.
-
 module Publishers
   class PromoRegistrationsControllerTest < ActionDispatch::IntegrationTest
     include Devise::Test::IntegrationHelpers
@@ -47,92 +43,6 @@ module Publishers
 
       # verify publisher has not enabled promo
       assert_equal publisher.may_create_referrals?, false
-    end
-
-    test "#create does nothing and renders _active if promo already enabled " do
-      skip # Check comment at the root
-      publisher = publishers(:completed)
-      sign_in publisher
-
-      # verify _over is rendered
-      post promo_registrations_path
-      assert_select("[data-test=promo-active]")
-
-      # verify publisher has not enabled promo
-      # assert_equal publisher.promo_enabled_2018q1, false
-    end
-
-    test "#create renders _activated_verified and enables promo for verfied publisher, sends email" do
-      skip # Check comment at the root
-      publisher = publishers(:completed)
-      sign_in publisher
-
-      # verify promo-activated email is sent
-      assert_difference("ActionMailer::Base.deliveries.count" , 0) do
-        post promo_registrations_path
-      end
-
-      channel = publisher.channels.first
-
-      Promo::RegisterChannelForPromoJob.perform_now(channel_id: channel.id)
-
-      perform_enqueued_jobs do
-        PromoMailer.new_channel_registered_2018q1(channel.publisher, channel).deliver_now
-      end
-      email = ActionMailer::Base.deliveries.last
-
-      # verify email is sent to correct publisher
-      assert email.to, publisher.email
-
-      # verify the referral link sent matches the publisher's channel
-      assert_email_body_matches(matcher: https_referral_url(publisher.channels.first.promo_registration.referral_code), email: email)
-
-      # verify create is rendered
-      assert_select("[data-test=promo-activated-verified]")
-
-      # verify promo is enabled for publisher
-      assert publisher.may_create_referrals?
-    end
-
-    test "#create redirects to #index if publisher promo enabled and renders _active and supports the new FeatureFlag" do
-      skip # Check comment at the root
-      publisher = publishers(:completed)
-      publisher.save
-
-      sign_in publisher
-
-      # verify activate is loaded
-      get promo_registrations_path
-      assert_select("[data-test=promo-activate]")
-
-      # enabled promo
-      post promo_registrations_path
-      follow_redirect!
-
-      # verify _active is rendered
-      assert_select("[data-test=promo-activated-verified]")
-
-      # verify they have enabled the promo
-      publisher.reload
-      assert publisher.may_create_referrals?
-
-      # verify active page is loaded
-      get promo_registrations_path
-      assert_select("[data-test=promo-active]")
-    end
-
-    test "all requests with no promo_token in params or publisher in the session redirect homepage" do
-      skip # Check comment at the root
-      publisher = publishers(:completed)
-      sign_out publisher
-
-      # verify #create redirects to home if no token is supplied
-      post promo_registrations_path
-      assert_redirected_to root_path
-
-      # verify #index redirects to home if no token is supplied
-      get promo_registrations_path
-      assert_redirected_to root_path
     end
   end
 end

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -275,12 +275,10 @@ locked_out_verifier:
 promo_enabled:
   email: "enabled@promo.org"
   name: "peter promo"
-  promo_enabled_2018q1: true
 
 promo_enabled_but_only_user_funds:
   email: "only user funds@promo.org"
   name: "peter promo"
-  promo_enabled_2018q1: true
 
 potentially_paid:
   email: "priscilla@potentiallypaid.org"

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -96,7 +96,6 @@ class ChannelTest < ActionDispatch::IntegrationTest
   test "verifying a channel calls register_channel_for_promo (site)" do
     channel = channels(:default)
     publisher = channel.publisher
-    publisher.promo_enabled_2018q1 = true
     publisher.save!
 
     # verify RegisterChannelForPromoJob is called
@@ -125,7 +124,6 @@ class ChannelTest < ActionDispatch::IntegrationTest
     channel_details_copy = channel_original.details.dup
     channel_original.destroy!
 
-    publisher.promo_enabled_2018q1 = true
     publisher.save!
 
     # check that RegisterChannelForPromoJob is called when it is verified


### PR DESCRIPTION
The `promo_enabled_2018q1` column in `publishers` was being used to turn on/off promo registrations for users. We changed the default behavior so that this flag is false, but we're essentially causing an erroneous double feature-flag for users. 

In a later PR, a migration will be used to remove the column in `publishers`. 