### PR TITLE
Don't include potential payments which don't have an address

### DIFF
--- a/app/models/bitflyer_connection.rb
+++ b/app/models/bitflyer_connection.rb
@@ -28,6 +28,11 @@ class BitflyerConnection < ApplicationRecord
     ""
   end
 
+  def referral_deposit_address
+    # Don't support referrals at this time for BF
+    nil
+  end
+
   # Public: All the support currency pairs for BAT on the Bitflyer Exchange
   # https://bitflyer.com/en-us/api
   #

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -298,6 +298,18 @@ class Channel < ApplicationRecord
     site_banner_lookup.sync!
   end
 
+  def channel_deposit_address
+    selected_wallet_type = publisher.selected_wallet_provider_type
+    case selected_wallet_type
+    when Publisher::UPHOLD_CONNECTION
+      publisher.selected_wallet_provider.referral_deposit_address
+    when Publisher::GEMINI_CONNECTION
+      publisher.selected_wallet_provider.referral_deposit_address
+    when Publisher::BITFLYER_CONNECTION
+      deposit_id
+    end
+  end
+
   private
 
   def should_register_channel_for_promo?

--- a/app/models/gemini_connection.rb
+++ b/app/models/gemini_connection.rb
@@ -46,6 +46,10 @@ class GeminiConnection < ApplicationRecord
     access_expiration_time.present? && Time.now > access_expiration_time
   end
 
+  def referral_deposit_address
+    recipient_id
+  end
+
   # Makes a request to the Gemini API to refresh the current access_token
   def refresh_authorization!
     # Ensure we have an refresh_token.

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -47,9 +47,9 @@ class Publisher < ApplicationRecord
 
   belongs_to :youtube_channel
   belongs_to :selected_wallet_provider, polymorphic: true
-  belongs_to :uphold_for_join, foreign_key: :selected_wallet_provider_id, class_name: UPHOLD_CONNECTION # rubocop:disable Rails/ReflectionClassName
-  belongs_to :gemini_for_join, foreign_key: :selected_wallet_provider_id, class_name: GEMINI_CONNECTION # rubocop:disable Rails/ReflectionClassName
-  belongs_to :bitflyer_for_join, foreign_key: :selected_wallet_provider_id, class_name: BITFLYER_CONNECTION # rubocop:disable Rails/ReflectionClassName
+  belongs_to :uphold_for_join, foreign_key: :selected_wallet_provider_id, class_name: UPHOLD_CONNECTION
+  belongs_to :gemini_for_join, foreign_key: :selected_wallet_provider_id, class_name: GEMINI_CONNECTION
+  belongs_to :bitflyer_for_join, foreign_key: :selected_wallet_provider_id, class_name: BITFLYER_CONNECTION
 
   has_one :uphold_connection
   has_one :stripe_connection
@@ -300,6 +300,12 @@ class Publisher < ApplicationRecord
 
   def has_verified_channel?
     channels.any?(&:verified?)
+  end
+
+  def has_deposit_address?
+    verified_channels = channels.verified
+    selected_wallet_provider.referral_deposit_address.present? ||
+      (verified_channels.any? { |channel| channel.channel_deposit_address.present? } && verified_channels.size > 0)
   end
 
   def admin?

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -180,6 +180,10 @@ class UpholdConnection < ActiveRecord::Base
     uphold_details&.currencies
   end
 
+  def referral_deposit_address
+    address
+  end
+
   # Calls the Uphold API and checks
   #   - if the address exists
   #   - the card is in the same currency as the publisher's chosen currency

--- a/app/services/payout/bitflyer_service.rb
+++ b/app/services/payout/bitflyer_service.rb
@@ -26,23 +26,25 @@ module Payout
       # only payout contributions on channels. To support referrals, we'd need to
       # create a deposit_id on each connection, not just the channels
       publisher.channels.verified.each do |channel|
