### PR TITLE
Add Wallet Syncer which Updates on Login

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -146,7 +146,6 @@ class PublishersController < ApplicationController
     @channels = @publisher.channels.visible.paginate(page: params[:page], per_page: 10)
     @publisher_unattached_promo_registrations = @publisher.promo_registrations.unattached_only
 
-    uphold_connection.sync_connection!
     if uphold_connection.uphold_details.present?
       @possible_currencies = uphold_connection.uphold_details&.currencies
     end

--- a/app/services/bitflyer/wallet_connection_syncer.rb
+++ b/app/services/bitflyer/wallet_connection_syncer.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 module Bitflyer
-    class WalletConnectionSyncer
-  
-      def self.build
-        new
-      end
-   
-      def call(connection:)
-        # TODO enable this once refreshing verified to work
-        # Bitflyer::Refresher.build.call(bitflyer_connection: connection)
-      end
+  class WalletConnectionSyncer
+    def self.build
+      new
+    end
+
+    def call(connection:)
+      # TODO enable this once refreshing verified to work
+      # Bitflyer::Refresher.build.call(bitflyer_connection: connection)
+    end
   end
 end

--- a/app/services/bitflyer/wallet_connection_syncer.rb
+++ b/app/services/bitflyer/wallet_connection_syncer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Bitflyer
+    class WalletConnectionSyncer
+  
+      def self.build
+        new
+      end
+   
+      def call(connection:)
+        # TODO enable this once refreshing verified to work
+        # Bitflyer::Refresher.build.call(bitflyer_connection: connection)
+      end
+  end
+end

--- a/app/services/gemini/wallet_connection_syncer.rb
+++ b/app/services/gemini/wallet_connection_syncer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Gemini
+    class WalletConnectionSyncer
+  
+      def self.build
+        new
+      end
+   
+      def call(connection:)
+        # TODO move this code out of the model!
+        connection.sync_connection!
+      end
+  end
+end

--- a/app/services/gemini/wallet_connection_syncer.rb
+++ b/app/services/gemini/wallet_connection_syncer.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 module Gemini
-    class WalletConnectionSyncer
-  
-      def self.build
-        new
-      end
-   
-      def call(connection:)
-        # TODO move this code out of the model!
-        connection.sync_connection!
-      end
+  class WalletConnectionSyncer
+    def self.build
+      new
+    end
+
+    def call(connection:)
+      # TODO move this code out of the model!
+      connection.sync_connection!
+    end
   end
 end

--- a/app/services/uphold/wallet_connection_syncer.rb
+++ b/app/services/uphold/wallet_connection_syncer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Uphold
+  class WalletConnectionSyncer
+
+    def self.build
+      new
+    end
+
+    def call(connection:)
+      # TODO move this code out of the model!
+      connection.sync_connection!
+    end
+  end
+end

--- a/app/services/uphold/wallet_connection_syncer.rb
+++ b/app/services/uphold/wallet_connection_syncer.rb
@@ -2,7 +2,6 @@
 
 module Uphold
   class WalletConnectionSyncer
-
     def self.build
       new
     end

--- a/app/services/util/wallet/connection_syncer.rb
+++ b/app/services/util/wallet/connection_syncer.rb
@@ -1,0 +1,30 @@
+# The hope is to make this the start of ripping out the
+# oauth connection functions out of the model and into
+# service classes
+class Util::Wallet::ConnectionSyncer
+
+  def self.build
+    new
+  end
+
+  def call(publisher:)
+    selected_wallet = publisher.selected_wallet_provider
+
+    # Could make this dynamic, but the intention is to add typing and make this a union type
+    # for exhaustiveness checking. Spelling it out to reduce magic in the codebase.
+    syncer = case selected_wallet
+    in UpholdConnection
+      Uphold::WalletConnectionSyncer
+    in GeminiConnection
+      Gemini::WalletConnectionSyncer
+    in BitflyerConnection
+      Bitflyer::WalletConnectionSyncer
+    else
+      # Until we have sorbet typing with exhaustive checks, log any data problems in new relic
+      LogException.perform(StandardError.new("Unknown Wallet Provider type: #{selected_wallet}"))
+      nil
+    end
+
+    syncer.build.call(connection: selected_wallet) if syncer
+  end
+end

--- a/app/services/util/wallet/connection_syncer.rb
+++ b/app/services/util/wallet/connection_syncer.rb
@@ -2,7 +2,6 @@
 # oauth connection functions out of the model and into
 # service classes
 class Util::Wallet::ConnectionSyncer
