### PR TITLE
Perf improvements for reading the database

### DIFF
--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -10,7 +10,9 @@ class Cache::BrowserChannels::ResponsesForPrefix
 
   def perform(prefix)
     return if Rails.env.development?
-    generate_brotli_encoded_channel_response(prefix: prefix)
+    ActiveRecord::Base.connected_to(role: :reading) do
+      generate_brotli_encoded_channel_response(prefix: prefix)
+    end
     pad_file!
     save_to_s3!(prefix: prefix) unless Rails.env.test?
     cleanup!


### PR DESCRIPTION
Details of how the separate write and read databases should be properly handled is described in https://github.com/rails/rails/issues/38548

Given that the jobs are consuming what seem to be the primary database's resources, this PR properly moves the work to the replica.