### PR TITLE
Fixing typo in `statements.overview.upholdCardLink`.

### DIFF
--- a/app/javascript/locale/en.ts
+++ b/app/javascript/locale/en.ts
@@ -245,7 +245,7 @@ export default {
         referralSettlement: "Referral Promo Earnings",
         upholdContributionSettlement: "Direct User Tips",
       },
-      upholdCardLink: "https://uphold.com/dashboard/cards/{cardId}/actvity",
+      upholdCardLink: "https://uphold.com/dashboard/cards/{cardId}/activity",
       view: "View",
       viewMore: "View More"
     }


### PR DESCRIPTION
## Fixing typo in `statements.overview.upholdCardLink`.

#### Features

There's a typo in `statements.overview.upholdCardLink` which creates a broken link to Uphold.
Closes https://github.com/brave-intl/publishers/issues/3329.

#### How To Test

Click on the Uphold card link.

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
