### PR TITLE
This adds the ability to add a security key using webauthn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN yarn install --frozen-lockfile
 # The second dot will copy it to the WORKDIR!
 COPY . .
 
-RUN RAILS_ENV=production SECRET_KEY_BASE="1" bundle exec rails assets:precompile DB_ADAPTER=nulldb DATABASE_URL='nulldb://nohost'
+RUN RAILS_ENV=production CREATORS_HOST="1" SECRET_KEY_BASE="1" bundle exec rails assets:precompile DB_ADAPTER=nulldb DATABASE_URL='nulldb://nohost'
 
 EXPOSE 3000
 ENTRYPOINT [ "./scripts/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,5 @@ COPY . .
 RUN RAILS_ENV=production CREATORS_HOST="1" SECRET_KEY_BASE="1" bundle exec rails assets:precompile DB_ADAPTER=nulldb DATABASE_URL='nulldb://nohost'
 
 EXPOSE 3000
-ENTRYPOINT [ 'CREATORS_HOST="1" ./scripts/entrypoint.sh' ]
+ENTRYPOINT [ "./scripts/entrypoint.sh" ]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb", "-e","${RACK_ENV:-development}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,5 @@ COPY . .
 RUN RAILS_ENV=production CREATORS_HOST="1" SECRET_KEY_BASE="1" bundle exec rails assets:precompile DB_ADAPTER=nulldb DATABASE_URL='nulldb://nohost'
 
 EXPOSE 3000
-ENTRYPOINT [ "./scripts/entrypoint.sh" ]
+ENTRYPOINT [ 'CREATORS_HOST="1" ./scripts/entrypoint.sh' ]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb", "-e","${RACK_ENV:-development}"]

--- a/app/controllers/u2f_authentications_controller.rb
+++ b/app/controllers/u2f_authentications_controller.rb
@@ -10,11 +10,15 @@ class U2fAuthenticationsController < ApplicationController
       webauthn_u2f_response: params[:webauthn_u2f_response],
       domain: request.base_url,
       session: session)
-    if result.success?
+
+    case result
+    when BSuccess
       sign_in(:publisher, publisher)
       redirect_to publisher_next_step_path(publisher)
-    else
+    when BFailure
       redirect_to two_factor_authentications_path
+    else
+      T.absurd(result)
     end
   end
 end

--- a/app/controllers/u2f_authentications_controller.rb
+++ b/app/controllers/u2f_authentications_controller.rb
@@ -12,10 +12,10 @@ class U2fAuthenticationsController < ApplicationController
       session: session)
 
     case result
-    when BSuccess
+    when ::BSuccess
       sign_in(:publisher, publisher)
       redirect_to publisher_next_step_path(publisher)
-    when BFailure
+    when ::BFailure
       redirect_to two_factor_authentications_path
     else
       T.absurd(result)

--- a/app/controllers/u2f_registrations_controller.rb
+++ b/app/controllers/u2f_registrations_controller.rb
@@ -31,11 +31,11 @@ class U2fRegistrationsController < ApplicationController
       challenge: challenge)
 
     case result
-    when BFailure
-      redirect_to new_u2f_registration_path && return
     when BSuccess
       logout_everybody_else!
       handle_redirect_after_2fa_registration
+    when BFailure
+      redirect_to new_u2f_registration_path && return
     else
       T.absurd(result)
     end

--- a/app/javascript/u2f/registrationPage.js
+++ b/app/javascript/u2f/registrationPage.js
@@ -1,52 +1,41 @@
-import './u2f-api';
+import { create } from "@github/webauthn-json";
 import { ErrorManager } from './shared';
 
 /*
  * Register a u2f device
  */
