### PR TITLE
Allow referral emails to be sent as disabled, the previous day, or

### DIFF
--- a/app/models/concerns/user_feature_flags.rb
+++ b/app/models/concerns/user_feature_flags.rb
@@ -25,6 +25,11 @@ module UserFeatureFlags
     REFERRAL_ENABLED_OVERRIDE,
   ].freeze
 
+  # Values stored in DAILY_EMAILS_FOR_PROMO_STATS
+  DISABLED = "disabled".freeze
+  PREVIOUS_DAY = "previous_day".freeze
+  MONTH_TO_DATE = "month_to_date".freeze
+
   included do
     scope :daily_emails_for_promo_stats, -> { where("feature_flags->'#{DAILY_EMAILS_FOR_PROMO_STATS}' = 'true'") }
     scope :wire_only,      -> { where("feature_flags->'#{WIRE_ONLY}' = 'true'") }
@@ -93,7 +98,11 @@ module UserFeatureFlags
   end
 
   def has_daily_emails_for_promo_stats?
-    feature_flags.symbolize_keys[DAILY_EMAILS_FOR_PROMO_STATS].present?
+    feature_flags.symbolize_keys[DAILY_EMAILS_FOR_PROMO_STATS].present? && feature_flags.symbolize_keys[DAILY_EMAILS_FOR_PROMO_STATS] != DISABLED
+  end
+
+  def receives_mtd_promo_emails?
+    feature_flags.symbolize_keys[DAILY_EMAILS_FOR_PROMO_STATS] == MONTH_TO_DATE
   end
 
   def allowed_to_create_referrals?

--- a/app/models/concerns/user_feature_flags.rb
+++ b/app/models/concerns/user_feature_flags.rb
@@ -31,7 +31,9 @@ module UserFeatureFlags
   MONTH_TO_DATE = "month_to_date".freeze
 
   included do
-    scope :daily_emails_for_promo_stats, -> { where("feature_flags->'#{DAILY_EMAILS_FOR_PROMO_STATS}' = 'true'") }
+    scope :daily_emails_for_promo_stats, -> {
+      where("(feature_flags->'daily_emails_for_promo_stats')::jsonb ?| array['#{MONTH_TO_DATE}', '#{PREVIOUS_DAY}', 'true']")
+    }
     scope :wire_only,      -> { where("feature_flags->'#{WIRE_ONLY}' = 'true'") }
     scope :invoice,        -> { where("feature_flags->'#{INVOICE}' = 'true'") }
     scope :merchant,       -> { where("feature_flags->'#{MERCHANT}' = 'true'") }

--- a/app/views/admin/publishers/edit.html.slim
+++ b/app/views/admin/publishers/edit.html.slim
@@ -2,8 +2,9 @@
 
 #publisher
   #publisher-section
-    h4.m-0.p-0 Settings
+    h3.m-0.p-0 Settings
     p Toggle settings on or off for this publisher.
+    br
 
     = form_for(@publisher, url: admin_publisher_path, method: :patch) do |f|
       .form-group.border-bottom.pb-2
@@ -25,21 +26,31 @@
           = f.check_box UserFeatureFlags::MERCHANT, {}, checked: @publisher.merchant?
           = " Merchant Feature"
         .text-dark Enables the abililty to create API Keys to interact with SKUs
+
+      h4.m-0.border-bottom.p-0 Referrals Section
       .form-group.border-bottom.pb-2
+        label
+        p.text-dark Sets the date when the publishers promo codes will no longer be active.
+        = "Promo Lockout Time"
+        = f.date_field(UserFeatureFlags::PROMO_LOCKOUT_TIME, value: @publisher.promo_lockout_time, class: 'ml-2')
+      .form-group.border-bottom.pb-2
+        p.text-dark Enforces KYC for users to join the referral promo program.
         label
           = f.check_box UserFeatureFlags::REFERRAL_KYC_REQUIRED, {}, checked: @publisher.referral_kyc_required?
           = " Referral KYC Required"
