### PR TITLE
Fix double locked publisher status

### DIFF
--- a/app/jobs/two_factor_authentication_removal_job.rb
+++ b/app/jobs/two_factor_authentication_removal_job.rb
@@ -32,8 +32,7 @@ class TwoFactorAuthenticationRemovalJob < ApplicationJob
         # Return publisher to previous state.
         ActiveRecord::Base.transaction do
           if publisher.locked?
-            # Status_updates is sorted by entry, first is "locked", second is the status the publisher was in before
-            previous_status = publisher.status_updates&.second&.status || PublisherStatusUpdate::ACTIVE
+            previous_status = publisher.status_updates.select { |status_update| status_update.status != PublisherStatusUpdate::LOCKED }.first.status
             publisher.status_updates.create(status: previous_status)
           end
 

--- a/lib/tasks/database_updates/reset_permalocked_users.rake
+++ b/lib/tasks/database_updates/reset_permalocked_users.rake
@@ -1,0 +1,18 @@
+namespace :database_updates do
+  desc 'Reset Permalocked users'
+  task :reset_permalocked_users => :environment do
+    publisher_ids = []
+    PublisherStatusUpdate.select(:status, :publisher_id).where(status: "locked").group(:publisher_id, :status).having("count(*) > 1").each do |psu|
+      publisher_ids.append(psu.publisher_id)
+    end
+
+    publisher_ids -= TwoFactorAuthenticationRemoval.pluck(:publisher_id)
+
+    Publisher.includes(:status_updates).where(id: publisher_ids).find_each do |publisher|
+      if publisher.locked?
+        previous_status = publisher.status_updates.select { |status_update| status_update.status != PublisherStatusUpdate::LOCKED }.first.status
+        publisher.status_updates.create(status: previous_status)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix an issue where a user could be put in a permanent "locked" state after resetting their 2FA twice.

Closes https://github.com/brave-intl/publishers/issues/3387