### PR TITLE
Enable CSP policy in reporting mode

### DIFF
--- a/app/controllers/csp_violations_report_controller.rb
+++ b/app/controllers/csp_violations_report_controller.rb
@@ -1,0 +1,22 @@
+class CspViolationsReportController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    # Reports look something like:
+    # {"document-uri"=>"https://localhost:3000/",
+    #   "referrer"=>"",
+    #   "violated-directive"=>"style-src-elem",
+    #   "effective-directive"=>"style-src-elem",
+    #   "original-policy"=>"default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src 'self' https: 'nonce-vF0eAyl4aPYfB1gs7173UQ=='; style-src 'self' https: 'nonce-vF0eAyl4aPYfB1gs7173UQ=='; report-uri /csp-violation-report",
+    #   "disposition"=>"report",
+    #   "blocked-uri"=>"inline",
+    #   "line-number"=>4,
+    #   "source-file"=>"https://localhost:3000/",
+    #   "status-code"=>0,
+    #   "script-sample"=>""}
+    # We only care about the document-uri, blocked-uri, and directives for now
+    report = JSON.parse(request.body.read)['csp-report']
+    sliced_report = report.slice('document-uri', 'violated-directive', 'effective-directive', 'blocked-uri')
+    CspViolationReport.create!(report: sliced_report)
+  end
+end

--- a/app/models/csp_violation_report.rb
+++ b/app/models/csp_violation_report.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CspViolationReport < ApplicationRecord
+  validates_uniqueness_of :report
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,20 +4,20 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https
+  policy.style_src   :self, :https
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  policy.report_uri "/csp-violation-report"
+end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
 
 # Set the nonce only to specific directives
 # Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
@@ -25,4 +25,4 @@
 # Report CSP violations to a specified URI
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+Rails.application.config.content_security_policy_report_only = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   get 'publishers/stripe_connection/new', to: 'payment/connection/stripe_connections#edit'
   get 'publishers/paypal_connections/connect_callback', to: 'payment/connection/paypal_connections#connect_callback'
 
+  # CSP
+  post 'csp-violation-report', to: 'csp_violations_report#create'
+
   # Routes for Browser Users to login via Uphold
   namespace :uphold_connections do
     get :login

--- a/db/migrate/20210604205513_add_csp_violation_report.rb
+++ b/db/migrate/20210604205513_add_csp_violation_report.rb
@@ -1,0 +1,8 @@
+class AddCspViolationReport < ActiveRecord::Migration[6.0]
+  def change
+    create_table :csp_violation_reports, id: :uuid, default: -> { "uuid_generate_v4()"}, force: :cascade do |t|
+      t.jsonb    "report", defaults: {}, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_001133) do
+ActiveRecord::Schema.define(version: 2021_06_04_205513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -142,6 +142,13 @@ ActiveRecord::Schema.define(version: 2021_02_09_001133) do
     t.index ["contested_by_channel_id"], name: "index_channels_on_contested_by_channel_id"
     t.index ["details_type", "details_id"], name: "index_channels_on_details_type_and_details_id", unique: true
     t.index ["publisher_id"], name: "index_channels_on_publisher_id"
+  end
+
+  create_table "csp_violation_reports", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.jsonb "report"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["report"], name: "index_csp_violation_reports_on_report", unique: true
   end
 
   create_table "daily_metrics", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|


### PR DESCRIPTION
We want to ensure a good CSP policy. This was initially driven by
the need to look at spectre mitigations (#3124), but as part of that
involves a good CSP policy, i.e.
https://security.googleblog.com/2020/07/towards-native-security-defenses-for.html

we need to get a good CSP policy in place to begin with.

For now, we'll just log the violations. We can quickly clean them up
and keep an eye on any new violations that come in over time, eventually
phasing out this code.
