### PR TITLE
Gemfile: disable sorbet when arch is not x86_64

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+def x86_64?
+  `uname -p`.strip == 'x86_64'
+end
 
 ruby "~> 3.0.2"
 
@@ -136,7 +139,7 @@ gem "sidekiq-scheduler", "~> 3.0.1"
 # slim for view templates
 gem "slim-rails", "~> 3.1"
 
-gem "sorbet", "0.5.9318", group: :development
+gem "sorbet", "0.5.9318", group: :development if x86_64?
 gem "sorbet-runtime", "0.5.9318"
 
 gem "stripe", "~> 5.1", ">= 5.1.1"
@@ -184,7 +187,7 @@ group :development do
   # i18n-tasks helps you find and manage missing and unused translations.
   gem "i18n-tasks", "~> 0.9.12"
 
-  gem "tapioca", "0.5.4", require: false
+  gem "tapioca", "0.5.4", require: false if x86_64?
 end
 
 group :test do


### PR DESCRIPTION
## Disable sorbet conditionally

#### Features

Disable `sorbet` on anything !x86_64.
This is required to develop on foreign platforms.

Revert this change when multi-arch support is added to `sorbet`

#### How To Test

1. Download on non x86_64 Linux architecture
2. Prepare the environment
3. Test if it starts properly

#### Pull Request Checklist


- [ ] ~~Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)~~
- [ ] ~~XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)~~
- [ ] ~~No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)~~
- [ ] ~~UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)~~
- [ ] ~~Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)~~
- [ ] ~~Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)~~
