### PR TITLE
Remove bitflyer_enabled publisher feature

### DIFF
--- a/app/javascript/views/walletServices/BraveConnection.tsx
+++ b/app/javascript/views/walletServices/BraveConnection.tsx
@@ -66,7 +66,6 @@ class BraveConnection extends React.Component<any, any> {
       // If there's a bitflyer connection let's show the BitflyerConnection component
     }
     else if (
-      this.props.featureFlags.bitflyer_enabled &&
       this.state.bitflyerConnection
     ) {
       return (

--- a/app/models/concerns/user_feature_flags.rb
+++ b/app/models/concerns/user_feature_flags.rb
@@ -11,7 +11,6 @@ module UserFeatureFlags
   REFERRAL_KYC_REQUIRED = :referral_kyc_required
   STRIPE_ENABLED = :stripe_enabled
   GEMINI_ENABLED = :gemini_enabled
-  BITFLYER_ENABLED = :bitflyer_enabled
   REFERRAL_ENABLED_OVERRIDE = :referral_enabled_override
 
   VALID_FEATURE_FLAGS = [
@@ -40,7 +39,6 @@ module UserFeatureFlags
     scope :merchant, -> { where("feature_flags->'#{MERCHANT}' = 'true'") }
     scope :stripe_enabled, -> { where("feature_flags->'#{STRIPE_ENABLED}' = 'true'") }
     scope :gemini_enabled, -> { where("feature_flags->'#{GEMINI_ENABLED}' = 'true'") }
-    scope :bitflyer_enabled, -> { where("feature_flags->'#{BITFLYER_ENABLED}' = 'true'") }
     scope :in_top_referrer_program, -> { where("feature_flags->'#{REFERRAL_ENABLED_OVERRIDE}' = 'true'") }
     scope :not_in_top_referrer_program, -> { where.not(id: in_top_referrer_program) }
   end
@@ -96,10 +94,6 @@ module UserFeatureFlags
 
   def gemini_enabled?
     feature_flags.symbolize_keys[GEMINI_ENABLED].present?
-  end
-
-  def bitflyer_enabled?
-    feature_flags.symbolize_keys[BITFLYER_ENABLED].present?
   end
 
   def has_daily_emails_for_promo_stats?

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -449,10 +449,6 @@ class Publisher < ApplicationRecord
     provider_country.to_s.upcase
   end
 
-  def bitflyer_enabled?
-    feature_flags["bitflyer_enabled"] == true
-  end
-
   private
 
   def cleanup_name
@@ -467,7 +463,6 @@ class Publisher < ApplicationRecord
   def set_default_features
     feature_flags[UserFeatureFlags::REFERRAL_KYC_REQUIRED] = true
     feature_flags[UserFeatureFlags::GEMINI_ENABLED] = true
-    feature_flags[UserFeatureFlags::BITFLYER_ENABLED] = true
   end
 
   def set_created_status

--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -190,7 +190,6 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
 
   test "login link of new japanese users which should use locale=ja" do
     publisher = publishers(:completed)
-    publisher.feature_flags["bitflyer_enabled"] = true
     publisher.save
 
     headers = {"Accept-Language" => "ja_JP"}

--- a/test/fixtures/bitflyer_connections.yml
+++ b/test/fixtures/bitflyer_connections.yml
@@ -1,6 +1,6 @@
 enabled_bitflyer_connection:
-  publisher: bitflyer_enabled
-  recipient_id: 'bitflyer_enabled_connectionABC'
+  publisher: bitflyer_pub
+  recipient_id: 'bitflyer_pub_connectionABC'
   <% salt = SecureRandom.random_bytes(12) %>
   encrypted_access_token:  "<%= TotpRegistration.encrypt_secret(
     'access_token',

--- a/test/fixtures/channels.yml
+++ b/test/fixtures/channels.yml
@@ -27,7 +27,7 @@ top_referrer_bitflyer_channel:
   publisher: top_referrer_bitflyer
   details: top_referrer_bitflyer_verified_details (SiteChannelDetails)
   verified: true
-  deposit_id: 'bitflyer_enabled_channel123'
+  deposit_id: 'bitflyer_pub_channel123'
 
 verified_exclude:
   publisher: medium_media_group
@@ -331,20 +331,20 @@ gemini_in_japan_completed_website:
   verified: true
   details: gemini_in_japan_website_details (SiteChannelDetails)
 
-bitflyer_enabled_channel:
-  publisher: bitflyer_enabled
-  details: bitflyer_enabled_details (SiteChannelDetails)
+bitflyer_pub_channel:
+  publisher: bitflyer_pub
+  details: bitflyer_pub_details (SiteChannelDetails)
   verified: true
-  deposit_id: 'bitflyer_enabled_channel123'
+  deposit_id: 'bitflyer_pub_channel123'
 
 bitflyer_suspended_channel:
   publisher: bitflyer_suspended
   details: bitflyer_suspended_details (SiteChannelDetails)
   verified: true
-  deposit_id: 'bitflyer_enabled_channel321'
+  deposit_id: 'bitflyer_pub_channel321'
 
-bitflyer_enabled_website:
-  publisher: bitflyer_enabled
+bitflyer_pub_website:
+  publisher: bitflyer_pub
   verified: true
   details: bitflyer_completed_website_details(SiteChannelDetails)
-  deposit_id: 'bitflyer_enabled_website1'
+  deposit_id: 'bitflyer_pub_website1'

--- a/test/fixtures/publishers.yml
+++ b/test/fixtures/publishers.yml
@@ -361,22 +361,13 @@ publisher_selected_wallet_provider:
   two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
 
-bitflyer_enabled:
-  email: "bitflyer_enabled@brave.com"
-  name: "Bitflyer Enabled"
+bitflyer_pub:
+  email: "bitflyer_pub@brave.com"
+  name: "Bitflyer Pub"
   agreed_to_tos: "<%= 1.day.ago %>"
   two_factor_prompted_at: "<%= 1.day.ago %>"
   default_currency_confirmed_at: "<%= 1.day.ago %>"
-  feature_flags: <%= { UserFeatureFlags::BITFLYER_ENABLED => true }.to_json %>
   selected_wallet_provider: enabled_bitflyer_connection (BitflyerConnection)
-
-bitflyer_not_enabled:
-  email: "bitflyer_not_enabled@brave.com"
-  name: "Bitflyer Not Enabled"
-  agreed_to_tos: "<%= 1.day.ago %>"
-  two_factor_prompted_at: "<%= 1.day.ago %>"
-  default_currency_confirmed_at: "<%= 1.day.ago %>"
-  feature_flags: <%= { UserFeatureFlags::BITFLYER_ENABLED => false }.to_json %>
 
 bitflyer_suspended:
   email: "bitflyer_suspended@completed.org"

--- a/test/fixtures/site_channel_details.yml
+++ b/test/fixtures/site_channel_details.yml
@@ -155,7 +155,7 @@ suspended_details:
 bitflyer_suspended_details:
   brave_publisher_id: "suspendedbitflyer.org"
 
-bitflyer_enabled_details:
+bitflyer_pub_details:
   brave_publisher_id: "enabledbitflyer.org"
 
 fraudulently_verified_site_details:

--- a/test/jobs/sync/bitflyer/update_missing_deposits_job_test.rb
+++ b/test/jobs/sync/bitflyer/update_missing_deposits_job_test.rb
@@ -10,7 +10,7 @@ class Sync::Bitflyer::UpdateMissingDepositsJobTest < SidekiqTestCase
   end
 
   test "enqueue a job when no deposit_id exists" do
-    publisher = publishers(:bitflyer_enabled)
+    publisher = publishers(:bitflyer_pub)
     publisher.channels.first.update_column(:deposit_id, nil)
     Sync::Bitflyer::UpdateMissingDepositsJob.perform_now
     assert_equal 1, Sync::Bitflyer::UpdateMissingDepositJob.jobs.size

--- a/test/services/payout/bitflyer_service_test.rb
+++ b/test/services/payout/bitflyer_service_test.rb
@@ -33,7 +33,7 @@ class BitflyerServiceTest < ActiveSupport::TestCase
   end
 
   describe "when a creator in good standing" do
-    let(:publisher) { publishers(:bitflyer_enabled) }
+    let(:publisher) { publishers(:bitflyer_pub) }
 
     before do
       subject


### PR DESCRIPTION
This was used when we were launching Bitflyer, but now all JP users have access to it.