### PR TITLE
Fix a double authentication issue due to a redirect on the before_action authentication_via_token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,7 +101,7 @@ class ApplicationController < ActionController::Base
 
   def use_jabap?
     locale = params[:locale]
-    (japanese_http_header? || locale == 'ja' && current_user && (!current_user.bitflyer_enabled? || current_user.selected_wallet_provider_type == "PaypalConnection")) || locale == 'jabap'
+    ((japanese_http_header? || locale == 'ja') && current_user && (!current_user.bitflyer_enabled? || current_user.selected_wallet_provider_type == "PaypalConnection")) || locale == 'jabap'
   end
 
   def extract_locale_from_accept_language_header

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,7 +101,7 @@ class ApplicationController < ActionController::Base
 
   def use_jabap?
     locale = params[:locale]
-   (locale == 'ja' && current_user && (!current_user.bitflyer_enabled? || current_user.selected_wallet_provider_type == "PaypalConnection")) || locale == 'jabap'
+    (japanese_http_header? || locale == 'ja' && current_user && (!current_user.bitflyer_enabled? || current_user.selected_wallet_provider_type == "PaypalConnection")) || locale == 'jabap'
   end
 
   def extract_locale_from_accept_language_header

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -114,9 +114,6 @@ class PublishersController < ApplicationController
     @publisher = current_publisher
   end
 
-  def switch_sign_in_locale(&action)
-  end
-
   # Entrypoint for the authenticated re-login link.
   def show
     I18n.with_locale(japanese_http_header? ? preferred_japanese_locale : I18n.default_locale) do

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -13,7 +13,6 @@ class PublishersController < ApplicationController
     :update,
   ].freeze
 
-  before_action :switch_sign_in_locale, only: [:show]
   before_action :authenticate_via_token, only: %i(show)
   before_action :authenticate_publisher!
 
@@ -116,15 +115,13 @@ class PublishersController < ApplicationController
   end
 
   def switch_sign_in_locale(&action)
-    if japanese_http_header?
-      return I18n.with_locale(preferred_japanese_locale, &action)
-    end
-    I18n.with_locale(I18n.default_locale, &action)
   end
 
   # Entrypoint for the authenticated re-login link.
   def show
-    redirect_to(publisher_next_step_path(current_publisher))
+    I18n.with_locale(japanese_http_header? ? preferred_japanese_locale : I18n.default_locale) do
+      redirect_to(publisher_next_step_path(current_publisher))
+    end
   end
 
   def destroy

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -13,6 +13,7 @@ class PublishersController < ApplicationController
     :update,
   ].freeze
 
+  before_action :switch_sign_in_locale, only: [:show]
   before_action :authenticate_via_token, only: %i(show)
   before_action :authenticate_publisher!
 
@@ -27,6 +28,8 @@ class PublishersController < ApplicationController
   before_action :prompt_for_two_factor_setup, only: %i(home)
 
   before_action :require_verified_email, only: %i(email_verified complete_signup)
+
+  skip_around_action :switch_locale, only: [:show]
 
   def log_out
     path = after_sign_out_path_for(current_publisher)
@@ -110,6 +113,13 @@ class PublishersController < ApplicationController
 
   def change_email_confirm
     @publisher = current_publisher
+  end
+
+  def switch_sign_in_locale(&action)
+    if japanese_http_header?
+      return I18n.with_locale(preferred_japanese_locale, &action)
+    end
+    I18n.with_locale(I18n.default_locale, &action)
   end
 
   # Entrypoint for the authenticated re-login link.

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -171,15 +171,14 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
   test "login link of japanese users takes them to home" do
     publisher = publishers(:completed)
-
+    headers = {'Accept-Language' => "ja_JP"}
     request_login_email(publisher: publisher)
     url = publisher_url(publisher, token: publisher.reload.authentication_token)
-    url = url.gsub("locale=en","locale=ja")
 
-    get(url)
+    get(url, headers: headers)
 
     # verify that verified publishers are taken to expired token page
-    assert_redirected_to home_publishers_path + "?locale=ja"
+    assert_redirected_to home_publishers_path + "?locale=jabap"
     follow_redirect!
 
     # verify publisher is not redirected to homepage

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -169,7 +169,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "login link of japanese users takes them to home" do
+  test "login link of pre-bitflyer enabled japanese users takes them to home" do
     publisher = publishers(:completed)
     headers = {'Accept-Language' => "ja_JP"}
     request_login_email(publisher: publisher)
@@ -179,6 +179,24 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
     # verify that verified publishers are taken to expired token page
     assert_redirected_to home_publishers_path + "?locale=jabap"
+    follow_redirect!
+
+    # verify publisher is not redirected to homepage
+    assert_response :success
+  end
+
+  test "login link of new japanese users which should use locale=ja" do
+    publisher = publishers(:completed)
+    publisher.feature_flags["bitflyer_enabled"] = true
+    publisher.save
+
+    headers = {'Accept-Language' => "ja_JP"}
+    request_login_email(publisher: publisher)
+    url = publisher_url(publisher, token: publisher.reload.authentication_token)
+
+    get(url, headers: headers)
+    # verify that verified publishers are taken to expired token page
+    assert_redirected_to home_publishers_path + "?locale=ja"
     follow_redirect!
 
     # verify publisher is not redirected to homepage


### PR DESCRIPTION
Fix a double authentication issue due to a redirect on the before_action authentication_via_token.

The solution in place is to use a separate before_action to set the
params in the locale.

Refactored the locale logic in the ApplicationController a bit to make
it cleaner.

Closes https://github.com/brave-intl/publishers/issues/3193

#### How To Test

1. Sign-in with an existing user, make sure page loads
2. Sign-in with an existing Japanese user, make sure page loads in Japanese
3. Sign-in with a new Japanese user, make sure Japanese locale params are apparent and the page loads in Japanese
