### PR TITLE
Refresh the Uphold token if authorization expired

### DIFF
--- a/app/services/uphold/refresher.rb
+++ b/app/services/uphold/refresher.rb
@@ -16,7 +16,6 @@ module Uphold
       refresh_token = uphold_connection.refresh_token
 
       return if refresh_token.blank?
-      return if uphold_connection.authorization_expired?
 
       authorization = @impl_refresher.refresh_authorization(uphold_connection)
 

--- a/test/services/uphold/refresher_test.rb
+++ b/test/services/uphold/refresher_test.rb
@@ -19,18 +19,6 @@ class UpholdRefresherTest < ActiveSupport::TestCase
     assert_nil connection.refresh_token
   end
 
-  test 'do not refresh because token too new' do
-    connection = uphold_connections(:google_connection)
-    refute_nil connection.refresh_token
-    refute_equal(connection.reload.refresh_token, '82b0')
-
-    mock_auth = MiniTest::Mock.new.expect(:refresh_authorization, received_from_uphold,
-                                          [connection])
-    refresher = Uphold::Refresher.new(impl_refresher: mock_auth)
-    refresher.call(uphold_connection: connection)
-    refute_equal(connection.reload.refresh_token, '82b0')
-  end
-
   test 'refresh with previously expired token' do
     connection = uphold_connections(:google_connection)
     refute_nil connection.refresh_token


### PR DESCRIPTION
We shouldn't skip refresh if we have an expired auth. That's the whole point of refresh.