### PR TITLE
Throw an exception if redis down in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,16 +26,15 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.application.secrets[:redis_url]
-    config.action_controller.perform_caching = true
-    config.cache_store = :redis_cache_store, { url: Rails.application.secrets[:redis_url] }
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=172800"
+  config.action_controller.perform_caching = true
+  config.cache_store =
+    :redis_cache_store, {
+      url: Rails.application.secrets[:redis_url],
+      error_handler: -> (method:, returning:, exception:) { raise exception },
     }
-  else
-    config.action_controller.perform_caching = false
-    config.cache_store = :null_store
-  end
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=172800",
+  }
 
   require 'connection_pool'
   REDIS = ConnectionPool.new(size: 5) { Redis.new }


### PR DESCRIPTION
When testing a recent PR in dev, I was not connected to
redis. Instead of give me a warning, the app switched to
null store which caused me to waste a bunch of Albert's
time asking why a PR didn't work.

With this change, if we can't connect to redis, we throw
an exception. Also, in general, if there are any issues with
redis this will also throw an exception which is desirable in
development.
