### PR TITLE
Show date for CSV

### DIFF
--- a/app/jobs/promo/email_breakdowns_job.rb
+++ b/app/jobs/promo/email_breakdowns_job.rb
@@ -23,12 +23,11 @@ class Promo::EmailBreakdownsJob
     csv.each do |row|
       row = row.dup
       row.delete_at(5) # delete the 30-day-confirmation column
-      row.delete_at(2) # delete Day column
       if header
         row << "Confirmations received"
         header = false
       else
-        row << total_for_date(date: 1.days.ago.to_date,
+        row << total_for_date(date: row[2].to_date,
                               referral_code: row[0],
                               country: "\"" + (row[1] || "") + "\"",
                               publisher_id: publisher_id)


### PR DESCRIPTION
To support month-to-date, we should show the date column rather than just hiding it. 

Furthermore, fix an issue where when we got confirmations, we didn't include the data from 30 days ago for that particular date in the CSV's row.