-        potential_payments << PotentialPayment.new(
-          payout_report_id: payout_report&.id,
-          name: "#{channel.publication_title}",
-          amount: "0",
-          fees: "0",
-          publisher_id: publisher.id,
-          channel_id: channel.id,
-          kind: ::PotentialPayment::CONTRIBUTION,
-          url: "#{channel.details.url}",
-          address: channel.deposit_id || '',
-          wallet_provider_id: connection.display_name || '', # this is a hash of the account_id
-          wallet_provider: ::PotentialPayment.wallet_providers['bitflyer'],
-          suspended: publisher.suspended?,
-          status: publisher.last_status_update&.status,
-          channel_stats: channel.details.stats,
-          channel_type: channel.details_type
-        )
+        if channel.channel_deposit_address.present?
+          potential_payments << PotentialPayment.new(
+            payout_report_id: payout_report&.id,
+            name: "#{channel.publication_title}",
+            amount: "0",
+            fees: "0",
+            publisher_id: publisher.id,
+            channel_id: channel.id,
+            kind: ::PotentialPayment::CONTRIBUTION,
+            url: "#{channel.details.url}",
+            address: channel.channel_deposit_address,
+            wallet_provider_id: connection.display_name || '', # this is a hash of the account_id
+            wallet_provider: ::PotentialPayment.wallet_providers['bitflyer'],
+            suspended: publisher.suspended?,
+            status: publisher.last_status_update&.status,
+            channel_stats: channel.details.stats,
+            channel_type: channel.details_type
+          )
+        end
       end
 
       unless payout_utils.should_only_notify?

--- a/app/services/payout/service.rb
+++ b/app/services/payout/service.rb
@@ -31,6 +31,11 @@ module Payout
         return true
       end
 
+      if !@publisher.has_deposit_address?
+        create_message("Publisher has no deposit address for wallet")
+        return true
+      end
+
       if @publisher.excluded_from_payout?
         create_message("Publisher has been marked as excluded from payout")
         return true

--- a/app/services/payout/uphold_service.rb
+++ b/app/services/payout/uphold_service.rb
@@ -11,39 +11,20 @@ module Payout
         uphold_connection.create_uphold_cards
         # Reload the connection because create_uphold_cards modifies the database records.
         uphold_connection.reload
+        # also reload publisher so it doesn't keep old references around
+        @publisher.reload
       end
 
-      # Create the referral payment for the owner
-      potential_payments << PotentialPayment.new(
-        payout_report_id: @payout_report&.id,
-        name: @publisher.name,
-        amount: "0",
-        fees: "0",
-        publisher_id: @publisher.id,
-        kind: ::PotentialPayment::REFERRAL,
-        address: "#{uphold_connection.address}",
-        uphold_status: uphold_connection.status,
-        reauthorization_needed: uphold_connection.uphold_access_parameters.blank?,
-        uphold_member: uphold_connection.is_member?,
-        uphold_id: uphold_connection.uphold_id,
-        wallet_provider_id: uphold_connection.uphold_id,
-        wallet_provider: ::PotentialPayment.wallet_providers['uphold'],
-        suspended: @publisher.suspended?,
-        status: @publisher.last_status_update&.status
-      )
-
-      # Create potential payments for channel contributions
-      @publisher.channels.verified.each do |channel|
+      if uphold_connection.referral_deposit_address.present?
+        # Create the referral payment for the owner
         potential_payments << PotentialPayment.new(
           payout_report_id: @payout_report&.id,
-          name: "#{channel.publication_title}",
+          name: @publisher.name,
           amount: "0",
           fees: "0",
           publisher_id: @publisher.id,
-          channel_id: channel.id,
-          kind: ::PotentialPayment::CONTRIBUTION,
-          address: "#{uphold_connection.address}",
-          url: "#{channel.details.url}",
+          kind: ::PotentialPayment::REFERRAL,
+          address: "#{uphold_connection.referral_deposit_address}",
           uphold_status: uphold_connection.status,
           reauthorization_needed: uphold_connection.uphold_access_parameters.blank?,
           uphold_member: uphold_connection.is_member?,
@@ -51,10 +32,35 @@ module Payout
           wallet_provider_id: uphold_connection.uphold_id,
           wallet_provider: ::PotentialPayment.wallet_providers['uphold'],
           suspended: @publisher.suspended?,
-          status: @publisher.last_status_update&.status,
-          channel_stats: channel.details.stats,
-          channel_type: channel.details_type
+          status: @publisher.last_status_update&.status
         )
