### PR TITLE
Fix authorization expired

### DIFF
--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -210,7 +210,7 @@ class UpholdConnection < ApplicationRecord
   end
 
   def authorization_expired?
-    authorization_expires_at.present? && authorization_expires_at > Time.zone.now
+    authorization_expires_at.present? && authorization_expires_at < Time.zone.now
   end
 
   # Makes an HTTP Request to Uphold and sychronizes

--- a/app/services/uphold/refresher.rb
+++ b/app/services/uphold/refresher.rb
@@ -13,16 +13,16 @@ module Uphold
     # Makes a request to the Uphold API to refresh the current access_token
     def call(uphold_connection:)
       # Ensure we have an refresh_token.
-      refresh_token = uphold_connection.refresh_token
 
-      return if refresh_token.blank?
+      return if !uphold_connection.authorization_expired?
+      return if uphold_connection.refresh_token.blank?
 
       authorization = @impl_refresher.refresh_authorization(uphold_connection)
 
       # add expiration time
       authorization_hash = JSON.parse(authorization)
 
-      authorization_hash["expiration_time"] = authorization_hash["expires_in"].to_i.seconds.from_now.to_s
+      authorization_hash["expiration_time"] = authorization_hash["expires_in"].to_i.seconds.from_now
 
       # Update with the latest Authorization
       uphold_connection.uphold_access_parameters = JSON.dump(authorization_hash)


### PR DESCRIPTION
This will not call to reauthorize if the current authorization is still good. Note that previously we were checking if the expired at time was still in the future and then returning that we were expired if it was. This has been reversed.