-function registerU2fDevice(formElement, responseInput, errorManager) {
+async function registerU2fDevice(formElement, responseInput) {
   formElement.classList.add('js-u2f-working');
 
-  let appId = formElement.querySelector('[name=u2f_app_id]').value;
-  let registrationRequests = JSON.parse(formElement.querySelector('[name=u2f_registration_requests]').value);
-  let registeredKeys = JSON.parse(formElement.querySelector('[name=u2f_sign_requests]').value);
-  window.u2f.register(appId, registrationRequests, registeredKeys, function(registerResponse) {
-    switch(registerResponse.errorCode) {
+  let challenge = formElement.querySelector('[name=webauthn_challenge]').value;
+  let userID = formElement.querySelector('[name=webauthn_user_id]').value;
+  let userDisplayName = formElement.querySelector('[name=webauthn_user_display_name]').value;
+  let exclude = JSON.parse(formElement.querySelector('[name=webauthn_exclusions]').value)
 
-      case undefined: // OK
-      case 0: // OK
-        responseInput.value = JSON.stringify(registerResponse);
-        formElement.submit();
-        return;
+  async function register({userID, challenge, userDisplayName, exclude}) {
+    return await create({
+      publicKey: {
+        challenge: challenge,
+        rp: {name: ""},
+        user: {
+          id: userID,
+          name: userDisplayName,
+          displayName: userDisplayName,
+        },
+        pubKeyCredParams: [{type: "public-key", alg: -7}],
+        excludeCredentials: exclude.map(x => ({id: x, type: 'public-key'})),
+        authenticatorSelection: {userVerification: "discouraged"},
+        extensions: {
+          credProps: true,
+        },
+      },
+    });
+  }
 
-      case 1: // OTHER_ERROR:
-        errorManager.show('u2f-error-other-error');
-        break;
-      case 2: // BAD_REQUEST:
-        errorManager.show('u2f-error-bad-request');
-        break;
-      case 3: // CONFIGURATION_UNSUPPORTED:
-        errorManager.show('u2f-error-configuration-unsupported');
-        break;
-      case 4: // DEVICE_INELIGIBLE:
-        errorManager.show('u2f-error-device-ineligible');
-        break;
-      case 5: // TIMEOUT
-        errorManager.show('u2f-error-timeout');
-        break;
-      case 99900: // IMPLEMENTATION_INCOMPLETE
-        errorManager.show('u2f-error-implementation-incomplete');
-        break;
-    }
+  const result = await register({userID, challenge, userDisplayName, exclude});
 
-    formElement.classList.remove('js-u2f-working');
-    // Reset the form after an error to permit a second attempt
-    let submit = formElement.querySelector('input[type=submit][disabled]');
-    if (submit) {
-      submit.removeAttribute('disabled');
-      submit.blur();
-    }
-  });
+  responseInput.value = JSON.stringify(result);
+  formElement.submit();
 }
 
 /*
@@ -54,15 +43,13 @@ function registerU2fDevice(formElement, responseInput, errorManager) {
  *
  */
 document.addEventListener('DOMContentLoaded', function() {
-  let formElement = document.querySelector('.js-register-u2f');
+  let formElement = document.querySelector('.js-register-webauthn');
   if (formElement) {
-    let errorManager = new ErrorManager('register-u2f-error');
     formElement.addEventListener('submit', function(event) {
-      errorManager.clear();
-      let responseInput = formElement.querySelector('[name=u2f_response]');
+      let responseInput = formElement.querySelector('[name=webauthn_response]');
       if (!responseInput.value) {
         event.preventDefault();
-        registerU2fDevice(formElement, responseInput, errorManager);
+        registerU2fDevice(formElement, responseInput);
       }
     });
   }

--- a/app/models/u2f_registration.rb
+++ b/app/models/u2f_registration.rb
@@ -1,4 +1,7 @@
 # typed: strict
 class U2fRegistration < ApplicationRecord
+  FORMATS = %w[u2f webauthn]
+  enum format: FORMATS.zip(FORMATS).to_h
+
   belongs_to :publisher
 end

--- a/app/models/u2f_registration.rb
+++ b/app/models/u2f_registration.rb
@@ -1,6 +1,6 @@
 # typed: strict
 class U2fRegistration < ApplicationRecord
-  FORMATS = %w[u2f webauthn]
+  FORMATS = T.let(%w[u2f webauthn], T::Array[String])
   enum format: FORMATS.zip(FORMATS).to_h
 
   belongs_to :publisher

--- a/app/services/builder_base_service.rb
+++ b/app/services/builder_base_service.rb
@@ -5,16 +5,6 @@ class BuilderBaseService
   extend T::Sig
   abstract!
 
-  class ::BSuccess < T::Struct
-    prop :result, T.any(T::Hash[T.untyped, T.untyped], T::Array[T.untyped], Integer, Float, T::Boolean)
-  end
-
-  class ::BFailure < T::Struct
-    prop :errors, T::Array[String]
-  end
-
-  ::BServiceResult = T.type_alias { T.any(BSuccess, BFailure) }
-
   sig { abstract.returns(T.self_type) }
   def self.build
   end

--- a/app/services/builder_base_service.rb
+++ b/app/services/builder_base_service.rb
@@ -3,6 +3,7 @@
 class BuilderBaseService
   extend T::Helpers
   extend T::Sig
+  abstract!
 
   class ::BSuccess < T::Struct
     prop :result, T.any(T::Hash[T.untyped, T.untyped], T::Array[T.untyped], Integer, Float, T::Boolean)
@@ -12,15 +13,13 @@ class BuilderBaseService
     prop :errors, T::Array[String]
   end
 
-  ServiceResult = T.type_alias { T.any(BSuccess, BFailure) }
-
-  abstract!
+  ::BServiceResult = T.type_alias { T.any(BSuccess, BFailure) }
 
   sig { abstract.returns(T.self_type) }
   def self.build
   end
 
-  sig { abstract.returns(ServiceResult) }
+  sig { abstract.returns(BServiceResult) }
   def call
   end
 

--- a/app/services/two_factor_auth/webauthn_registration_service.rb
+++ b/app/services/two_factor_auth/webauthn_registration_service.rb
@@ -1,0 +1,38 @@
+# typed: true
+# frozen_string_literal: true
+
+module TwoFactorAuth
+  class WebauthnRegistrationService < BuilderBaseService
+    def self.build
+      new(webauthn_credentialer: WebAuthn::Credential)
+    end
+
+    def initialize(webauthn_credentialer:)
+      @webauthn_credentialer = webauthn_credentialer
+    end
+
+    def call(publisher:, webauthn_response:, challenge:, name:)
+      response = JSON.parse(webauthn_response)
+      credential = @webauthn_credentialer.from_create(response)
+
+      begin
+        credential.verify(challenge)
+      rescue WebAuthn::Error => e
+        Rails.logger.debug("Webauthn::Error! #{e}")
+        return problem(e)
+      end
+
+      publisher.u2f_registrations.create!(
+        {
+          key_handle: credential.id,
+          public_key: credential.public_key,
+          counter: credential.sign_count,
+          name: name,
+          format: U2fRegistration.formats[:webauthn]
+        }
+      )
+
+      pass
+    end
+  end
+end

--- a/app/services/two_factor_auth/webauthn_registration_service.rb
+++ b/app/services/two_factor_auth/webauthn_registration_service.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: ignore
 # frozen_string_literal: true
 
 module TwoFactorAuth
@@ -11,6 +11,15 @@ module TwoFactorAuth
       @webauthn_credentialer = webauthn_credentialer
     end
 
+    sig do
+      override.params(
+        publisher: Publisher,
+        webauthn_response: String,
+        challenge: String,
+        name: String
+      )
+        .returns(BServiceResult)
+    end
     def call(publisher:, webauthn_response:, challenge:, name:)
       response = JSON.parse(webauthn_response)
       credential = @webauthn_credentialer.from_create(response)
@@ -28,7 +37,7 @@ module TwoFactorAuth
           public_key: credential.public_key,
           counter: credential.sign_count,
           name: name,
-          format: U2fRegistration.formats[:webauthn]
+          format: U2fRegistration.format[:webauthn]
         }
       )
 

--- a/app/services/two_factor_auth/webauthn_registration_service.rb
+++ b/app/services/two_factor_auth/webauthn_registration_service.rb
@@ -19,7 +19,7 @@ module TwoFactorAuth
         credential.verify(challenge)
       rescue WebAuthn::Error => e
         Rails.logger.debug("Webauthn::Error! #{e}")
-        return problem(e)
+        return problem(e.message)
       end
 
       publisher.u2f_registrations.create!(

--- a/app/services/two_factor_auth/webauthn_registration_service.rb
+++ b/app/services/two_factor_auth/webauthn_registration_service.rb
@@ -11,15 +11,15 @@ module TwoFactorAuth
       @webauthn_credentialer = webauthn_credentialer
     end
 
-    sig do
-      override.params(
-        publisher: Publisher,
-        webauthn_response: String,
-        challenge: String,
-        name: String
-      )
-        .returns(BServiceResult)
-    end
+    # sig do
+    #   override.params(
+    #     publisher: Publisher,
+    #     webauthn_response: String,
+    #     challenge: String,
+    #     name: String
+    #   )
+    #     .returns(BServiceResult)
+    # end
     def call(publisher:, webauthn_response:, challenge:, name:)
       response = JSON.parse(webauthn_response)
       credential = @webauthn_credentialer.from_create(response)
@@ -37,7 +37,7 @@ module TwoFactorAuth
           public_key: credential.public_key,
           counter: credential.sign_count,
           name: name,
-          format: U2fRegistration.format[:webauthn]
+          format: U2fRegistration.formats[:webauthn]
         }
       )
 

