### PR TITLE
Pass the display_name to antifraud

### DIFF
--- a/app/services/payout/bitflyer_service.rb
+++ b/app/services/payout/bitflyer_service.rb
@@ -36,7 +36,7 @@ module Payout
           kind: ::PotentialPayment::CONTRIBUTION,
           url: "#{channel.details.url}",
           address: channel.deposit_id || '',
-          wallet_provider_id: connection.display_name || '',
+          wallet_provider_id: connection.display_name || '', # this is a hash of the account_id
           wallet_provider: ::PotentialPayment.wallet_providers['bitflyer'],
           suspended: publisher.suspended?,
           status: publisher.last_status_update&.status,

--- a/app/services/payout/bitflyer_service.rb
+++ b/app/services/payout/bitflyer_service.rb
@@ -22,20 +22,9 @@ module Payout
       # Sync the connection
       @refresher.call(bitflyer_connection: connection)
 
-      potential_payments << PotentialPayment.new(
-        payout_report_id: payout_report&.id,
-        name: publisher.name,
-        amount: "0",
-        fees: "0",
-        publisher_id: publisher.id,
-        kind: ::PotentialPayment::REFERRAL,
-        address: connection.recipient_id || '',
-        wallet_provider_id: connection.recipient_id || '',
-        wallet_provider: ::PotentialPayment.wallet_providers['bitflyer'],
-        suspended: publisher.suspended?,
-        status: publisher.last_status_update&.status
-      )
-
+      # We don't currently support referrals payouts for Bitflyer accounts, so
+      # only payout contributions on channels. To support referrals, we'd need to
+      # create a deposit_id on each connection, not just the channels
       publisher.channels.verified.each do |channel|
         potential_payments << PotentialPayment.new(
           payout_report_id: payout_report&.id,
@@ -47,7 +36,7 @@ module Payout
           kind: ::PotentialPayment::CONTRIBUTION,
           url: "#{channel.details.url}",
           address: channel.deposit_id || '',
-          wallet_provider_id: channel.deposit_id || '',
+          wallet_provider_id: connection.display_name || '',
           wallet_provider: ::PotentialPayment.wallet_providers['bitflyer'],
           suspended: publisher.suspended?,
           status: publisher.last_status_update&.status,

--- a/test/fixtures/bitflyer_connections.yml
+++ b/test/fixtures/bitflyer_connections.yml
@@ -14,6 +14,7 @@ connection_with_token:
     iv: salt
   ) %>"
   encrypted_refresh_token_iv: "<%= Base64.encode64(salt) %>"
+  display_name: 123
 
 suspended_bitflyer_connection:
   publisher: bitflyer_suspended

--- a/test/services/payout/bitflyer_service_test.rb
+++ b/test/services/payout/bitflyer_service_test.rb
@@ -53,13 +53,16 @@ class BitflyerServiceTest < ActiveSupport::TestCase
     end
 
     it 'the address is not empty' do
-      assert PotentialPayment.all.all? { |potential_payment|
-               if potential_payment.kind == ::PotentialPayment::REFERRAL
-                 potential_payment.address == publisher.bitflyer_connection.recipient_id
-               else
-                 publisher.channels.verified.where(deposit_id: potential_payment.address).present?
-               end
-             }
+      assert PotentialPayment.all.all? { |potential_payment| publisher.channels.verified.where(deposit_id: potential_payment.address).present? }
+    end
+
+    it 'sends the display_name unique BF identifier' do
+      assert PotentialPayment.count > 0
+      PotentialPayment.all.each do |potential_payment|
+        assert publisher.bitflyer_connection.display_name.present?
+        assert_equal potential_payment.wallet_provider_id, publisher.bitflyer_connection.display_name
+        assert_equal potential_payment.wallet_provider, 'bitflyer'
+      end
     end
   end
 end


### PR DESCRIPTION
We also don't need to generate potential payments
for referrals for Bitflyer for the time being, until
we dedide we want to.

Note that display_name is only set on successful authentication, so will be blank if oauth didn't complete, but then so will deposit_id. I made a task to clean this filtering up later https://github.com/brave-intl/publishers/issues/3257