### PR TITLE
Eager load the polymorphic channel details

### DIFF
--- a/app/jobs/enqueue_publishers_for_payout_job.rb
+++ b/app/jobs/enqueue_publishers_for_payout_job.rb
@@ -27,8 +27,9 @@ class EnqueuePublishersForPayoutJob < ApplicationJob
 
   def enqueue_payout(payout_report:, manual:, publisher_ids:)
     base_publishers = Publisher.strict_loading.includes(
-      :channels,
       :status_updates,
+    ).preload(
+      channels: :details
     )
     filtered_publishers = if publisher_ids.present?
                             base_publishers.where(id: publisher_ids)


### PR DESCRIPTION
This lets us eager load polymorphic associations for when we call `publication_title` in `gemini_service`, `uphold_service`, `bitflyer_service`.

Rails doesn't support polymorphic eager loading through `includes`, only though `preload`.