### PR TITLE
Serve the public cloudfront URL instead of the private

### DIFF
--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -107,7 +107,7 @@ class SiteBanner < ApplicationRecord
   end
 
   def pcdn_public_image_url(image)
-    "Rails.application.secrets[:s3_rewards_public_domain]/#{image.blob.key}"
+    "Rails.application.secrets[:s3_rewards_public_domain]/#{image&.blob&.key}"
   end
 
   def non_default_properties

--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -107,7 +107,7 @@ class SiteBanner < ApplicationRecord
   end
 
   def pcdn_public_image_url(image)
-    "Rails.application.secrets[:s3_rewards_public_domain]/#{image&.blob&.key}"
+    "#{Rails.application.secrets[:s3_rewards_public_domain]}/#{image&.blob&.key}"
   end
 
   def non_default_properties

--- a/app/models/site_banner.rb
+++ b/app/models/site_banner.rb
@@ -99,11 +99,15 @@ class SiteBanner < ApplicationRecord
     {
       title: title,
       description: description,
-      backgroundUrl: background_image.url,
-      logoUrl: logo.url,
+      backgroundUrl: pcdn_public_image_url(background_image),
+      logoUrl: pcdn_public_image_url(logo),
       donationAmounts: donation_amounts,
       socialLinks: social_links
     }
+  end
+
+  def pcdn_public_image_url(image)
+    "Rails.application.secrets[:s3_rewards_public_domain]/#{image.blob.key}"
   end
 
   def non_default_properties

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -215,6 +215,8 @@ test:
   bitflyer_client_id: "client_id_abc123"
   bitflyer_client_secret: "client_secret_123abc"
   bitflyer_scope: "some_scope"
+  # AWS for pcdn
+  s3_rewards_public_domain: "https://TESTDOMAIN.com"
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/test/controllers/publishers/site_banners_controller_test.rb
+++ b/test/controllers/publishers/site_banners_controller_test.rb
@@ -11,6 +11,7 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
     get "/publishers/" + publisher.id + "/site_banners/00000000-0000-0000-0000-000000000000", headers: {"HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token"}
     site_banner = JSON.parse(response.body)
     assert_equal("Hello World", site_banner["title"])
+    assert_equal("https://TESTDOMAIN.com/", site_banner["logoUrl"])
     assert_equal("Lorem Ipsum", site_banner["description"])
   end
 


### PR DESCRIPTION
When we migrated to ruby-wasmer, we removed an activestorage plugin we had written which essentially just sets the URL to a cloudfront URL. Restoring that functionality.