### PR TITLE
Fix label from referral-depreciation-account to referral-deprecation-…

### DIFF
--- a/app/services/publisher_transactions_getter.rb
+++ b/app/services/publisher_transactions_getter.rb
@@ -9,7 +9,7 @@ class PublisherTransactionsGetter < BaseApiClient
   OFFLINE_UPHOLD_ACCOUNT_ID = "bdfd128a-976e-4a42-b07a-3fab7fb2cbea"
   OFFLINE_PAYMENT_ACCOUNT_ID = "f6221085-e2e4-45e3-9ba8-17c6572b42fe"
 
-  REFERRAL_DEPRECIATION_ACCOUNT = "referral-depreciation-account"
+  REFERRAL_DEPRECATION_ACCOUNT = "referral-deprecation-account"
 
   def initialize(publisher:)
     @publisher = publisher
@@ -26,7 +26,7 @@ class PublisherTransactionsGetter < BaseApiClient
     transactions = JSON.parse(response.body)
 
     # In the statements and balances, we don't want to show transactions that balance out the accounting on eyeshade
-    transactions.reject! { |transaction| transaction["to_account"] == PublisherTransactionsGetter::REFERRAL_DEPRECIATION_ACCOUNT }
+    transactions.reject! { |transaction| transaction["to_account"] == PublisherTransactionsGetter::REFERRAL_DEPRECATION_ACCOUNT }
     transactions
     # Example eyeshade response
     # [
@@ -123,10 +123,10 @@ class PublisherTransactionsGetter < BaseApiClient
           "settlement_currency" => "ETH",
         })
 
-        # Referral depreciation
+        # Referral deprecation
         transactions.push({
           "from_account" =>  OFFLINE_CANONICAL_PUBLISHER_ID,
-          "to_account" => REFERRAL_DEPRECIATION_ACCOUNT,
+          "to_account" => REFERRAL_DEPRECATION_ACCOUNT,
           "created_at" => "#{base_date}",
           "description" => "Transaction to cancel referrals finalizing past 90 days after 2021-01-23 for legacy referrals.",
           "amount" => "#{-(referral_amount)}",

--- a/test/services/publisher_transactions_getter_test.rb
+++ b/test/services/publisher_transactions_getter_test.rb
@@ -26,9 +26,9 @@ class PublisherBalanceGetterTest < ActiveJob::TestCase
       end
     end
 
-    test "removes the referral depreciation transaction" do
-      assert_not_empty @mocked_response.select { |transaction| transaction['to_account'] == PublisherTransactionsGetter::REFERRAL_DEPRECIATION_ACCOUNT }
-      assert_empty @transactions.select { |transaction| transaction['to_account'] == PublisherTransactionsGetter::REFERRAL_DEPRECIATION_ACCOUNT }
+    test "removes the referral deprecation transaction" do
+      assert_not_empty @mocked_response.select { |transaction| transaction['to_account'] == PublisherTransactionsGetter::REFERRAL_DEPRECATION_ACCOUNT }
+      assert_empty @transactions.select { |transaction| transaction['to_account'] == PublisherTransactionsGetter::REFERRAL_DEPRECATION_ACCOUNT }
     end
   end
 end


### PR DESCRIPTION
…account

The spelling in eyeshade is `referral-deprecation-account`.