### PR TITLE
Updates the README with newer Oauth instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ BASE_REFERRAL_LINK="brave.com"
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 
+# For Youtube channel stats via the data api
+YOUTUBE_API_KEY=""
+
 # Create a reddit application - https://www.reddit.com/prefs/apps
 REDDIT_CLIENT_ID=""
 REDDIT_CLIENT_SECRET=""
@@ -44,3 +47,7 @@ VIMEO_CLIENT_SECRET=""
 # Create a Github Connection - https://developer.github.com/apps/building-github-apps/creating-a-github-app/
 GITHUB_CLIENT_ID=""
 GITHUB_CLIENT_SECRET=""
+
+# For RECAPCHA  - https://github.com/ambethia/recaptcha#rails-installation
+RECAPTCHA_SITE_KEY=""
+RECAPTCHA_SECRET_KEY=""

--- a/README.md
+++ b/README.md
@@ -104,19 +104,19 @@ Setup a google API project:
 - Login to your google account (dev), or the Brave google account (staging, production)
 - Go to [https://console.developers.google.com](https://console.developers.google.com)
 - Select "Create Project" then "Create" to setup a new API project
-- Give the project a name such as "publishers-dev"
+- Give the project a name such as "creators-dev"
 - Select "+ Enable APIs and Services"
 - Enable "Google+ API" and "YouTube Data API v3"
 - Back at the console select Credentials, then select the "OAuth consent screen" sub tab
-- Fill in the details. For development you need the Product name, try "Publishers Dev (localhost)"
+- Fill in the details. For development you need the Product name, try "Creators Dev (localhost)"
 - Then Select "Create credentials", then "OAuth client ID"
   - Application type is "Web application"
-  - Name is "Publishers"
+  - Name is "Creators"
   - Authorized redirect URIs is `http://localhost:3000/publishers/auth/google_oauth2/callback`
   - select "Create"
-- Record the Client ID and Client secret and enter them in your Env variables
+- Record the Client ID and Client secret and enter them in your `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` variables
 - Back at the console select "Create credentials" and select API key. This will be used for youtube channel stats via the data api.
-- Record the API and enter it in your Env variables
+- Record the API and enter it in your `YOUTUBE_API_KEY` variable
 
 You may need to wait up to 10 minutes for the changes to propagate.
 
@@ -128,14 +128,17 @@ Setup a twitch API project:
 
 - Login to your Twitch account (dev), or the Brave Twitch account (staging, production)
 - Go to [https://dev.twitch.tv/dashboard](https://dev.twitch.tv/dashboard)
-- Select "Get Started" for "App"
-- Give the project a name such as "publishers-dev"
+- Make sure you first set up 2 factor auth for your twitch account
+- Select "Register Your Application" under "Applications"
+- Give the project a name such as "creators-dev"
 - Give the app a name and application category.
 - Use the redirect URI `https://localhost:3000/publishers/auth/register_twitch_channel/callback` in development.
+- Use the 'Website Integration' category
+- Save the app
+- Once the application is created, click on "Manage" where you can view the Client ID and create the Client Secret
 - Create a Client ID and secret, saving each of them.
   - Update your env to include `TWITCH_CLIENT_ID="your-app-id"`
   - Update your env to include `TWITCH_CLIENT_SECRET="your-app-secret"`
-- Save the app
 
 ### Twitter API Setup
 


### PR DESCRIPTION
## Pull Request Name

Updates the README with newer Oauth instructions

#### Description

As I went through the README, I noticed that some of the
instructions are out-of-date. At the same time, I'd like
to start moving references to the app to 'creators' instead
of 'publishers' wherever possible to start unifying on the
new name.