--- a/app/views/u2f_registrations/new.html.slim
+++ b/app/views/u2f_registrations/new.html.slim
@@ -53,11 +53,12 @@
 
       .col-small-centered.text-left
 
-        = form_for @u2f_registration, html: { class: "js-register-u2f js-feature-u2f-available" } do |f|
-          input type="hidden" name="u2f_app_id" value=(@app_id)
-          input type="hidden" name="u2f_registration_requests" value=(@registration_requests.as_json.to_json)
-          input type="hidden" name="u2f_sign_requests" value=(@sign_requests.as_json.to_json)
-          input type="hidden" name="u2f_response"
+        = form_for @u2f_registration, html: { class: "js-register-webauthn js-feature-u2f-available" } do |f|
+          input type="hidden" name="webauthn_challenge" value=(@webauthn_options.challenge)
+          input type="hidden" name="webauthn_user_display_name" value=(@webauthn_options.user.display_name)
+          input type="hidden" name="webauthn_user_id" value=(@webauthn_options.user.id)
+          input type="hidden" name="webauthn_exclusions" value=(@webauthn_options.exclude.to_json)
+          input type="hidden" name="webauthn_response"
 
           .form-group
             = f.label :name

--- a/config/initializers/service_result_types.rb
+++ b/config/initializers/service_result_types.rb
@@ -1,0 +1,9 @@
+class BSuccess < T::Struct
+  prop :result, T.any(T::Hash[T.untyped, T.untyped], T::Array[T.untyped], Integer, Float, T::Boolean)
+end
+
+class BFailure < T::Struct
+  prop :errors, T::Array[String]
+end
+
+BServiceResult = T.type_alias { T.any(BSuccess, BFailure) }

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,7 +1,7 @@
 WebAuthn.configure do |config|
   # This value needs to match `window.location.origin` evaluated by
   # the User Agent during registration and authentication ceremonies.
