### PR TITLE
Use NULLDB to compile assets when no DB available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN yarn install --frozen-lockfile
 # The second dot will copy it to the WORKDIR!
 COPY . .
 
-RUN bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile DB_ADAPTER=nulldb DATABASE_URL='nulldb://nohost'
 
 EXPOSE 3000
 ENTRYPOINT [ "./scripts/entrypoint.sh" ]

--- a/Gemfile
+++ b/Gemfile
@@ -201,6 +201,8 @@ group :development, :test do
   gem 'selenium-webdriver', "~> 3.142.0"
   gem 'solargraph'
   gem 'dotenv-rails', "2.7.6"
+
+  gem 'activerecord-nulldb-adapter', git: 'https://github.com/tsmartt/nulldb.git', branch: 'tsmartt-patch-1'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -202,7 +202,7 @@ group :development, :test do
   gem 'solargraph'
   gem 'dotenv-rails', "2.7.6"
 
-  gem 'activerecord-nulldb-adapter'
+  gem 'activerecord-nulldb-adapter', "0.7.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -202,7 +202,7 @@ group :development, :test do
   gem 'solargraph'
   gem 'dotenv-rails', "2.7.6"
 
-  gem 'activerecord-nulldb-adapter', git: 'https://github.com/brave-intl/nulldb.git', branch: 'tsmartt-patch-1'
+  gem 'activerecord-nulldb-adapter'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -202,7 +202,7 @@ group :development, :test do
   gem 'solargraph'
   gem 'dotenv-rails', "2.7.6"
 
-  gem 'activerecord-nulldb-adapter', git: 'https://github.com/tsmartt/nulldb.git', branch: 'tsmartt-patch-1'
+  gem 'activerecord-nulldb-adapter', git: 'https://github.com/brave-intl/nulldb.git', branch: 'tsmartt-patch-1'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/brave-intl/nulldb.git
+  revision: 1db1ff143f8c05e8aee80e02e8597b8f97ae96f1
+  branch: tsmartt-patch-1
+  specs:
+    activerecord-nulldb-adapter (0.7.0)
+      activerecord (>= 5.2.0, < 6.3)
+
+GIT
   remote: https://github.com/dlipeles/omniauth-reddit.git
   revision: a9abff8c5a6de217811945dc6f2949d26debfb29
   branch: master
@@ -15,14 +23,6 @@ GIT
       activesupport (>= 3.0, < 7.0)
       rest-client
       xml-simple
-
-GIT
-  remote: https://github.com/tsmartt/nulldb.git
-  revision: 158c7e7fc5fb09d7e777589a6b9a1197e4c87ccc
-  branch: tsmartt-patch-1
-  specs:
-    activerecord-nulldb-adapter (0.7.0)
-      activerecord (>= 5.2.0, < 6.3)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,7 +561,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
-  activerecord-nulldb-adapter
+  activerecord-nulldb-adapter (= 0.7.0)
   activerecord-session_store (~> 2.0)
   activerecord6-redshift-adapter (= 1.2.1)
   addressable (~> 2.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/brave-intl/nulldb.git
-  revision: 1db1ff143f8c05e8aee80e02e8597b8f97ae96f1
-  branch: tsmartt-patch-1
-  specs:
-    activerecord-nulldb-adapter (0.7.0)
-      activerecord (>= 5.2.0, < 6.3)
-
-GIT
   remote: https://github.com/dlipeles/omniauth-reddit.git
   revision: a9abff8c5a6de217811945dc6f2949d26debfb29
   branch: master
@@ -78,6 +70,8 @@ GEM
     activerecord (6.1.3.2)
       activemodel (= 6.1.3.2)
       activesupport (= 6.1.3.2)
+    activerecord-nulldb-adapter (0.7.0)
+      activerecord (>= 5.2.0, < 6.3)
     activerecord-session_store (2.0.0)
       actionpack (>= 5.2.4.1)
       activerecord (>= 5.2.4.1)
@@ -567,7 +561,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
-  activerecord-nulldb-adapter!
+  activerecord-nulldb-adapter
   activerecord-session_store (~> 2.0)
   activerecord6-redshift-adapter (= 1.2.1)
   addressable (~> 2.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,14 @@ GIT
       rest-client
       xml-simple
 
+GIT
+  remote: https://github.com/tsmartt/nulldb.git
+  revision: 158c7e7fc5fb09d7e777589a6b9a1197e4c87ccc
+  branch: tsmartt-patch-1
+  specs:
+    activerecord-nulldb-adapter (0.7.0)
+      activerecord (>= 5.2.0, < 6.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -158,7 +166,7 @@ GEM
       nokogiri (~> 1.8)
     chunky_png (1.4.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
@@ -559,6 +567,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
+  activerecord-nulldb-adapter!
   activerecord-session_store (~> 2.0)
   activerecord6-redshift-adapter (= 1.2.1)
   addressable (~> 2.8)

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@
 # https://github.com/rails/rails/blob/3df3d80ade705dd096ec481845ff0fc2d70427b0/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml
 
 default: &default
-  adapter: postgresql
+  adapter: <%= ENV['DB_ADAPTER'] ||= 'postgresql' %>
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 

--- a/config/initializers/add_column_types_to_null_db.rb
+++ b/config/initializers/add_column_types_to_null_db.rb
@@ -1,0 +1,4 @@
+class ActiveRecord::ConnectionAdapters::NullDBAdapter::TableDefinition
+  alias_method :serial, :integer
+  alias_method :inet, :string
+end


### PR DESCRIPTION
The monkey patch we introduced for rotating attr-encrypted fields
causes the deploy to fail since when we go to precompile assets,
we need to connect to the DB. There is no DB at that point, so use
a fake one.