+      end
+
+      # Create potential payments for channel contributions
+      @publisher.channels.verified.each do |channel|
+        if channel.channel_deposit_address.present?
+          potential_payments << PotentialPayment.new(
+            payout_report_id: @payout_report&.id,
+            name: "#{channel.publication_title}",
+            amount: "0",
+            fees: "0",
+            publisher_id: @publisher.id,
+            channel_id: channel.id,
+            kind: ::PotentialPayment::CONTRIBUTION,
+            address: "#{channel.channel_deposit_address}",
+            url: "#{channel.details.url}",
+            uphold_status: uphold_connection.status,
+            reauthorization_needed: uphold_connection.uphold_access_parameters.blank?,
+            uphold_member: uphold_connection.is_member?,
+            uphold_id: uphold_connection.uphold_id,
+            wallet_provider_id: uphold_connection.uphold_id,
+            wallet_provider: ::PotentialPayment.wallet_providers['uphold'],
+            suspended: @publisher.suspended?,
+            status: @publisher.last_status_update&.status,
+            channel_stats: channel.details.stats,
+            channel_type: channel.details_type
+          )
+        end
       end
 
       unless should_only_notify?

--- a/test/fixtures/gemini_connections.yml
+++ b/test/fixtures/gemini_connections.yml
@@ -12,6 +12,7 @@ gemini_in_japan_connection:
 connection_with_token:
   publisher: gemini_completed
   is_verified: true
+  recipient_id: <%= SecureRandom.uuid %>
   <% salt = SecureRandom.random_bytes(12) %>
   encrypted_access_token:  "<%= TotpRegistration.encrypt_secret(
     'access_token',
@@ -29,6 +30,26 @@ connection_with_token:
 
 connection_not_verified:
   publisher: gemini_not_completed
+  is_verified: false
+  recipient_id: <%= SecureRandom.uuid %>
+  status: 'Active'
+  <% salt = SecureRandom.random_bytes(12) %>
+  encrypted_access_token:  "<%= TotpRegistration.encrypt_secret(
+    'access_token',
+    key: GeminiConnection.new.send(:encryption_key),
+    iv: salt
+  ) %>"
+  encrypted_access_token_iv: "<%= Base64.encode64(salt) %>"
+  encrypted_refresh_token:  "<%= TotpRegistration.encrypt_secret(
+    'access_token',
+    key: GeminiConnection.new.send(:encryption_key),
+    iv: salt
+  ) %>"
+  encrypted_refresh_token_iv: "<%= Base64.encode64(salt) %>"
+
+
+connection_not_verified_no_address:
+  publisher: gemini_not_completed_no_address
   is_verified: false
   status: 'Active'
   <% salt = SecureRandom.random_bytes(12) %>

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -73,6 +73,16 @@ gemini_not_completed:
   agreed_to_tos: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= DateTime.now %>"
   subscribed_to_marketing_emails: true
+  selected_wallet_provider: connection_not_verified (GeminiConnection)
+
+gemini_not_completed_no_address:
+  email: "gemini_not_address@completed.org"
+  name: "Gemini the Completed No Address"
+  two_factor_prompted_at: "<%= 1.day.ago %>"
+  agreed_to_tos: "<%= 1.day.ago %>"
+  default_currency_confirmed_at: "<%= DateTime.now %>"
+  subscribed_to_marketing_emails: true
+  selected_wallet_provider: connection_not_verified_no_address (GeminiConnection)
 
 gemini_suspended:
   email: "gemini_suspended@completed.org"
@@ -81,6 +91,7 @@ gemini_suspended:
   agreed_to_tos: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= DateTime.now %>"
   subscribed_to_marketing_emails: true
+  selected_wallet_provider: suspended_gemini_connection (GeminiConnection)
 
 uphold_in_japan:
   email: "uphold_in_japan@completed.org"
@@ -144,6 +155,7 @@ fake1:
   email: "alice@fake.org"
   name: "Fake Alice"
   agreed_to_tos: "<%= 1.day.ago %>"
