### PR TITLE
Add prefix response support for Gemini wallets

### DIFF
--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -21,7 +21,7 @@ class Cache::BrowserChannels::ResponsesForPrefix
   def generate_brotli_encoded_channel_response(prefix:)
     @site_banner_lookups = SiteBannerLookup.where("sha2_base16 LIKE ?", prefix + "%")
     channel_responses = PublishersPb::ChannelResponseList.new
-    @site_banner_lookups.includes(publisher: [:uphold_connection, :bitflyer_connection, :gemini_connection, :paypal_connection]).each do |site_banner_lookup|
+    @site_banner_lookups.includes(publisher: [:uphold_connection, :bitflyer_connection, :gemini_connection]).each do |site_banner_lookup|
       channel_response = PublishersPb::ChannelResponse.new
       channel_response.channel_identifier = site_banner_lookup.channel_identifier
       # Some malformed data shouldn't prevent the list from being generated.

--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -34,13 +34,6 @@ class Cache::BrowserChannels::ResponsesForPrefix
           wallet.uphold_wallet = uphold_wallet
           channel_response.wallets.push(wallet)
         end
-        if site_banner_lookup.publisher.paypal_connection.present? && site_banner_lookup.publisher.selected_wallet_provider_type != BITFLYER_CONNECTION
-          wallet = PublishersPb::Wallet.new
-          paypal_wallet = PublishersPb::PaypalWallet.new
-          paypal_wallet.wallet_state = get_paypal_wallet_state(paypal_connection: site_banner_lookup.publisher.paypal_connection)
-          wallet.paypal_wallet = paypal_wallet
-          channel_response.wallets.push(wallet)
-        end
         if site_banner_lookup.publisher.bitflyer_connection.present?
           wallet = PublishersPb::Wallet.new
           bitflyer_wallet = PublishersPb::BitflyerWallet.new

--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -51,7 +51,7 @@ class Cache::BrowserChannels::ResponsesForPrefix
         end
         if site_banner_lookup.publisher.gemini_connection.present?
           wallet = PublishersPb::Wallet.new
-          gemini_wallet = PublishersPb::GemniniWallet.new
+          gemini_wallet = PublishersPb::GeminiWallet.new
           gemini_wallet.wallet_state = get_gemini_wallet_state(gemini_connection: site_banner_lookup.publisher.gemini_connection)
           gemini_wallet.address = site_banner_lookup.publisher.gemini_connection.recipient_id
           wallet.gemini_wallet = gemini_wallet

--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -21,7 +21,7 @@ class Cache::BrowserChannels::ResponsesForPrefix
   def generate_brotli_encoded_channel_response(prefix:)
     @site_banner_lookups = SiteBannerLookup.where("sha2_base16 LIKE ?", prefix + "%")
     channel_responses = PublishersPb::ChannelResponseList.new
-    @site_banner_lookups.includes(publisher: :uphold_connection).includes(publisher: :paypal_connection).each do |site_banner_lookup|
+    @site_banner_lookups.includes(publisher: [:uphold_connection, :bitflyer_connection, :gemini_connection, :paypal_connection]).each do |site_banner_lookup|
       channel_response = PublishersPb::ChannelResponse.new
       channel_response.channel_identifier = site_banner_lookup.channel_identifier
       # Some malformed data shouldn't prevent the list from being generated.
@@ -47,6 +47,14 @@ class Cache::BrowserChannels::ResponsesForPrefix
           bitflyer_wallet.wallet_state = get_bitflyer_wallet_state(bitflyer_connection: site_banner_lookup.publisher.bitflyer_connection)
           bitflyer_wallet.address = site_banner_lookup.channel.deposit_id
           wallet.bitflyer_wallet = bitflyer_wallet
+          channel_response.wallets.push(wallet)
+        end
+        if site_banner_lookup.publisher.gemini_connection.present?
+          wallet = PublishersPb::Wallet.new
+          gemini_wallet = PublishersPb::GemniniWallet.new
+          gemini_wallet.wallet_state = get_gemini_wallet_state(gemini_connection: site_banner_lookup.publisher.gemini_connection)
+          gemini_wallet.address = site_banner_lookup.publisher.gemini_connection.recipient_id
+          wallet.gemini_wallet = gemini_wallet
           channel_response.wallets.push(wallet)
         end
       rescue Exception => e
@@ -88,6 +96,14 @@ class Cache::BrowserChannels::ResponsesForPrefix
 
   def get_bitflyer_wallet_state(bitflyer_connection:)
     PublishersPb::BitflyerWalletState::BITFLYER_ACCOUNT_KYC
+  end
+
+  def get_gemini_wallet_state(gemini_connection:)
+    if gemini_connection.payable?
+      PublishersPb::GeminiWalletState::GEMINI_ACCOUNT_KYC
+    else
+      PublishersPb::GeminiWalletState::GEMINI_ACCOUNT_NO_KYC
+    end
   end
 
   def cleanup!

--- a/protos/channel_responses.proto
+++ b/protos/channel_responses.proto
@@ -47,11 +47,22 @@ enum BitflyerWalletState {
   BITFLYER_ACCOUNT_KYC = 1;
 }
 
+message GeminiWallet {
+  GeminiWalletState wallet_state = 1;
+  string address = 2;
+}
+
+enum GeminiWalletState {
+  GEMINI_ACCOUNT_NO_KYC = 0;
+  GEMINI_ACCOUNT_KYC = 1;
+}
+
 message Wallet {
   oneof provider {
     UpholdWallet uphold_wallet = 1;
     PaypalWallet paypal_wallet = 2;
     BitflyerWallet bitflyer_wallet = 3;
+    GeminiWallet gemini_wallet = 4;
   }
 }
 

