### PR TITLE
Read from primary DB for admin creator search

### DIFF
--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -4,7 +4,7 @@ class Admin::PublishersController < AdminController
   include ActiveRecord::Sanitization::ClassMethods
 
   def index
-    ActiveRecord::Base.connected_to(role: :reading) do
+    ActiveRecord::Base.connected_to(database: :primary) do
       @publishers = if sort_column&.to_sym&.in? Publisher::ADVANCED_SORTABLE_COLUMNS
                       Publisher.advanced_sort(sort_column.to_sym, sort_direction)
                     else

--- a/app/controllers/admin/publishers_controller.rb
+++ b/app/controllers/admin/publishers_controller.rb
@@ -4,48 +4,46 @@ class Admin::PublishersController < AdminController
   include ActiveRecord::Sanitization::ClassMethods
 
   def index
-    ActiveRecord::Base.connected_to(database: :primary) do
-      @publishers = if sort_column&.to_sym&.in? Publisher::ADVANCED_SORTABLE_COLUMNS
-                      Publisher.advanced_sort(sort_column.to_sym, sort_direction)
-                    else
-                      Publisher.order(sanitize_sql_for_order("#{sort_column} #{sort_direction} NULLS LAST"))
-                    end
+    @publishers = if sort_column&.to_sym&.in? Publisher::ADVANCED_SORTABLE_COLUMNS
+                    Publisher.advanced_sort(sort_column.to_sym, sort_direction)
+                  else
+                    Publisher.order(sanitize_sql_for_order("#{sort_column} #{sort_direction} NULLS LAST"))
+                  end
 
-      if params[:q].present?
+    if params[:q].present?
 
-        @publishers = publishers_search(@publishers, params[:q])
-      end
+      @publishers = publishers_search(@publishers, params[:q])
+    end
 
-      if params[:status].present? && PublisherStatusUpdate::ALL_STATUSES.include?(params[:status])
-        # Effectively sanitizes the users input
-        method = PublisherStatusUpdate::ALL_STATUSES.detect { |x| x == params[:status] }
-        @publishers = @publishers.send(method)
-      end
+    if params[:status].present? && PublisherStatusUpdate::ALL_STATUSES.include?(params[:status])
+      # Effectively sanitizes the users input
+      method = PublisherStatusUpdate::ALL_STATUSES.detect { |x| x == params[:status] }
+      @publishers = @publishers.send(method)
+    end
 
-      if params[:role].present?
-        @publishers = @publishers.where(role: params[:role])
-      end
+    if params[:role].present?
+      @publishers = @publishers.where(role: params[:role])
+    end
 
-      if params[:uphold_status].present?
-        @publishers = @publishers.joins(:uphold_connection).where('uphold_connections.status = ?', params[:uphold_status])
-      end
+    if params[:uphold_status].present?
+      @publishers = @publishers.joins(:uphold_connection).where('uphold_connections.status = ?', params[:uphold_status])
+    end
 
-      if params[:feature_flag].present?
-        found_flag = UserFeatureFlags::VALID_FEATURE_FLAGS.find { |flag| flag == params[:feature_flag].to_sym }
+    if params[:feature_flag].present?
+      found_flag = UserFeatureFlags::VALID_FEATURE_FLAGS.find { |flag| flag == params[:feature_flag].to_sym }
 
-        @publishers = @publishers.send(found_flag)
-      end
+      @publishers = @publishers.send(found_flag)
+    end
 
-      if params[:two_factor_authentication_removal].present?
-        @publishers = @publishers.joins(:two_factor_authentication_removal).distinct
-      end
+    if params[:two_factor_authentication_removal].present?
+      @publishers = @publishers.joins(:two_factor_authentication_removal).distinct
+    end
 
-      @publishers = @publishers.where.not(email: nil).or(@publishers.where.not(pending_email: nil)) # Don't include deleted users
+    @publishers = @publishers.where.not(email: nil).or(@publishers.where.not(pending_email: nil)) # Don't include deleted users
 
-      respond_to do |format|
-        format.json { render json: @publishers.to_json(only: [:id, :name, :email], methods: :avatar_color) }
-        format.html { @publishers = @publishers.group(:id).paginate(page: params[:page], total_entries: total_publishers) }
-      end
+    respond_to do |format|
+      format.json { render json: @publishers.to_json(only: [:id, :name, :email], methods: :avatar_color) }
+      format.html { @publishers = @publishers.group(:id).paginate(page: params[:page], total_entries: total_publishers) }
     end
   end
 


### PR DESCRIPTION
While generating the payout report, this query becomes slow
reading from the follower DB. This may be due to the high
number of connections that happen at that time, jumping from
50 to 250 as all the sidekiq jobs process, or just from general
DB slowness as the query goes from 8 seconds (already slow)
to 330. We need to look into the root cause of this, but for now
we can have this query run on the primary DB.