+  selected_wallet_provider: fake1_connection (UpholdConnection)
 
 fake2:
   email: "bob@fake.org"
@@ -169,6 +181,7 @@ uphold_connected_reauthorize:
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
+  selected_wallet_provider: connected_reauthorize (UpholdConnection)
 
 uphold_connected_details:
   email: "alice@upholdconnecteddetails.org"
@@ -184,6 +197,7 @@ uphold_connected_blocked:
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
+  selected_wallet_provider: blocked_connection (UpholdConnection)
 
 uphold_connected_restricted_member:
   email: "restricted@upholdconnected.org"
@@ -191,6 +205,7 @@ uphold_connected_restricted_member:
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
+  selected_wallet_provider: restricted_member (UpholdConnection)
 
 uphold_connected_currency_unconfirmed:
   email: "carol@upholdconnected.org"
@@ -203,6 +218,7 @@ youtube_initial:
   email: "alice@spud.com"
   name: "Alice the Youtuber"
   agreed_to_tos: "<%= 1.day.ago %>"
+  selected_wallet_provider: youtube_initial_connection (UpholdConnection)
 
 youtube_new:
   email: "alice2@spud.com"
@@ -275,6 +291,7 @@ suspended:
   name: "Susan the suspended"
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
+  selected_wallet_provider: suspended_connection (UpholdConnection)
 
 # Has one verified channel, and one unverified channel
 partially_completed:
@@ -324,6 +341,7 @@ promo_lockout:
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
+  selected_wallet_provider: promo_lockout_connection (UpholdConnection)
 
 publisher_selected_wallet_provider:
   email: "provider@brave.com"
@@ -342,7 +360,7 @@ bitflyer_enabled:
   two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
   feature_flags: <%= { UserFeatureFlags::BITFLYER_ENABLED => true }.to_json %>
-  selected_wallet_provider: enabled_bitflyer_connection (BitflyerConnection)
+  selected_wallet_provider: connection_with_token (BitflyerConnection)
 
 bitflyer_not_enabled:
   email: "bitflyer_not_enabled@brave.com"

--- a/test/fixtures/uphold_connections.yml
+++ b/test/fixtures/uphold_connections.yml
@@ -24,10 +24,12 @@ unconnected:
 
 suspended_connection:
   publisher: suspended
+  address: <%= SecureRandom.uuid %>
   is_member: true
 
 youtube_initial_connection:
   publisher: youtube_initial
+  address: <%= SecureRandom.uuid %>
   uphold_verified: true
   encrypted_uphold_access_parameters: "<%= TotpRegistration.encrypt_secret(
     '{}',
@@ -121,6 +123,7 @@ details_connection:
 
 blocked_connection:
   status: blocked
+  address: <%= SecureRandom.uuid %>
   publisher: uphold_connected_blocked
   encrypted_uphold_access_parameters:  "<%= TotpRegistration.encrypt_secret(
     { scope: 'cards:write' }.to_json,
@@ -183,3 +186,7 @@ promo_lockout_connection:
 selected_wallet_provider_connection:
   <<: *base_verified_connection
   publisher: publisher_selected_wallet_provider
+
+fake1_connection:
+  <<: *base_verified_connection
+  publisher: fake1

--- a/test/mailers/publisher_mailer_test.rb
+++ b/test/mailers/publisher_mailer_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class PublisherMailerTest < ActionMailer::TestCase
-
   before do
     @prev_eyeshade_offline = Rails.application.secrets[:api_eyeshade_offline]
   end
@@ -11,7 +10,7 @@ class PublisherMailerTest < ActionMailer::TestCase
   end
 
   test "wallet_not_connected" do
-    publisher = publishers(:youtube_initial)
+    publisher = publishers(:youtube_new)
     email = PublisherMailer.wallet_not_connected(publisher, 750.0)
 
     assert_emails 1 do

--- a/test/models/gemini_connection_test.rb
+++ b/test/models/gemini_connection_test.rb
@@ -5,7 +5,6 @@ require "webmock/minitest"
 class GeminiConnectionTest < ActiveSupport::TestCase
   include MockGeminiResponses
 
