### PR TITLE
Fix JS error on admin payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-intl": "^3.3.2",
     "react-select": "^3.0.8",
     "react-tooltip": "^4.2.3",
-    "styled-components": "^5.1.0",
+    "styled-components": "5.1.0",
     "tributejs": "^3.7.1",
     "ts-loader": "^5.3.0",
     "typescript": "^3.1.6",

--- a/test/features/admin_test.rb
+++ b/test/features/admin_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class AdminFeatureTest < Capybara::Rails::TestCase
+  include Devise::Test::IntegrationHelpers
+  include Rails.application.routes.url_helpers
+
+  let(:publisher) { publishers(:admin) }
+
+  before do
+    sign_in publisher
+  end
+
+  test "can view admin home" do
+    visit admin_root_path
+    assert_content page, "Contributions processed"
+  end
+
+  test "can view a creators payments" do
+    visit admin_publisher_payments_path(publisher_id: publisher.id)
+    assert_content page, "Earned To Date"
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,7 +1952,7 @@ babel-plugin-polyfill-regenerator@^0.2.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.0"
 
-"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^1.10.0:
+"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.10.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
   integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
@@ -9362,6 +9362,22 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
+styled-components@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.0.tgz#2e3985b54f461027e1c91af3229e1c2530872a4e"
+  integrity sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 styled-components@^3.2.5:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.10.tgz#9a654c50ea2b516c36ade57ddcfa296bf85c96e1"
@@ -9376,22 +9392,6 @@ styled-components@^3.2.5:
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
     supports-color "^3.2.3"
-
-styled-components@^5.1.0:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.3.tgz#752669fd694aac10de814d96efc287dde0d11385"
-  integrity sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^0.8.8"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
A recent yarn upgrade brought with it an updated styled-components
which broke the admin payments page. I've rolled that back and
added a simple capybara test to ensure it doesn't happen again.