### PR TITLE
Fix codeql alerts and prepare to enforce trusted types

### DIFF
--- a/app/javascript/modal.js
+++ b/app/javascript/modal.js
@@ -84,7 +84,7 @@ var MODAL_SHOW_CLASS = "modal-show";
  * On demand open a modal.
  */
 self.openModal = function openModal(
-  html,
+  template,
   confirmCallback,
   denyCallback,
   identifier
@@ -93,7 +93,7 @@ self.openModal = function openModal(
   var contentElement = modalElement.querySelector(".modal-panel--content");
   var containerElement = modalElement.querySelector(".modal-container");
 
-  contentElement.innerHTML = html;
+  contentElement.innerHTML = template.innerHTML;
 
   let identifierClass =
     identifier && `modal-container--modal-identifier--${identifier}`;
@@ -164,7 +164,7 @@ function confirmWithModal(confirmableLink) {
   var template = document.getElementById(identifier);
 
   openModal(
-    template.innerHTML,
+    template,
     function() {
       confirmableLink.setAttribute("data-user-verified", "");
       confirmableLink.click();
@@ -195,7 +195,7 @@ function detectModals() {
   var modalTemplate = document.getElementById("js-open-modal-on-load");
   if (modalTemplate) {
     openModal(
-      modalTemplate.innerHTML,
+      modalTemplate,
       function() {},
       function() {
         modalTemplate.parentNode.removeChild(modalTemplate);

--- a/app/javascript/packs/admin_case.js
+++ b/app/javascript/packs/admin_case.js
@@ -1,4 +1,5 @@
 import Rails from "@rails/ujs";
+import DOMPurify from 'dompurify';
 
 const shiftClick = () => {
   // get array of items
@@ -83,9 +84,11 @@ function selected(e) {
 
   event.target.value = "";
 
-  const assignedHTML = `<div class="text-dark">${
+  const assignedHTML = DOMPurify.sanitize(`<div class="text-dark">${
     e.detail.item.original.key
-  }</div>`;
+  }</div>`, {
+    RETURN_TRUSTED_TYPE: true
+  });
 
   assignCheckboxes(e, event.target, assignedHTML);
 

--- a/app/javascript/packs/case.jsx
+++ b/app/javascript/packs/case.jsx
@@ -76,8 +76,8 @@ document.body.addEventListener("ajax:before", function(event) {
 document.body.addEventListener("ajax:error", function(event) {
   const errorMessage = document.createElement("div");
   errorMessage.classList = "mt-3 alert alert-warning";
-  errorMessage.innerHTML =
-    'An unknown error occurred 😳. Try refreshing the page or letting a team member know at <a href="community.brave.com">the Brave Community</a>';
+  errorMessage.innerText =
+    'An unknown error occurred 😳. Try refreshing the page or letting a team member know on https://community.brave.com.';
 
   const form = document.querySelector("form");
   form.appendChild(errorMessage);

--- a/app/javascript/publishers/home.js
+++ b/app/javascript/publishers/home.js
@@ -70,7 +70,7 @@ document.addEventListener("DOMContentLoaded", function() {
           '[data-js-channel-removal-confirmation-template="' + channelId + '"]'
         );
         openModal(
-          template.innerHTML,
+          template,
           function() {
             removeChannel(channelId);
           },

--- a/app/javascript/site_channels/siteChannels.js
+++ b/app/javascript/site_channels/siteChannels.js
@@ -1,6 +1,6 @@
 function openFailedVerificationModal() {
   let template = document.querySelector('#verification_failed_modal_wrapper');
-  let closeFn = openModal(template.innerHTML);
+  let closeFn = openModal(template);
 }
 
 function isAVerificationPage(){

--- a/app/javascript/utils/flash.js
+++ b/app/javascript/utils/flash.js
@@ -14,7 +14,7 @@ export default {
     var containerElement = flashElement();
     var messageElement = document.createElement('div');
     messageElement.className = 'alert flash alert-' + type;
-    messageElement.innerHTML = message;
+    messageElement.innerText = message;
     containerElement.appendChild(messageElement);
   },
 

--- a/app/javascript/utils/spinner.js
+++ b/app/javascript/utils/spinner.js
@@ -25,7 +25,16 @@ export default {
       if (!element) {
         element = document.createElement('div');
         element.id = elementId;
-        element.innerHTML = '<div class="cssload-container"><div class="cssload-loading"><i></i><i></i></div></div>';
+
+        const outerDiv = document.createElement('div')
+        outerDiv.setAttribute('class', 'cssload-container')
+        const innerDiv = document.createElement('div')
+        innerDiv.setAttribute('class', 'cssload-loading')
+
+        element.appendChild(outerDiv)
+        outerDiv.appendChild(innerDiv)
+        innerDiv.appendChild(document.createElement('i'))
+        innerDiv.appendChild(document.createElement('i'))
 
         let parentElement;
         if (parentElementOrId) {

--- a/app/javascript/views/walletServices/braveConnection/CurrencySelection.tsx
+++ b/app/javascript/views/walletServices/braveConnection/CurrencySelection.tsx
@@ -86,7 +86,7 @@ const CurrencySelection = (props) => {
           <FormattedMessage
             id="walletServices.currencies.fees"
             values={{
-              a: (chunks) => <a target="_blank" href={props.link}>{chunks}</a>,
+              a: (chunks) => <a target="_blank" rel="noopener noreferrer" href={props.link}>{chunks}</a>,
             }}
           />
           </span>

--- a/app/javascript/views/walletServices/braveConnection/VerifyButton.tsx
+++ b/app/javascript/views/walletServices/braveConnection/VerifyButton.tsx
@@ -10,7 +10,7 @@ export const VerifyButton = (props) => (
       <div className="row align-items-center">
         <small className="col-sm-8 text-dark">{props.children}</small>
         <small className="col-sm-4">
-          <a className="font-weight-bold" target="_blank" href={props.verifyUrl}>
+          <a className="font-weight-bold" target="_blank" rel="noopener noreferrer" href={props.verifyUrl}>
             <FormattedMessage id={"walletServices.verify"} />
           </a>
         </small>

--- a/app/views/publishers/cases/update.js.erb
+++ b/app/views/publishers/cases/update.js.erb
@@ -4,7 +4,7 @@ if(<%= @case.errors.full_messages.length.positive? %>) {
 
   const errorMessage = document.createElement("div");
   errorMessage.classList = "mt-3 alert alert-warning";
-  errorMessage.innerHTML = "<%=@case.errors.full_messages.join(", ") %>";
+  errorMessage.innerText = "<%=@case.errors.full_messages.join(", ") %>";
   const form = document.querySelector("form");
   form.appendChild(errorMessage);
 }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,6 +12,9 @@ Rails.application.config.content_security_policy do |policy|
   policy.script_src  :self, :https
   policy.style_src   :self, :https
 
+  # Enable once updated to Rails 7
+  # policy.require_trusted_types_for "'script'"
+
   # Specify URI for violation reports
   policy.report_uri "/csp-violation-report"
 end

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "brave-ui": "^0.38.0",
     "chart.js": "^2.7.2",
     "clipboard": "^2.0.1",
+    "dompurify": "^2.3.3",
     "is-accessor-descriptor": "3.0.1",
     "js-yaml": "3.13.1",
     "kind-of": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4033,6 +4033,11 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.3.tgz#c1af3eb88be47324432964d8abc75cf4b98d634c"
+  integrity sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==
+
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz"


### PR DESCRIPTION
fixes all the alerts in https://github.com/brave-intl/publishers/security/code-scanning

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