-
   describe 'validations' do
     let(:gemini_connection) { gemini_connections(:default_connection) }
 
@@ -52,7 +51,7 @@ class GeminiConnectionTest < ActiveSupport::TestCase
     let(:subject) { connection.sync_connection! }
 
     describe 'when a connection is not payable' do
-      let(:connection) { gemini_connections(:connection_not_verified) }
+      let(:connection) { gemini_connections(:connection_not_verified_no_address) }
       before do
         mock_gemini_unverified_account_request!
       end

--- a/test/services/payout/gemini_job_implementation_test.rb
+++ b/test/services/payout/gemini_job_implementation_test.rb
@@ -7,9 +7,9 @@ class GeminiJobImplementationTest < ActiveSupport::TestCase
     gemini_in_japan = publishers(:gemini_in_japan)
     assert gemini_in_japan.selected_wallet_provider.japanese_account?
     mock_report_job = mock
-    mock_report_job.expects(:perform_async).with { |*args|
+    mock_report_job.expects(:perform_async).with do |*args|
       refute Publisher.find(args[0][:publisher_id]).gemini_connection.japanese_account?
-    }
+    end.at_least_once
     gemini_job = Payout::GeminiJobImplementation.new(payout_report_job: mock_report_job)
     gemini_job.call
   end

--- a/test/services/payout/gemini_service_test.rb
+++ b/test/services/payout/gemini_service_test.rb
@@ -41,24 +41,15 @@ class GeminiServiceTest < ActiveJob::TestCase
   end
 
   describe 'when a gemini connection is not verified' do
-    let(:publisher) { publishers(:gemini_not_completed) }
+    let(:publisher) { publishers(:gemini_not_completed_no_address) }
 
     before do
       mock_gemini_unverified_account_request!
       subject
     end
 
-    it 'creates potential payments for the right publisher' do
-      refute_equal PotentialPayment.count, 0
-      PotentialPayment.all.each { |pp| assert_equal publisher.id, pp.publisher_id }
-    end
-
-    it 'has all payments marked as not verified' do
-      refute PotentialPayment.all.any? { |pp| pp.gemini_is_verified }
-    end
-
-    it 'the address is empty' do
-      refute PotentialPayment.all.any? { |pp| pp.address.present? }
+    it 'creates no Potential Payments' do
+      assert_equal PotentialPayment.count, 0
     end
   end
 
@@ -81,7 +72,7 @@ class GeminiServiceTest < ActiveJob::TestCase
     end
 
     it 'the address is the recipient id' do
-      PotentialPayment.all.each { |pp| assert_equal pp.wallet_provider_id, '5f0cdc2f-622b-4c30-ad9f-3a5e6dc85079' }
+      PotentialPayment.all.each { |pp| assert_equal pp.wallet_provider_id, publisher.selected_wallet_provider.referral_deposit_address }
     end
   end
 end

--- a/test/services/payout/uphold_service_test.rb
+++ b/test/services/payout/uphold_service_test.rb
@@ -28,8 +28,8 @@ class UpholdServiceTest < ActiveJob::TestCase
     let(:subject) do
       perform_enqueued_jobs do
         Payout::UpholdService.new(payout_report: PayoutReport.create(expected_num_payments: PayoutReport.expected_num_payments(Publisher.all)),
-                                          publisher: publisher,
-                                          should_send_notifications: true).perform
+                                  publisher: publisher,
+                                  should_send_notifications: true).perform
       end
     end
 
@@ -46,8 +46,8 @@ class UpholdServiceTest < ActiveJob::TestCase
     let(:subject) do
       perform_enqueued_jobs do
         Payout::UpholdService.new(payout_report: PayoutReport.create(expected_num_payments: PayoutReport.expected_num_payments(Publisher.all)),
-                                          publisher: publisher,
-                                          should_send_notifications: true).perform
+                                  publisher: publisher,
+                                  should_send_notifications: true).perform
       end
     end
 
