### PR TITLE
401 reapply with homepage sync

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -146,6 +146,7 @@ class PublishersController < ApplicationController
     @channels = @publisher.channels.visible.paginate(page: params[:page], per_page: 10)
     @publisher_unattached_promo_registrations = @publisher.promo_registrations.unattached_only
 
+    uphold_connection.sync_connection!
     if uphold_connection.uphold_details.present?
       @possible_currencies = uphold_connection.uphold_details&.currencies
     end

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -26,6 +26,7 @@ class UpholdConnection < ApplicationRecord
     # aren't valid states: https://uphold.com/en/developer/api/documentation/#user-object
     RESTRICTED = :restricted
     BLOCKED = :blocked
+    OLD_ACCESS_CREDENTIALS = :old_access_credentials
   end
 
   OK = "ok"
@@ -94,7 +95,7 @@ class UpholdConnection < ApplicationRecord
     # TODO Let's make sure that if we can't access the user's information then we set uphold_verified? to false
     # Perhaps through a rescue on 401
     uphold_verified? &&
-      (uphold_access_parameters.blank? || scope.exclude?("cards:write") || uphold_details.nil?)
+      (uphold_access_parameters.blank? || scope.exclude?("cards:write") || uphold_details.nil? || status&.to_sym == UpholdAccountState::OLD_ACCESS_CREDENTIALS)
   end
 
   # Makes a remote HTTP call to Uphold to get more details
@@ -105,6 +106,7 @@ class UpholdConnection < ApplicationRecord
     @user ||= UpholdClient.user.find(self)
   rescue Faraday::ClientError => e
     if e.response&.dig(:status) == 401
+      update(status: UpholdAccountState::OLD_ACCESS_CREDENTIALS)
       Rails.logger.fatal("#{e.response[:body]} for uphold connection #{id}")
       nil
     else

--- a/test/models/uphold_connection_test.rb
+++ b/test/models/uphold_connection_test.rb
@@ -196,5 +196,17 @@ class UpholdConnectionTest < ActiveSupport::TestCase
         assert_equal :reauthorization_needed, uphold_connection.uphold_status
       end
     end
+
+    describe "when status is OLD_ACCESS_CREDENTIALS" do
+      before do
+        uphold_connection.status = UpholdConnection::UpholdAccountState::OLD_ACCESS_CREDENTIALS
+        uphold_connection.uphold_access_parameters = JSON.dump({a: 1})
+        uphold_connection.uphold_verified = true
+      end
+
+      it "returns reauthorize" do
+        assert_equal :reauthorization_needed, uphold_connection.uphold_status
+      end
+    end
   end
 end


### PR DESCRIPTION
Since we no longer update the status during potential payment generation, do it when visiting the homepage. Appropriately cached so that we don't hit Uphold multiple times in the same request, but a further optimization will be to background this, perhaps with a backoff of up to a few days in case the Uphold API is down for some reason. In this way, we could avoid immediately update to a bad status per #3468