### PR TITLE
Builder Base Class changes

### DIFF
--- a/app/services/builder_base_service.rb
+++ b/app/services/builder_base_service.rb
@@ -4,28 +4,32 @@ class BuilderBaseService
   extend T::Helpers
   extend T::Sig
 
-  class SuccessStruct < T::Struct
-    prop :success, TrueClass
-    prop :result, T.any(Hash, String, Array, NilClass)
+  class ::BSuccess < T::Struct
+    prop :result, T.untyped
   end
 
-  class FailureStruct < T::Struct
-    prop :success, FalseClass
+  class ::BFailure < T::Struct
     prop :errors, T::Array[String]
   end
 
-  class ResultStruct < T::Struct
-    prop :success, T::Boolean
-    prop :result, T.any(Hash, String, Array, NilClass)
-  end
+  ServiceResult = T.type_alias { T.any(BSuccess, BFailure) }
 
   abstract!
 
-  sig { abstract.returns(BuilderBaseService) }
+  sig { abstract.returns(T.self_type) }
   def self.build
   end
 
-  sig { abstract.returns(T.any(SuccessStruct, FailureStruct, ResultStruct)) }
+  sig { abstract.returns(ServiceResult) }
   def call
+  end
+
+  def pass(val = true)
+    T.must(val)
+    BSuccess.new(result: val)
+  end
+
+  def problem(e)
+    BFailure.new(errors: [e])
   end
 end

--- a/test/services/builder_base_service_test.rb
+++ b/test/services/builder_base_service_test.rb
@@ -30,14 +30,14 @@ class BuilderBaseServiceTest < ActiveSupport::TestCase
     end
 
     def call(service: "service")
-      BuilderBaseService::SuccessStruct.new(result: service, success: true)
+      pass
     end
   end
 
   test ValidChildOfBuilderBaseService.name do
     output = ValidChildOfBuilderBaseService.build.call
-    assert_instance_of(BuilderBaseService::SuccessStruct, output)
-    assert output.result == "service"
+    assert_instance_of(BSuccess, output)
+    assert output.result == true
   end
 
   class FailedChildOfBuilderBaseService < BuilderBaseService
@@ -46,13 +46,13 @@ class BuilderBaseServiceTest < ActiveSupport::TestCase
     end
 
     def call(service: "service")
-      BuilderBaseService::FailureStruct.new(errors: ["We could not succeed"], success: false)
+      BFailure.new(errors: ["We could not succeed"])
     end
   end
 
   test FailedChildOfBuilderBaseService.name do
     output = FailedChildOfBuilderBaseService.build.call
-    assert_instance_of(BuilderBaseService::FailureStruct, output)
+    assert_instance_of(BFailure, output)
     assert !output.errors.empty?
   end
 end


### PR DESCRIPTION
We introduce a union type which can be distinguished by pattern matching

The reason for this is we want Sorbet to help us as much as possible. If
we have an error, we don't want to accidentally put those in a success
callback. With the fields of the success/error structs being different,
sorbet can now help prevent sensitive information escaping.

An example of usage:

```ruby
  case res = ChildService.build.call
  when BFailure
    puts "I can access errors! #{res.errors}"
    problem("1")
  when BSuccess
    puts "I can access result!"
    pass(res.result.add(2))
  else
    T.absurd(res)
  end
```