@@ -65,8 +65,8 @@ class UpholdServiceTest < ActiveJob::TestCase
     let (:subject) do
       perform_enqueued_jobs do
         Payout::UpholdService.new(payout_report: @payout_report,
-                                          publisher: publisher,
-                                          should_send_notifications: false).perform
+                                  publisher: publisher,
+                                  should_send_notifications: false).perform
       end
     end
 
@@ -75,22 +75,22 @@ class UpholdServiceTest < ActiveJob::TestCase
         {
           account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
           account_type: "owner",
-          balance: "20.00"
+          balance: "20.00",
         },
         {
           account_id: "uphold_connected.org",
           account_type: "channel",
-          balance: "20.00"
+          balance: "20.00",
         },
         {
           account_id: "twitch#author:ucTw",
           account_type: "channel",
-          balance: "20.00"
+          balance: "20.00",
         }, {
           account_id: "twitter#channel:def456",
           account_type: "channel",
-          balance: "20.00"
-        }
+          balance: "20.00",
+        },
       ]
     end
 
@@ -104,7 +104,7 @@ class UpholdServiceTest < ActiveJob::TestCase
       subject
     end
 
-   it "creates the potential payments" do
+    it "creates the potential payments" do
       assert_equal 4, PotentialPayment.count
     end
 
@@ -126,8 +126,8 @@ class UpholdServiceTest < ActiveJob::TestCase
     let(:subject) do
       perform_enqueued_jobs do
         Payout::UpholdService.new(payout_report: @payout_report,
-                                          publisher: publisher,
-                                          should_send_notifications: false).perform
+                                  publisher: publisher,
+                                  should_send_notifications: false).perform
       end
     end
 
@@ -136,22 +136,22 @@ class UpholdServiceTest < ActiveJob::TestCase
         {
           account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
           account_type: "owner",
-          balance: "20.00"
+          balance: "20.00",
         },
         {
           account_id: "uphold_connected_blocked.org",
           account_type: "channel",
-          balance: "20.00"
+          balance: "20.00",
         },
         {
           account_id: "twitch#author:blocked",
           account_type: "channel",
-          balance: "20.00"
+          balance: "20.00",
         }, {
           account_id: "twitter#channel:blocked",
           account_type: "channel",
-          balance: "20.00"
-        }
+          balance: "20.00",
+        },
       ]
     end
 
@@ -176,7 +176,7 @@ class UpholdServiceTest < ActiveJob::TestCase
           assert_equal "0", potential_payment.fees
           assert_equal 'uphold', potential_payment.wallet_provider # uphold enum
         elsif potential_payment.kind == PotentialPayment::CONTRIBUTION
-          assert_equal  "0", potential_payment.fees
+          assert_equal "0", potential_payment.fees
           assert_equal 'uphold', potential_payment.wallet_provider # uphold enum
         end
       end
@@ -202,28 +202,28 @@ class UpholdServiceTest < ActiveJob::TestCase
           {
             account_id: "publishers#uuid:2fcb973c-7f7c-5351-809f-0eed1de17a77",
             account_type: "owner",
-            balance: "500.00"
+            balance: "500.00",
           },
           {
             account_id: "youtube#channel:",
             account_type: "channel",
-            balance: "500.00"
-          }
+            balance: "500.00",
+          },
         ]
       end
 
       let(:subject) do
         perform_enqueued_jobs do
           Payout::UpholdService.new(payout_report: PayoutReport.create(expected_num_payments: PayoutReport.expected_num_payments(Publisher.all)),
-                                            publisher: publisher,
-                                            should_send_notifications: should_send_notifications).perform
+                                    publisher: publisher,
+                                    should_send_notifications: should_send_notifications).perform
         end
       end
 
       before do
         Rails.application.secrets[:api_eyeshade_offline] = false
         stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
-        stub_request(:get, uphold_url).to_return(body: { }.to_json)
+        stub_request(:get, uphold_url).to_return(body: {}.to_json)
 
         subject
       end
@@ -350,8 +350,8 @@ class UpholdServiceTest < ActiveJob::TestCase
               it "does not create any extra payments" do
                 assert_difference -> { PotentialPayment.count }, 0 do
                   Payout::UpholdService.new(payout_report: @payout_report,
-                                                    publisher: publisher,
-                                                    should_send_notifications: should_send_notifications).perform
+                                            publisher: publisher,
+                                            should_send_notifications: should_send_notifications).perform
                 end
               end
 