-
   def self.build
     new
   end
@@ -25,6 +24,6 @@ class Util::Wallet::ConnectionSyncer
       nil
     end
 
-    syncer.build.call(connection: selected_wallet) if syncer
+    syncer&.build&.call(connection: selected_wallet)
   end
 end

--- a/config/initializers/login_activities.rb
+++ b/config/initializers/login_activities.rb
@@ -8,7 +8,7 @@ Warden::Manager.after_authentication except: :fetch do |publisher, auth, _opts|
 
   LoginActivity.create!(params)
 
-  if publisher and !Rails.env.test?
+  if publisher && !Rails.env.test?
     Util::Wallet::ConnectionSyncer.build.call(publisher: publisher)
   end
 end

--- a/config/initializers/login_activities.rb
+++ b/config/initializers/login_activities.rb
@@ -1,5 +1,5 @@
-# Record the publishers's successful login
-Warden::Manager.after_authentication except: :fetch do |publisher, auth, opts|
+# Record the publishers' successful login
+Warden::Manager.after_authentication except: :fetch do |publisher, auth, _opts|
   params = {
     publisher: publisher,
     user_agent: auth.request.headers["User-Agent"],
@@ -7,4 +7,8 @@ Warden::Manager.after_authentication except: :fetch do |publisher, auth, opts|
   }
 
   LoginActivity.create!(params)
+
+  if publisher and !Rails.env.test?
+    Util::Wallet::ConnectionSyncer.build.call(publisher: publisher)
+  end
 end

--- a/test/services/util/wallet/connection_syncer_test.rb
+++ b/test/services/util/wallet/connection_syncer_test.rb
@@ -1,0 +1,27 @@
+
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Util::Wallet::ConnectionSyncerTest < ActiveSupport::TestCase
+  test "with no wallet does nothing" do
+    LogException.expects('perform').at_least_once.returns(1)
+    refute Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:notes))
+  end
+
+  test 'Uphold' do
+    UpholdConnection.any_instance.expects('sync_connection!').at_least_once.returns(1)
+    Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:verified))
+  end
+
+  test 'Gemini' do
+    GeminiConnection.any_instance.expects('sync_connection!').at_least_once.returns(1)
+    Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:top_referrer_gemini))
+  end
+
+  test 'Bitflyer' do
+    Bitflyer::WalletConnectionSyncer.any_instance.expects('call').at_least_once.returns(1)
+    Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:top_referrer_bitflyer))
+  end
+
+end

--- a/test/services/util/wallet/connection_syncer_test.rb
+++ b/test/services/util/wallet/connection_syncer_test.rb
@@ -1,27 +1,25 @@
-
 # frozen_string_literal: true
 
 require "test_helper"
 
 class Util::Wallet::ConnectionSyncerTest < ActiveSupport::TestCase
   test "with no wallet does nothing" do
-    LogException.expects('perform').at_least_once.returns(1)
+    LogException.expects("perform").at_least_once.returns(1)
     refute Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:notes))
   end
 
-  test 'Uphold' do
-    UpholdConnection.any_instance.expects('sync_connection!').at_least_once.returns(1)
+  test "Uphold" do
+    UpholdConnection.any_instance.expects("sync_connection!").at_least_once.returns(1)
     Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:verified))
   end
 
-  test 'Gemini' do
-    GeminiConnection.any_instance.expects('sync_connection!').at_least_once.returns(1)
+  test "Gemini" do
+    GeminiConnection.any_instance.expects("sync_connection!").at_least_once.returns(1)
     Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:top_referrer_gemini))
   end
 
-  test 'Bitflyer' do
-    Bitflyer::WalletConnectionSyncer.any_instance.expects('call').at_least_once.returns(1)
+  test "Bitflyer" do
+    Bitflyer::WalletConnectionSyncer.any_instance.expects("call").at_least_once.returns(1)
     Util::Wallet::ConnectionSyncer.new.call(publisher: publishers(:top_referrer_bitflyer))
   end
-
 end


### PR DESCRIPTION
We don't want to update on home page view, and we want to cover
all wallet providers. Currently we won't sync Bitflyer since I need to 
verify refreshing works properly and this is
mainly addressing Uphold, for the moment. Will need to come back and
turn that on for Bitflyer, though it's not as big of a priority since
at connection, the user is already KYCd.
