### PR TITLE
Fix Potential Payments ordering bug

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -110,7 +110,7 @@ class Publisher < ApplicationRecord
   ###############################
 
   scope :uphold_selected_provider, -> {
-    joins(:uphold_connection).
+    joins(:uphold_connection). # rubocop:disable Airbnb/RiskyActiverecordInvocation
       where("uphold_connections.id = publishers.selected_wallet_provider_id
            AND publishers.selected_wallet_provider_type = '#{UpholdConnection}'")
   }
@@ -132,7 +132,7 @@ class Publisher < ApplicationRecord
   ###############################
 
   scope :bitflyer_selected_provider, -> {
-    joins(:bitflyer_connection).
+    joins(:bitflyer_connection). # rubocop:disable Airbnb/RiskyActiverecordInvocation
       where("bitflyer_connections.id = publishers.selected_wallet_provider_id
            AND publishers.selected_wallet_provider_type = '#{BitflyerConnection}'")
   }

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -110,8 +110,7 @@ class Publisher < ApplicationRecord
   ###############################
 
   scope :uphold_selected_provider, -> {
-    includes(:uphold_connection). # rubocop:disable Airbnb/RiskyActiverecordInvocation
-      joins(:uphold_connection).
+    joins(:uphold_connection).
       where("uphold_connections.id = publishers.selected_wallet_provider_id
            AND publishers.selected_wallet_provider_type = '#{UpholdConnection}'")
   }
@@ -133,8 +132,7 @@ class Publisher < ApplicationRecord
   ###############################
 
   scope :bitflyer_selected_provider, -> {
-    includes(:bitflyer_connection). # rubocop:disable Airbnb/RiskyActiverecordInvocation
-      joins(:bitflyer_connection).
+    joins(:bitflyer_connection).
       where("bitflyer_connections.id = publishers.selected_wallet_provider_id
            AND publishers.selected_wallet_provider_type = '#{BitflyerConnection}'")
   }
@@ -151,13 +149,12 @@ class Publisher < ApplicationRecord
 
   scope :gemini_selected_provider, -> {
     joins(:gemini_connection). # rubocop:disable Airbnb/RiskyActiverecordInvocation
-      gemini_selected_provider.
       where("gemini_connections.id = publishers.selected_wallet_provider_id
            AND publishers.selected_wallet_provider_type = '#{GeminiConnection}'")
   }
 
   scope :valid_payable_gemini_creators, -> {
-    includes(:gemini_connection).
+    gemini_selected_provider.
       where(gemini_connections: { is_verified: true }).
       where.not(gemini_connections: { recipient_id: nil }).
       where.not(gemini_connections: { country: GeminiConnection::JAPAN })

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -211,6 +211,7 @@ class UpholdConnection < ApplicationRecord
   end
 
   def authorization_expired?
+    return true if authorization_expires_at.blank?
     authorization_expires_at.present? && authorization_expires_at < Time.zone.now
   end
 


### PR DESCRIPTION
When generating the payout report, the publisher statuses
were not being properly accounted for after switching to the new
much speedier, eager loaded payout report generation. When eager loading,
Rails was dropping the default ordering on the publisher statuses
table and instead just ordering by ID. I played around with added a new
scope that would only let us pull in the latest status update. The scope
looked like this:

```
  # Eager loading these will NOT keep the ordering, so make it explicit here
  has_one :latest_status_update, class_name: "PublisherStatusUpdate", primary_key: :latest_publisher_status_id, foreign_key: :publisher_id
  scope :with_latest_status, lambda {
    select(
      "publishers.*,
      (
        SELECT publisher_id as latest_publisher_status_id
        FROM publisher_status_updates
        WHERE publisher_id = publishers.id
        ORDER BY created_at DESC
        LIMIT 1
      )"
    )
  }
```

But in the end, Rails kept wanting to use this scope in all subqueries
for processing the payouts. It looked like it wasn't going to work unless
I wrote a bunch of manual SQL, so instead I opted to separate the
payment generation into 2 steps.

1) Get all the publishers who need a payout, with all the crazy scoping
that entails.
2) Eager load those publishers.

By removing the crazy scoping and doing a simple query to eager load,
Rails keeps the default ordering. In particular, the parts of the query
that overrode the status ordering was

`with_verified_channel.not_in_top_referrer_program.valid_payable_uphold_creators`

Which generates all kinds of subqueries that make it tricky to try to
enforce the proper ordering of the publisher statuses.