@@ -381,7 +381,7 @@ class UpholdServiceTest < ActiveJob::TestCase
 
             it "has the correct content" do
               PotentialPayment.where(payout_report_id: @payout_report.id).each do |potential_payment|
-                assert_equal potential_payment.address, publisher.uphold_connection.address
+                assert_equal potential_payment.address, Publisher.find(publisher.id).uphold_connection.address
                 assert_equal potential_payment.publisher_id, publisher.id.to_s
               end
             end
@@ -389,8 +389,8 @@ class UpholdServiceTest < ActiveJob::TestCase
             it "does not create any extra payments" do
               assert_difference -> { PotentialPayment.count }, 0 do
                 Payout::UpholdService.new(payout_report: @payout_report,
-                                                  publisher: publisher,
-                                                  should_send_notifications: should_send_notifications).perform
+                                          publisher: publisher,
+                                          should_send_notifications: should_send_notifications).perform
               end
             end
           end
@@ -399,7 +399,7 @@ class UpholdServiceTest < ActiveJob::TestCase
             let(:publisher) { publishers(:promo_lockout) }
 
             before do
-              publisher.update(feature_flags: { UserFeatureFlags::PROMO_LOCKOUT_TIME => 3.days.from_now } )
+              publisher.update(feature_flags: { UserFeatureFlags::PROMO_LOCKOUT_TIME => 3.days.from_now })
               Rails.application.secrets[:api_eyeshade_offline] = false
               stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
               subject
@@ -417,131 +417,130 @@ class UpholdServiceTest < ActiveJob::TestCase
           end
         end
 
-
-      describe "without balance" do
-        let(:balance_response) do
+        describe "without balance" do
+          let(:balance_response) do
             [
               {
                 account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
                 account_type: "owner",
-                balance: "0.00"
+                balance: "0.00",
               },
               {
                 account_id: "uphold_connected_details.org",
                 account_type: "channel",
-                balance: "0.00"
+                balance: "0.00",
               },
               {
                 account_id: "twitch#author:ucTw",
                 account_type: "channel",
-                balance: "0.00"
+                balance: "0.00",
               }, {
                 account_id: "twitter#channel:def456",
                 account_type: "channel",
-                balance: "0.00"
-              }
+                balance: "0.00",
+              },
             ]
           end
-        let(:should_send_notifications) { true }
-        let(:publisher) { publishers(:uphold_connected_details) }
-
-        before do
-          Rails.application.secrets[:fee_rate] = 0.05
-          Rails.application.secrets[:api_eyeshade_offline] = false
-          @payout_report = PayoutReport.create(fee_rate: 0.05, expected_num_payments: PayoutReport.expected_num_payments(Publisher.all))
-          stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
-          subject
-        end
-
-        it "is not included in the payout report" do
-          assert_equal 4, PotentialPayment.count
-          assert_equal 0, @payout_report.amount
-        end
-
-        it "recieves no emails" do
-          assert_empty ActionMailer::Base.deliveries
-        end
-      end
-    end
-
-    describe "without address" do
-      describe "with balance" do
-        let(:balance_response) do
-          [
-            {
-              account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
-              account_type: "owner",
-              balance: "20.00"
-            },
-            {
-              account_id: "uphold_connected_details.org",
-              account_type: "channel",
-              balance: "20.00"
-            },
-            {
-              account_id: "twitch#author:restricted_member",
-              account_type: "channel",
-              balance: "20.00"
-            }, {
-              account_id: "twitter#channel:restrcted_member",
-              account_type: "channel",
-              balance: "20.00"
-            }
-          ]
-        end
-
-        before do
-          Rails.application.secrets[:fee_rate] = 0.05
-          Rails.application.secrets[:api_eyeshade_offline] = false
-          @payout_report = PayoutReport.create(fee_rate: 0.05, expected_num_payments: PayoutReport.expected_num_payments(Publisher.all))
-          stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
-        end
-
-        # Technically this path would only be possible if the user was restricted
-        #  eyeshade omits the wallet address if the status is not ok
-        describe "is a member and restricted" do
-          let(:publisher) { publishers(:uphold_connected_restricted_member) }
+          let(:should_send_notifications) { true }
+          let(:publisher) { publishers(:uphold_connected_details) }
 
           before do
