### PR TITLE
Resolved 504s during pCDN upload

### DIFF
--- a/db/migrate/20211208230135_add_proper_index_to_site_banner_lookups.rb
+++ b/db/migrate/20211208230135_add_proper_index_to_site_banner_lookups.rb
@@ -1,0 +1,9 @@
+class AddProperIndexToSiteBannerLookups < ActiveRecord::Migration[6.1]
+  def change
+    execute %Q{
+      CREATE INDEX IF NOT EXISTS index_site_banner_lookups_collation_c_on_sha_base16
+      ON site_banner_lookups USING btree
+      (sha2_base16 COLLATE pg_catalog."C" text_pattern_ops ASC NULLS LAST);
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_28_205253) do
+ActiveRecord::Schema.define(version: 2021_12_08_230135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
@@ -574,6 +575,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_205253) do
     t.index ["channel_identifier"], name: "index_site_banner_lookups_on_channel_identifier"
     t.index ["publisher_id"], name: "index_site_banner_lookups_on_publisher_id"
     t.index ["sha2_base16"], name: "index_gin_site_banner_lookups_on_sha2_base16", using: :gin
+    t.index ["sha2_base16"], name: "index_site_banner_lookups_collation_c_on_sha_base16", opclass: :text_pattern_ops
     t.index ["sha2_base16"], name: "index_site_banner_lookups_on_sha2_base16"
   end
 


### PR DESCRIPTION
The call to find the SiteBannerLookup

https://github.com/brave-intl/publishers/blob/staging/app/jobs/cache/browser_channels/responses_for_prefix.rb#L23

`@site_banner_lookups = SiteBannerLookup.where("sha2_base16 LIKE ?", prefix + "%")`

was doing a table scan and not using the index. Through experimentation,
I found out that we aren't using the current indexes because the collation
is off. This corrects that. I ran a full upload to the pcdn and verified
that the 504s are gone. This should greatly improve responsiveness both
for the admin panel and stats hitting our API.