--- a/protos/channel_responses.rb
+++ b/protos/channel_responses.rb
@@ -29,11 +29,16 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :wallet_state, :enum, 1, "publishers_pb.BitflyerWalletState"
       optional :address, :string, 2
     end
+    add_message "publishers_pb.GeminiWallet" do
+      optional :wallet_state, :enum, 1, "publishers_pb.GeminiWalletState"
+      optional :address, :string, 2
+    end
     add_message "publishers_pb.Wallet" do
       oneof :provider do
         optional :uphold_wallet, :message, 1, "publishers_pb.UpholdWallet"
         optional :paypal_wallet, :message, 2, "publishers_pb.PaypalWallet"
         optional :bitflyer_wallet, :message, 3, "publishers_pb.BitflyerWallet"
+        optional :gemini_wallet, :message, 4, "publishers_pb.GeminiWallet"
       end
     end
     add_message "publishers_pb.ChannelResponse" do
@@ -56,6 +61,10 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       value :BITFLYER_ACCOUNT_NO_KYC, 0
       value :BITFLYER_ACCOUNT_KYC, 1
     end
+    add_enum "publishers_pb.GeminiWalletState" do
+      value :GEMINI_ACCOUNT_NO_KYC, 0
+      value :GEMINI_ACCOUNT_KYC, 1
+    end
   end
 end
 
@@ -65,10 +74,12 @@ module PublishersPb
   UpholdWallet = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.UpholdWallet").msgclass
   PaypalWallet = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.PaypalWallet").msgclass
   BitflyerWallet = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.BitflyerWallet").msgclass
+  GeminiWallet = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.GeminiWallet").msgclass
   Wallet = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.Wallet").msgclass
   ChannelResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.ChannelResponse").msgclass
   ChannelResponseList = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.ChannelResponseList").msgclass
   UpholdWalletState = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.UpholdWalletState").enummodule
   PaypalWalletState = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.PaypalWalletState").enummodule
   BitflyerWalletState = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.BitflyerWalletState").enummodule
+  GeminiWalletState = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("publishers_pb.GeminiWalletState").enummodule
 end

--- a/test/fixtures/gemini_connections.yml
+++ b/test/fixtures/gemini_connections.yml
@@ -21,6 +21,7 @@ connection_with_token:
     iv: salt
   ) %>"
   encrypted_refresh_token_iv: "<%= Base64.encode64(salt) %>"
+  recipient_id: '123'
 
 connection_not_verified:
   publisher: gemini_not_completed

--- a/test/jobs/cache/browser_channels/responses_for_prefix_test.rb
+++ b/test/jobs/cache/browser_channels/responses_for_prefix_test.rb
@@ -20,6 +20,7 @@ class Cache::BrowserChannels::ResponsesForPrefixTest < ActiveSupport::TestCase
     assert service.temp_file.present?
     result = Brotli.inflate(File.open(service.temp_file.path, 'rb').readlines.join("").slice(4..-1))
     result = PublishersPb::ChannelResponseList.decode(result)
+    assert result.channel_responses[0].wallets[0].uphold_wallet.address
     assert_equal result.channel_responses[0].wallets[0].uphold_wallet.address, channel.uphold_connection.address
     assert_equal result.channel_responses[0].channel_identifier, channel.details.channel_identifier
   end

--- a/test/jobs/cache/browser_channels/responses_for_prefix_test.rb
+++ b/test/jobs/cache/browser_channels/responses_for_prefix_test.rb
@@ -24,6 +24,23 @@ class Cache::BrowserChannels::ResponsesForPrefixTest < ActiveSupport::TestCase
     assert_equal result.channel_responses[0].channel_identifier, channel.details.channel_identifier
   end
 
+  test 'gemini wallet generation' do
+    channel = channels(:gemini_completed_website)
+    channel.send(:update_site_banner_lookup!)
+    site_banner_lookup = SiteBannerLookup.find_by(channel_id: channel.id)
+    assert site_banner_lookup.present?
+
+    service = Cache::BrowserChannels::ResponsesForPrefix.new
+    ActiveRecord::Base.connected_to(role: :reading) do
+      service.generate_brotli_encoded_channel_response(prefix: site_banner_lookup.sha2_base16[0, SiteBannerLookup::NIBBLE_LENGTH_FOR_RESPONSES])
+    end
+    assert service.temp_file.present?
+    result = Brotli.inflate(File.open(service.temp_file.path, 'rb').readlines.join("").slice(4..-1))
+    result = PublishersPb::ChannelResponseList.decode(result)
+    assert_equal result.channel_responses[0].wallets[0].gemini_wallet.address, channel.publisher.gemini_connection.recipient_id
+    assert_equal result.channel_responses[0].channel_identifier, channel.details.channel_identifier
+  end
+
   describe "complex channel response file generation" do
     before do
       @channel = channels(:verified)

--- a/test/models/gemini_connection_test.rb
+++ b/test/models/gemini_connection_test.rb
@@ -68,6 +68,7 @@ class GeminiConnectionTest < ActiveSupport::TestCase
       end
 
       it 'does creates a recipient id' do
+        connection.update(recipient_id: nil)
         refute connection.recipient_id
         subject
         assert connection.recipient_id


### PR DESCRIPTION
We need to tell the browser which Gemini wallet a user has for direct deposits. We use the protobuf prefix responses for this, and this PR adds Gemini wallet support for that.

Closes #3227
