### PR TITLE
Don't show displayName for bitflyer accounts

### DIFF
--- a/app/javascript/locale/en.ts
+++ b/app/javascript/locale/en.ts
@@ -265,7 +265,7 @@ export default {
       description: "Connect a crypto wallet to receive contributions and other payments.",
       title: "Wallet for BAT Payment"
     },
-    connected: "Connected <span>{displayName}</span>",
+    connected: "Connected",
     currencies: {
       description: 'You will receive monthly contributions from your Brave fans in this currency in your account.',
       fees: 'For currency choices other than BAT, This exchange will charge an exchange fee upon deposit. <a>Check fees</a>.',


### PR DESCRIPTION

![Screen Shot 2021-07-26 at 6 36 33 PM](https://user-images.githubusercontent.com/8647607/127081042-74b83070-991e-433f-ba24-85e85f3771d7.png)


Closes https://github.com/brave-intl/publishers/issues/3327