-  config.origin = ENV.fetch("CREATORS_HOST")
+  config.origin = Rails.env.production? ? ENV.fetch("CREATORS_HOST") : ENV.fetch("CREATORS_HOST", "https://localhost:3000")
 
   # Relying Party name for display purposes
   config.rp_name = "Brave"

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,0 +1,35 @@
+WebAuthn.configure do |config|
+  # This value needs to match `window.location.origin` evaluated by
+  # the User Agent during registration and authentication ceremonies.
+  config.origin = ENV.fetch("CREATORS_HOST")
+
+  # Relying Party name for display purposes
+  config.rp_name = "Brave"
+
+  # Optionally configure a client timeout hint, in milliseconds.
+  # This hint specifies how long the browser should wait for any
+  # interaction with the user.
+  # This hint may be overridden by the browser.
+  # https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-timeout
+  # config.credential_options_timeout = 120_000
+
+  # You can optionally specify a different Relying Party ID
+  # (https://www.w3.org/TR/webauthn/#relying-party-identifier)
+  # if it differs from the default one.
+  #
+  # In this case the default would be "auth.example.com", but you can set it to
+  # the suffix "example.com"
+  #
+  # config.rp_id = "example.com"
+
+  # Configure preferred binary-to-text encoding scheme. This should match the encoding scheme
+  # used in your client-side (user agent) code before sending the credential to the server.
+  # Supported values: `:base64url` (default), `:base64` or `false` to disable all encoding.
+  #
+  # config.encoding = :base64url
+
+  # Possible values: "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256", "RS384", "RS512", "RS1"
+  # Default: ["ES256", "PS256", "RS256"]
+  #
+  # config.algorithms << "ES384"
+end

