### PR TITLE
Uphold don't erase 401

### DIFF
--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -101,10 +101,11 @@ class UpholdConnection < ApplicationRecord
   # TODO should we actually call uphold_user?
 
   def uphold_details
+    sync_connection!
     @user ||= UpholdClient.user.find(self)
   rescue Faraday::ClientError => e
     if e.response&.dig(:status) == 401
-      Rails.logger.info("#{e.response[:body]} for uphold connection #{id}")
+      Rails.logger.fatal("#{e.response[:body]} for uphold connection #{id}")
     else
       raise
     end

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -105,8 +105,6 @@ class UpholdConnection < ApplicationRecord
   rescue Faraday::ClientError => e
     if e.response&.dig(:status) == 401
       Rails.logger.info("#{e.response[:body]} for uphold connection #{id}")
-      update(uphold_access_parameters: nil)
-      nil
     else
       raise
     end


### PR DESCRIPTION
When we check the connection details, we don't sync first, and then we wipe out the details that currently exist. This PR removed the wiping out of details and forces a sync before returning the details.