### PR TITLE
Add referral code to promo email contributions

### DIFF
--- a/app/jobs/promo/email_breakdowns_job.rb
+++ b/app/jobs/promo/email_breakdowns_job.rb
@@ -27,9 +27,9 @@ class Promo::EmailBreakdownsJob
       referral_codes.each do |referral_code|
         start_of_day = date.beginning_of_day
         end_of_day = date.end_of_day
-        result = ReferralDownload.select('sum(total) AS total_for_day, country_code, ymd').where(referral_code: referral_code, owner_id: publisher_id)
+        result = ReferralDownload.select("sum(total) AS total_for_day, country_code, ymd").where(referral_code: referral_code, owner_id: publisher_id)
           .where("finalized_ts >= ?", start_of_day)
-          .where("finalized_ts <= ?", end_of_day).group('ymd, country_code').order('ymd desc, country_code asc')
+          .where("finalized_ts <= ?", end_of_day).group("ymd, country_code").order("ymd desc, country_code asc")
         result.each do |referral_download|
           csv.append(
             [


### PR DESCRIPTION
Also the data in referral_downloads is not grouped and summed to get
the total confirmations for a region per code per day, so we do that on
our end. Previously we had too many rows in the report.
