### PR TITLE
Destroy Uphold Wallets Instead of Clearing

### DIFF
--- a/app/controllers/payment/connection/uphold_connections_controller.rb
+++ b/app/controllers/payment/connection/uphold_connections_controller.rb
@@ -77,7 +77,7 @@ module Payment
       # publishers/disconnect_uphold
       def destroy
         publisher = current_publisher
-        publisher.uphold_connection.disconnect_uphold
+        publisher.uphold_connection.destroy
 
         render json: {}
       end

--- a/app/jobs/two_factor_authentication_removal_job.rb
+++ b/app/jobs/two_factor_authentication_removal_job.rb
@@ -22,7 +22,7 @@ class TwoFactorAuthenticationRemovalJob < ApplicationJob
               raise ActiveRecord::Rollback unless is_deleted
             end
           end
-          publisher.uphold_connection.disconnect_uphold if publisher.uphold_connection.present?
+          publisher.selected_wallet_provider.destroy if publisher.selected_wallet_provider.present?
           publisher.status_updates.create(status: PublisherStatusUpdate::LOCKED)
           two_factor_authentication_removal.update(removal_completed: true)
         end

--- a/app/models/bitflyer_connection.rb
+++ b/app/models/bitflyer_connection.rb
@@ -5,6 +5,8 @@ class BitflyerConnection < ApplicationRecord
   SUPPORTED_CURRENCIES = ["BAT", "USD", "BTC", "ETH"].freeze
   JAPAN = "JP"
 
+  has_paper_trail
+
   belongs_to :publisher
   attr_encrypted :access_token, :refresh_token, key: :encryption_key
   validates :recipient_id, uniqueness: true, allow_blank: true

--- a/app/models/gemini_connection.rb
+++ b/app/models/gemini_connection.rb
@@ -6,6 +6,8 @@ class GeminiConnection < ApplicationRecord
   SUPPORTED_CURRENCIES = ["BAT", "USD", "BTC", "ETH"].freeze
   JAPAN = 'JP'
 
+  has_paper_trail
+
   belongs_to :publisher
 
   validates :recipient_id, uniqueness: true, allow_blank: true

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UpholdConnection < ActiveRecord::Base
+  include WalletProviderProperties
+
   has_paper_trail only: [:is_member, :member_at, :uphold_id, :address, :status, :default_currency]
 
   UPHOLD_CODE_TIMEOUT = 5.minutes
@@ -81,21 +83,6 @@ class UpholdConnection < ActiveRecord::Base
       uphold_access_parameters: nil,
       uphold_verified: false,
     )
-  end
-
-  def disconnect_uphold
-    update(
-      address: nil,
-      is_member: false,
-      status: nil,
-      uphold_id: nil,
-      uphold_code: nil,
-      uphold_access_parameters: nil,
-      uphold_verified: false,
-      default_currency_confirmed_at: nil,
-      default_currency: nil,
-    )
-    publisher.update(selected_wallet_provider: nil) if publisher.selected_wallet_provider.id == id
   end
 
   # Public: Determines if a user needs to reconnect their Uphold account.

--- a/test/jobs/two_factor_authentication_removal_job_test.rb
+++ b/test/jobs/two_factor_authentication_removal_job_test.rb
@@ -7,6 +7,20 @@ class TwoFactorAuthenticationRemovalJobTest < ActiveJob::TestCase
     assert_not_nil(publisher.totp_registration)
   end
 
+  test "Removes selected wallet" do
+    publisher = publishers(:uphold_connected)
+
+    assert publisher.selected_wallet_provider
+
+    two_factor_authentication_removal = two_factor_authentication_removals(:one)
+    original_date = two_factor_authentication_removal.created_at
+    advanced_date = original_date - 14.days
+    two_factor_authentication_removal.update(created_at: advanced_date)
+    TwoFactorAuthenticationRemovalJob.perform_now
+
+    refute publisher.reload.selected_wallet_provider
+  end
+
   test "Removes publisher's 2fa when timeout period has passed" do
     publisher = publishers(:uphold_connected)
     two_factor_authentication_removal = two_factor_authentication_removals(:one)

--- a/test/models/uphold_connection_test.rb
+++ b/test/models/uphold_connection_test.rb
@@ -111,7 +111,6 @@ class UpholdConnectionTest < ActiveSupport::TestCase
         it 'is valid' do
           assert uphold_connection.valid?
         end
-
       end
     end
   end
@@ -143,22 +142,6 @@ class UpholdConnectionTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'disconnect upholds' do
-    let(:uphold_connection) { uphold_connections(:verified_connection) }
-
-    before do
-      uphold_connection.disconnect_uphold
-    end
-
-    it 'not uphold_verified?' do
-      refute uphold_connection.uphold_verified?
-    end
-
-    it 'uphold_connection is valid?' do
-      assert uphold_connection.valid?
-    end
-  end
-
   describe 'verify_uphold_status' do
     uphold_connection = nil
 
@@ -166,7 +149,7 @@ class UpholdConnectionTest < ActiveSupport::TestCase
       uphold_connection = uphold_connections(:verified_connection)
     end
 
-    describe 'when uphold_code, access_parameters, and uphold_verified are nil'  do
+    describe 'when uphold_code, access_parameters, and uphold_verified are nil' do
       before do
         uphold_connection.uphold_code = nil
         uphold_connection.uphold_access_parameters = nil


### PR DESCRIPTION
We need to keep track of deletions of wallet connections, so
we add papertrail on gemini and bitflyer.

We also now just destroy the uphold connection when disconnecting,
this will fix the issue with TwoFactorAuth removal as well as
bring it into line with the other connection types.
