### PR TITLE
Remove Paypal Payment job

### DIFF
--- a/app/jobs/enqueue_publishers_for_payout_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_job.rb
@@ -43,9 +43,6 @@ class EnqueuePublishersForPayoutJob < ApplicationJob
       should_send_notifications: true,
       publisher_ids: publisher_ids
     )
-    Payout::PaypalJob.perform_later(
-      should_send_notifications: true,
-    )
   end
 
   def enqueue_payout(payout_report:, manual:, publisher_ids:)
@@ -61,10 +58,6 @@ class EnqueuePublishersForPayoutJob < ApplicationJob
       publisher_ids: publisher_ids
     )
     Payout::BitflyerJob.perform_later(
-      payout_report_id: payout_report.id,
-      publisher_ids: publisher_ids
-    )
-    Payout::PaypalJob.perform_later(
       payout_report_id: payout_report.id,
       publisher_ids: publisher_ids
     )

--- a/test/jobs/enqueue_publishers_for_payout_job_test.rb
+++ b/test/jobs/enqueue_publishers_for_payout_job_test.rb
@@ -18,7 +18,7 @@ class EnqueuePublishersForPayoutJobTest < ActiveJob::TestCase
       final: false
     )
     assert_equal prc + 1, PayoutReport.count
-    assert_enqueued_jobs 4
+    assert_enqueued_jobs 3
   end
 
   test "can specify an existing payout report and a new one won't be created" do
@@ -40,6 +40,6 @@ class EnqueuePublishersForPayoutJobTest < ActiveJob::TestCase
         publisher_ids: publishers.pluck(:id)
       )
     end
-    assert_enqueued_jobs 4
+    assert_enqueued_jobs 3
   end
 end


### PR DESCRIPTION
Paypal is no longer supported, so don't run it. Later on, after the BitFlyer job is successful, we will remove the Paypal payment code.
