### PR TITLE
Address a scenario where system time might not have been initialized.

### DIFF
--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -16,7 +16,12 @@ class HealthChecksController < ActionController::Base
       { name: "cache", healthy: cache_connected? },
       { name: "database", healthy: database_connected? },
       { name: "mailer_queue", healthy: mailer_queue_low? },
+      { name: "system_time", healthy: system_time_current_year? },
     ]
+  end
+
+  def system_time_current_year?
+    DateTime.now.to_s.starts_with?("202")
   end
 
   def healthy?(status)

--- a/app/models/concerns/referral_promo.rb
+++ b/app/models/concerns/referral_promo.rb
@@ -23,7 +23,7 @@ module ReferralPromo
   #
   # Returns a boolean determining if the user's promos can still be used
   def promo_lockout_time_passed?
-    return promo_lockout_time < DateTime.now if promo_lockout_time.present?
+    return promo_lockout_time.to_date < DateTime.now if promo_lockout_time.present?
     false
   end
 


### PR DESCRIPTION
There was an incident in which
(1) some users who aren't supposed to see the ref panel were able to see the ref panel
(2) some users who are supposed to see the ref panel weren't able to see
the ref panel

Unless the code started bitflipping, the other possibility is that
during startup, the system time never got initialized for the pod.