--- a/db/migrate/20220202213910_add_format_to_u2f_registrations.rb
+++ b/db/migrate/20220202213910_add_format_to_u2f_registrations.rb
@@ -1,0 +1,5 @@
+class AddFormatToU2fRegistrations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :u2f_registrations, :format, :string, default: 'webauthn'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -149,7 +149,7 @@ ActiveRecord::Schema.define(version: 2022_02_07_192120) do
     t.string "deposit_id"
     t.text "derived_brave_publisher_id"
     t.index ["contested_by_channel_id"], name: "index_channels_on_contested_by_channel_id"
-    t.index ["details_type", "details_id"], name: "index_channels_on_details", unique: true
+    t.index ["details_type", "details_id"], name: "index_channels_on_details_type_and_details_id", unique: true
     t.index ["publisher_id"], name: "index_channels_on_publisher_id"
   end
 
@@ -533,6 +533,7 @@ ActiveRecord::Schema.define(version: 2022_02_07_192120) do
     t.jsonb "feature_flags", default: {}
     t.string "selected_wallet_provider_type"
     t.uuid "selected_wallet_provider_id"
+    t.string "bitflyer_deposit_id"
     t.string "session_salt"
     t.index "lower((email)::text)", name: "index_publishers_on_lower_email", unique: true
     t.index ["created_at"], name: "index_publishers_on_created_at"
@@ -687,6 +688,7 @@ ActiveRecord::Schema.define(version: 2022_02_07_192120) do
     t.uuid "publisher_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "format", default: "webauthn"
     t.index ["key_handle"], name: "index_u2f_registrations_on_key_handle"
     t.index ["publisher_id"], name: "index_u2f_registrations_on_publisher_id"
   end

--- a/lib/tasks/database_updates/u2f.rake
+++ b/lib/tasks/database_updates/u2f.rake
@@ -1,0 +1,11 @@
+namespace :database_updates do
+  desc "For adding Webauthn, convert u2f PKs to urlsafe Base64"
+  task convert_u2f_public_key_format: :environment do
+    U2fRegistration.find_each do |r|
+      r.format = :u2f
+      r.public_key = Base64.urlsafe_encode64(Base64.decode64(r.public_key))
+      r.save!
+    end
+    puts "Done!"
+  end
+end

--- a/test/controllers/u2f_registrations_controller_test.rb
+++ b/test/controllers/u2f_registrations_controller_test.rb
@@ -22,20 +22,12 @@ class U2fRegistrationsControllerTest < ActionDispatch::IntegrationTest
   test "U2F registration creation" do
     sign_in publishers(:verified)
 
-    mock_u2f_registration = stub(
-      certificate: "cert",
-      key_handle: "handle",
-      public_key: "sdf",
-      counter: 1
-    )
-    U2fRegistrationsController.any_instance.stubs(:u2f).returns(mock(register!: mock_u2f_registration))
+    TwoFactorAuth::WebauthnRegistrationService.any_instance.stubs(:call).returns(success_struct_empty)
 
-    assert_difference("U2fRegistration.count") do
-      post u2f_registrations_path, params: {
-        u2f_registration: {name: "Name"},
-        u2f_response: canned_u2f_response
-      }
-    end
+    post u2f_registrations_path, params: {
+      u2f_registration: {name: "Name"},
+      u2f_response: canned_u2f_response
+    }
 
     assert_redirected_to controller: "/publishers/security", action: "index"
     refute @request.flash[:modal_partial]
@@ -44,22 +36,14 @@ class U2fRegistrationsControllerTest < ActionDispatch::IntegrationTest
   test "U2F registration creation after prompt" do
     sign_in publishers(:verified)
 
-    mock_u2f_registration = stub(
-      certificate: "cert",
-      key_handle: "handle",
-      public_key: "sdf",
-      counter: 1
-    )
-    U2fRegistrationsController.any_instance.stubs(:u2f).returns(mock(register!: mock_u2f_registration))
+    TwoFactorAuth::WebauthnRegistrationService.any_instance.stubs(:call).returns(success_struct_empty)
 
     get prompt_security_publishers_path
 
-    assert_difference("U2fRegistration.count") do
-      post u2f_registrations_path, params: {
-        u2f_registration: {name: "Name"},
-        u2f_response: canned_u2f_response
-      }
-    end
+    post u2f_registrations_path, params: {
+      u2f_registration: {name: "Name"},
+      u2f_response: canned_u2f_response
+    }
 
     assert_redirected_to controller: "/publishers", action: "home"
     assert @request.flash[:modal_partial]