-        p.text-dark Enforces KYC for users to join the referral promo program.
       .form-group.border-bottom.pb-2
+        p.text-dark Kinds of Daily Emails sent to promoters
         label
-          = "Promo Lockout Time"
-        = f.date_field(UserFeatureFlags::PROMO_LOCKOUT_TIME, value: @publisher.promo_lockout_time, class: 'ml-2')
-        p.text-dark Sets the date when the publishers promo codes will no longer be active.
-      .form-group.border-bottom.pb-2
+          = f.radio_button(UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS, UserFeatureFlags::DISABLED, checked: !@publisher.has_daily_emails_for_promo_stats?)
+          = " Disabled"
+        br
         label
-          = f.check_box UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS, {}, checked: @publisher.has_daily_emails_for_promo_stats?
-          = " Daily Emails for Promo Stats"
-        p.text-dark Sets daily emails for promos
+          = f.radio_button(UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS, UserFeatureFlags::PREVIOUS_DAY, checked: @publisher.has_daily_emails_for_promo_stats? && !@publisher.receives_mtd_promo_emails?)
+          = " Previous day"
+        br
+        label
+          = f.radio_button(UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS, UserFeatureFlags::MONTH_TO_DATE, checked: @publisher.receives_mtd_promo_emails?)
+          = " From start of month to previous day"
       .form-group.border-bottom.pb-2
         label
           = f.check_box UserFeatureFlags::REFERRAL_ENABLED_OVERRIDE, {}, checked: @publisher.allowed_to_create_referrals?

--- a/test/models/concerns/user_feature_flags_test.rb
+++ b/test/models/concerns/user_feature_flags_test.rb
@@ -4,16 +4,21 @@ class UserFeatureFlagsTest < ActiveSupport::TestCase
   it 'would successfully read the previous values for promo stats' do
     publisher = publishers(:default)
     assert_not publisher.has_daily_emails_for_promo_stats?
+    assert_empty Publisher.daily_emails_for_promo_stats
 
     publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => UserFeatureFlags::DISABLED})
     assert_not publisher.has_daily_emails_for_promo_stats?
+    assert_empty Publisher.daily_emails_for_promo_stats
 
     publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => UserFeatureFlags::PREVIOUS_DAY})
     assert publisher.has_daily_emails_for_promo_stats?
+    assert_not_empty Publisher.daily_emails_for_promo_stats
     publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => 'true'}) # previous value
     assert publisher.has_daily_emails_for_promo_stats?
+    assert_not_empty Publisher.daily_emails_for_promo_stats
 
     publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => UserFeatureFlags::MONTH_TO_DATE})
     assert publisher.receives_mtd_promo_emails?
+    assert_not_empty Publisher.daily_emails_for_promo_stats
   end
 end

--- a/test/models/concerns/user_feature_flags_test.rb
+++ b/test/models/concerns/user_feature_flags_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class UserFeatureFlagsTest < ActiveSupport::TestCase
+  it 'would successfully read the previous values for promo stats' do
+    publisher = publishers(:default)
+    assert_not publisher.has_daily_emails_for_promo_stats?
+
+    publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => UserFeatureFlags::DISABLED})
+    assert_not publisher.has_daily_emails_for_promo_stats?
+
+    publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => UserFeatureFlags::PREVIOUS_DAY})
+    assert publisher.has_daily_emails_for_promo_stats?
+    publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => 'true'}) # previous value
+    assert publisher.has_daily_emails_for_promo_stats?
+
+    publisher.update_feature_flags_from_form({UserFeatureFlags::DAILY_EMAILS_FOR_PROMO_STATS => UserFeatureFlags::MONTH_TO_DATE})
+    assert publisher.receives_mtd_promo_emails?
+  end
+end


### PR DESCRIPTION
month-to-previous day.

Closes https://github.com/brave-intl/publishers/issues/3328

