### PR TITLE
We were over reporting the nightly stats email

### DIFF
--- a/app/jobs/promo/email_breakdowns_job.rb
+++ b/app/jobs/promo/email_breakdowns_job.rb
@@ -26,11 +26,11 @@ class Promo::EmailBreakdownsJob
     csv.append(["ConfirmationDate", "CountryCode", "ReferralCode", "ConfirmationsTotal"].join(","))
     (start_date..end_date).each do |date|
       referral_codes.each do |referral_code|
-        start_of_day = date.beginning_of_day
-        end_of_day = date.end_of_day
         result = ReferralDownload.select("sum(total) AS total_for_day, country_code, ymd").where(referral_code: referral_code, owner_id: publisher_id)
-          .where("finalized_ts >= ?", start_of_day)
-          .where("finalized_ts <= ?", end_of_day).group("ymd, country_code").order("ymd desc, country_code asc")
+          .where(finalized: true)
+          .where("ymd = ?", date)
+          .group("ymd, country_code").order("ymd desc, country_code asc")
+
         result.each do |referral_download|
           csv.append(
             [


### PR DESCRIPTION
The promo system doesn't set the finalized=true until 30 days have passed,
so this nightly report will only report up until a month ago. That is, where a

retrieval = download from site
download = actual download and then launch

The Referral download table is a view on the download table, that is,
first launches. That table also tracks usage pings so a column gets updated
daily in it. That column is the finalized_ts, which is very unfortunate
and in fact, much of the naming here is.

So we get a finalized_ts that gets set daily, but the finalized column
itself doesn't get set until a month later.

So if you are looking at this report on Dec 6, the report's latest date
will be Nov 5, i.e. when a particular download was created. It's finalized
column was updated today, and it's finalized_ts column has today's date
in it, but all that matters is the `ymd`, that is, the created date, and
the finalized boolean. This finalized boolean is also what the promo UI
keys off of, so this brings the report in line with the UI.

Note also the check on the date via range was causing doubling issues. A direct date comparison fixed this.