@@ -90,20 +74,12 @@ class U2fRegistrationsControllerTest < ActionDispatch::IntegrationTest
     another_session = open_session
     another_session.sign_in publisher
 
-    mock_u2f_registration = stub(
-      certificate: "cert",
-      key_handle: "handle",
-      public_key: "sdf",
-      counter: 1
-    )
-    U2fRegistrationsController.any_instance.stubs(:u2f).returns(mock(register!: mock_u2f_registration))
+    TwoFactorAuth::WebauthnRegistrationService.any_instance.stubs(:call).returns(success_struct_empty)
 
-    assert_difference("U2fRegistration.count") do
-      post u2f_registrations_path, params: {
-        u2f_registration: {name: "Name"},
-        u2f_response: canned_u2f_response
-      }
-    end
+    post u2f_registrations_path, params: {
+      u2f_registration: {name: "Name"},
+      u2f_response: canned_u2f_response
+    }
 
     assert_redirected_to controller: "/publishers/security", action: "index"
     refute @request.flash[:modal_partial]

--- a/test/services/two_factor_authentication/webauthn_registration_service_test.rb
+++ b/test/services/two_factor_authentication/webauthn_registration_service_test.rb
@@ -1,0 +1,49 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WebauthnRegistrationServiceTest < ActiveSupport::TestCase
+  test "success creates a new registration" do
+    publisher = publishers(:completed)
+    mock_credential = mock
+    mock_credential.expects(:verify).with(5).returns(true)
+    mock_credential.expects(:id).returns(1)
+    mock_credential.expects(:public_key).returns(1)
+    mock_credential.expects(:sign_count).returns(1)
+
+    mock_credentialer = mock
+    mock_credentialer.expects(:from_create).returns(mock_credential)
+
+    registrar = TwoFactorAuth::WebauthnRegistrationService.new(webauthn_credentialer: mock_credentialer)
+
+    assert_difference("U2fRegistration.count") do
+      result = registrar.call(publisher: publisher,
+        webauthn_response: JSON.dump(""),
+        name: "name",
+        challenge: 5)
+
+      assert result.result
+    end
+  end
+
+  test "failure creates no new registration" do
+    publisher = publishers(:completed)
+    mock_credential = mock
+    mock_credential.expects(:verify).raises(WebAuthn::Error.new)
+
+    mock_credentialer = mock
+    mock_credentialer.expects(:from_create).returns(mock_credential)
+
+    registrar = TwoFactorAuth::WebauthnRegistrationService.new(webauthn_credentialer: mock_credentialer)
+
+    refute_difference("U2fRegistration.count") do
+      result = registrar.call(publisher: publisher,
+        webauthn_response: JSON.dump(""),
+        name: "name",
+        challenge: 5)
+
+      assert result.errors
+    end
+  end
+end

--- a/test/test_helpers/service_class_helpers.rb
+++ b/test/test_helpers/service_class_helpers.rb
@@ -1,10 +1,12 @@
 # typed: false
+
+require "#{Rails.root}/app/services/builder_base_service"
 module ServiceClassHelpers
   def success_struct_empty
-    BSuccess.new(result: true)
+    ::BSuccess.new(result: true)
   end
 
   def error_struct
-    BFailure.new(errors: [StandardError.new("error")])
+    ::BFailure.new(errors: ["error"])
   end
 end

--- a/test/test_helpers/service_class_helpers.rb
+++ b/test/test_helpers/service_class_helpers.rb
@@ -1,10 +1,10 @@
 # typed: false
 module ServiceClassHelpers
   def success_struct_empty
-    OpenStruct.new(success?: true, result: nil, errors: nil)
+    BSuccess.new(result: true)
   end
 
   def error_struct
-    OpenStruct.new(success?: false, result: nil, errors: [StandardError.new("error")])
+    BFailure.new(errors: [StandardError.new("error")])
   end
 end


### PR DESCRIPTION
The old U2F protocol is being phased out. The new Webauthn protocol is
more flexible and nicer to work with. Since most of the registrations are
in U2F, we just keep them there but mark the format. All new registrations
will be done using the Webauthn format. Note we must run the u2f rake job
in prod after deploy to mark them and standardize the base64 encoding of
the already-stored keys.

Tested locally with both a Yubikey that was registered using U2F and a
separate one under Webauthn. With both registered I could log in using
both.

Currently in draft as service refactoring and tests are needed.