+            Rails.application.secrets[:fee_rate] = 0.05
+            Rails.application.secrets[:api_eyeshade_offline] = false
+            @payout_report = PayoutReport.create(fee_rate: 0.05, expected_num_payments: PayoutReport.expected_num_payments(Publisher.all))
             stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
-            stub_request(:get, uphold_url).to_return(body: { status: "restricted", memberAt: "2019" }.to_json)
+            subject
           end
 
-          describe "should_send_notifications is true" do
-            let(:should_send_notifications) { true }
-
-            before do
-              subject
-            end
-
-            it "it creates potential payments" do
-              assert_equal 4, PotentialPayment.count
-              assert_equal 0, @payout_report.amount
-            end
-
-            it "does not include them in payout report json" do
-              @payout_report.update_report_contents
-              assert_equal 0, JSON.parse(@payout_report.contents).length
-            end
+          it "is not included in the payout report" do
+            assert_equal 4, PotentialPayment.count
+            assert_equal 0, @payout_report.amount
           end
 
-          describe "should_send_notifications is false" do
-            let(:should_send_notifications) { false }
-
-            before do
-              subject
-            end
-
-            it "creates payments" do
-              assert_equal 4, PotentialPayment.count
-              assert_equal 0, @payout_report.amount
-            end
-
-            it "does not recieve any emails" do
-              assert_empty ActionMailer::Base.deliveries
-            end
+          it "recieves no emails" do
+            assert_empty ActionMailer::Base.deliveries
           end
         end
+      end
+
+      describe "without address" do
+        describe "with balance" do
+          let(:balance_response) do
+            [
+              {
+                account_id: "publishers#uuid:1a526190-7fd0-5d5e-aa4f-a04cd8550da8",
+                account_type: "owner",
+                balance: "20.00",
+              },
+              {
+                account_id: "uphold_connected_details.org",
+                account_type: "channel",
+                balance: "20.00",
+              },
+              {
+                account_id: "twitch#author:restricted_member",
+                account_type: "channel",
+                balance: "20.00",
+              }, {
+                account_id: "twitter#channel:restrcted_member",
+                account_type: "channel",
+                balance: "20.00",
+              },
+            ]
+          end
+
+          before do
+            Rails.application.secrets[:fee_rate] = 0.05
+            Rails.application.secrets[:api_eyeshade_offline] = false
+            @payout_report = PayoutReport.create(fee_rate: 0.05, expected_num_payments: PayoutReport.expected_num_payments(Publisher.all))
+            stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
+          end
+
+          # Technically this path would only be possible if the user was restricted
+          #  eyeshade omits the wallet address if the status is not ok
+          describe "is a member and restricted" do
+            let(:publisher) { publishers(:uphold_connected_restricted_member) }
+
+            before do
+              stub_all_eyeshade_wallet_responses(publisher: publisher, balances: balance_response)
+              stub_request(:get, uphold_url).to_return(body: { status: "restricted", memberAt: "2019" }.to_json)
+            end
+
+            describe "should_send_notifications is true" do
+              let(:should_send_notifications) { true }
+
+              before do
+                subject
+              end
+
+              it "it creates potential payments" do
+                assert_equal 4, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it "does not include them in payout report json" do
+                @payout_report.update_report_contents
+                assert_equal 0, JSON.parse(@payout_report.contents).length
+              end
+            end
+
+            describe "should_send_notifications is false" do
+              let(:should_send_notifications) { false }
+
+              before do
+                subject
+              end
+
+              it "creates payments" do
+                assert_equal 4, PotentialPayment.count
+                assert_equal 0, @payout_report.amount
+              end
+
+              it "does not recieve any emails" do
+                assert_empty ActionMailer::Base.deliveries
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Closes #3142

We instead write a message to the database for debugging. Both these
and the potential payments should be rotated out regularly.
