### PR TITLE
Typed Eyeshade::Client and Eyeshade::Balances

### DIFF
--- a/lib/eyeshade/balances.rb
+++ b/lib/eyeshade/balances.rb
@@ -1,0 +1,147 @@
+# typed: true
+
+module Eyeshade
+  class Balances
+    include Eyeshade::Types
+    extend T::Sig
+
+    CHANNEL = "channel"
+    REFERRAL = "owner"
+
+    attr_reader :rates,
+      :default_currency,
+      :accounts
+
+    sig { params(rates: EyeshadeObject, accounts: EyeshadeArray, transactions: EyeshadeArray, default_currency: T.nilable(String)).void }
+    def initialize(rates: {}, accounts: [], transactions: [], default_currency: nil)
+      @rates = rates
+      @accounts = []
+      @account_type_hash = {}
+      @default_currency = default_currency
+      @amount_probi = 0
+      @fees_probi = 0
+      @zero = BigDecimal("0")
+
+      accounts.each do |account|
+        type = account.fetch("account_type", nil)
+        next if !type
+
+        account_struct = Account.new(account_type: type, account_id: T.must(account["account_id"]), balance: T.must(account["balance"]))
+
+        @accounts.append(account_struct)
+
+        if @account_type_hash.fetch(type, nil)
+          @account_type_hash[type].append(account_struct)
+        else
+          @account_type_hash[type] = [account_struct]
+        end
+      end
+    end
+
+    sig { returns(Balance) }
+    def overall_balance
+      balance(source: nil)
+    end
+
+    sig { returns(T::Array[Balance]) }
+    def channel_balances
+      @account_type_hash.fetch(CHANNEL, []).map { |account| account_balance(account) }
+    end
+
+    sig { returns(Balance) }
+    def referral_balance
+      balance(source: REFERRAL)
+    end
+
+    sig { returns(Balance) }
+    def contribution_balance
+      balance(source: "contribution")
+    end
+
+    sig { returns(Balance) }
+    def last_settlement_balance
+      balance(source: "settlement")
+    end
+
+    private
+
+    sig { params(source: T.nilable(String)).returns(Balance) }
+    def balance(source: nil)
+      iterable = if source
+        @account_type_hash.fetch(source, [])
+      else
+        @accounts
+      end
+
+      amount_bat = @zero
+      fees_bat = @zero
+      amount_default_currency = @zero
+      amount_usd = @zero
+
+      iterable.each do |account|
+        balance = account_balance(account)
+        amount_bat += balance.amount_bat
+        fees_bat += balance.fees_bat
+        amount_default_currency += balance.amount_default_currency
+        amount_usd += balance.amount_usd
+      end
+
+      Balance.new(amount_usd: amount_usd, amount_bat: amount_bat, fees_bat: fees_bat, amount_default_currency: amount_default_currency)
+    end
+
+    sig { params(account: Account).returns(Balance) }
+    def account_balance(account)
+      total_probi = bat_to_probi(BigDecimal(T.must(account.balance)))
+
+      amount_and_fees = calculate_fees(total_probi)
+      amount_probi = T.must(amount_and_fees["amount"])
+
+      fees_probi = if account.account_type == REFERRAL
+        0
+      else
+        T.must(amount_and_fees["fees"])
+      end
+
+      amount_bat = probi_to_bat(amount_probi)
+
+      fees_bat = probi_to_bat(fees_probi)
+
+      amount_default_currency = convert(amount_bat, @default_currency)
+      # fees_default_currency = convert(fees_bat, @default_currency)
+      amount_usd = convert(amount_bat, "USD")
+
+      Balance.new(amount_usd: amount_usd, amount_bat: amount_bat, fees_bat: fees_bat, amount_default_currency: amount_default_currency)
+    end
+
+    sig { params(amount_bat: BigDecimal, currency: T.nilable(String)).returns(BigDecimal) }
+    def convert(amount_bat, currency)
+      return amount_bat if currency == "BAT"
+      return @zero if currency.nil?
+      rate = @rates[currency]
+      return @zero if rate.nil?
+
+      amount_bat * BigDecimal(T.must(rate))
+    end
+
+    sig { params(probi: Integer).returns(BigDecimal) }
+    def probi_to_bat(probi)
+      probi.to_d / 1E18
+    end
+
+    sig { params(bat: BigDecimal).returns(Integer) }
+    def bat_to_probi(bat)
+      (bat * BigDecimal("1.0e18")).to_i
+    end
+
+    sig { params(total_probi: Integer).returns(T::Hash[String, Integer]) }
+    def calculate_fees(total_probi)
+      fees_probi = (total_probi * fee_rate).to_i
+      amount_probi = total_probi - fees_probi
+      {"amount" => amount_probi, "fees" => fees_probi}
+    end
+
+    def fee_rate
+      Rails.application.secrets[:fee_rate].to_d
+    end
+  end
+end

--- a/lib/eyeshade/client.rb
+++ b/lib/eyeshade/client.rb
@@ -1,0 +1,62 @@
+# typed: true
+
+module Eyeshade
+  class Client < BaseApiClient
+    include Eyeshade::Types
+    extend T::Sig
+
+    StructTypes = T.type_alias { T.any(AccountBalance, Transaction) }
+    ResponseTypes = T.type_alias { T.any(AccountBalances, Transactions) }
+
+    sig { params(payload: T::Hash[String, T.untyped]).returns(AccountBalances) }
+    def accounts_balances(payload)
+      # FIXME use request if you can
+      resp = connection.send(:post) do |req|
+        req.options.open_timeout = 5
+        req.options.timeout = 20
+        req.url client_url("/v1/accounts/balances")
+        req.headers["Authorization"] = api_authorization_header
+        req.headers["Content-Type"] = "application/json"
+        req.body = JSON.dump(payload)
+      end
+
+      parse_array_response_to_struct(resp, AccountBalance)
+    end
+
+    sig { params(id: String).returns(Transactions) }
+    def account_transactions(id)
+      # FIXME: use request
+      resp = connection.get do |request|
+        request.headers["Authorization"] = api_authorization_header
+        request.url client_url("/v1/accounts/#{id}/transactions")
+      end
+
+      parse_array_response_to_struct(resp, Transaction)
+    end
+
+    private
+
+    # This throws an error that... I don't thinkis correct.
+    #    sig { params(response: ActiveRecord::Response, struct: StructTypes).returns(ResponseTypes) }
+    def parse_array_response_to_struct(response, struct)
+      if response.success?
+        data = JSON.parse(response.body, symbolize_names: true)
+        data.map { |obj| struct.new(**obj) }
+      else
+        []
+      end
+    end
+
+    def client_url(path)
+      [api_base_uri, path].join("")
+    end
+
+    def api_base_uri
+      Rails.application.secrets[:api_eyeshade_base_uri]
+    end
+
+    def api_authorization_header
+      "Bearer #{Rails.application.secrets[:api_eyeshade_key]}"
+    end
+  end
+end

--- a/lib/eyeshade/types.rb
+++ b/lib/eyeshade/types.rb
@@ -4,21 +4,43 @@ module Eyeshade
   module Types
     extend T::Sig
 
-    class Balance < T::Struct
+    class ConvertedBalance < T::Struct
       const :amount_bat, BigDecimal
       const :fees_bat, BigDecimal
       const :amount_default_currency, BigDecimal
       const :amount_usd, BigDecimal
     end
 
-    class Account < T::Struct
+    # See: https://github.com/brave-intl/bat-ledger/blob/dfa58715e1e14278a7dde545c7dd3fe68621deff/eyeshade/controllers/accounts.js#L304-L312
+    class AccountBalance < T::Struct
       const :account_type, String
       const :account_id, String
       const :balance, String
     end
 
+    # See: https://github.com/brave-intl/bat-ledger/blob/dfa58715e1e14278a7dde545c7dd3fe68621deff/eyeshade/controllers/accounts.js#L159-L176
+    class Transaction < T::Struct
+      const :created_at, String
+      const :description, String
+      const :channel, String
+      const :amount, String
+      const :transaction_type, String
+
+      # FIXME: I don't know if these are actually nilable but the example response data I have
+      # was either missing/incorrect or both.
+      prop :settlement_currency, T.nilable(String)
+      prop :settlement_amount, T.nilable(String)
+      prop :settlement_destination_type, T.nilable(String)
+      prop :settlement_destination, T.nilable(String)
+      prop :to_account, T.nilable(String)
+      prop :from_account, T.nilable(String)
+    end
+
     # All eyeshade values are strings
     EyeshadeObject = T.type_alias { T::Hash[String, String] }
     EyeshadeArray = T.type_alias { T::Array[EyeshadeObject] }
+    Transactions = T.type_alias { T::Array[Transaction] }
+    AccountBalances = T.type_alias { T::Array[AccountBalance] }
+    ConvertedBalances = T.type_alias { T::Array[ConvertedBalance] }
   end
 end

--- a/lib/eyeshade/types.rb
+++ b/lib/eyeshade/types.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+module Eyeshade
+  module Types
+    extend T::Sig
+
+    class Balance < T::Struct
+      const :amount_bat, BigDecimal
+      const :fees_bat, BigDecimal
+      const :amount_default_currency, BigDecimal
+      const :amount_usd, BigDecimal
+    end
+
+    class Account < T::Struct
+      const :account_type, String
+      const :account_id, String
+      const :balance, String
+    end
+
+    # All eyeshade values are strings
+    EyeshadeObject = T.type_alias { T::Hash[String, String] }
+    EyeshadeArray = T.type_alias { T::Array[EyeshadeObject] }
+  end
+end

--- a/test/lib/eyeshade/balances_test.rb
+++ b/test/lib/eyeshade/balances_test.rb
@@ -1,0 +1,35 @@
+# typed: false
+require "test_helper"
+
+class EyeshadeBalancesTest < ActiveSupport::TestCase
+  # I'm leaving wallet nomenclature here, balances is basically a v2 of eyeshade wallet that
+  # is intended to be backwards compatible
+  let(:wallet) { EyeshadeHelper.balances }
+  let(:existing_methods) { [:rates, :default_currency, :channel_balances, :referral_balance, :overall_balance, :contribution_balance, :last_settlement_balance, :accounts] }
+
+  test "#init" do
+    assert_instance_of(Eyeshade::Balances, wallet)
+    existing_methods.each do |method|
+      assert_respond_to(wallet, method)
+    end
+  end
+
+  test "#overall_balance" do
+    assert_kind_of(Eyeshade::Types::Balance, wallet.overall_balance)
+    assert wallet.overall_balance.amount_bat > 0
+    assert wallet.overall_balance.fees_bat > 0
+  end
+
+  test "#channel_balances" do
+    result = wallet.channel_balances
+    assert_kind_of(Array, result)
+    assert result[0].amount_bat > 0
+    assert result[0].fees_bat > 0
+  end
+
+  test "#referral_balance" do
+    assert_kind_of(Eyeshade::Types::Balance, wallet.referral_balance)
+    assert wallet.referral_balance.amount_bat > 0
+    assert wallet.referral_balance.fees_bat == 0
+  end
+end

--- a/test/lib/eyeshade/balances_test.rb
+++ b/test/lib/eyeshade/balances_test.rb
@@ -2,9 +2,10 @@
 require "test_helper"
 
 class EyeshadeBalancesTest < ActiveSupport::TestCase
+  include Eyeshade::Types
   # I'm leaving wallet nomenclature here, balances is basically a v2 of eyeshade wallet that
   # is intended to be backwards compatible
-  let(:wallet) { EyeshadeHelper.balances }
+  let(:wallet) { EyeshadeHelper::Mocks.balances }
   let(:existing_methods) { [:rates, :default_currency, :channel_balances, :referral_balance, :overall_balance, :contribution_balance, :last_settlement_balance, :accounts] }
 
   test "#init" do
@@ -15,7 +16,7 @@ class EyeshadeBalancesTest < ActiveSupport::TestCase
   end
 
   test "#overall_balance" do
-    assert_kind_of(Eyeshade::Types::Balance, wallet.overall_balance)
+    assert_kind_of(ConvertedBalance, wallet.overall_balance)
     assert wallet.overall_balance.amount_bat > 0
     assert wallet.overall_balance.fees_bat > 0
   end
@@ -28,7 +29,7 @@ class EyeshadeBalancesTest < ActiveSupport::TestCase
   end
 
   test "#referral_balance" do
-    assert_kind_of(Eyeshade::Types::Balance, wallet.referral_balance)
+    assert_kind_of(ConvertedBalance, wallet.referral_balance)
     assert wallet.referral_balance.amount_bat > 0
     assert wallet.referral_balance.fees_bat == 0
   end

--- a/test/lib/eyeshade/client_test.rb
+++ b/test/lib/eyeshade/client_test.rb
@@ -1,0 +1,48 @@
+# typed: false
+require "test_helper"
+
+class EyeshadeClientTest < ActiveSupport::TestCase
+  include EyeshadeHelper
+  include Eyeshade::Types
+
+  let(:described_class) { Eyeshade::Client }
+  let(:inst) { described_class.new }
+  let(:id) { "some_id" }
+  let(:payload) { {body: "some content"} }
+
+  describe "#init" do
+    it "should return self" do
+      assert_instance_of(Eyeshade::Client, inst)
+    end
+  end
+
+  describe "#accounts_balances" do
+    let(:payload) { {body: "some content"} }
+    let(:publisher) { publishers(:default) }
+
+    before do
+      stub_request(:post, /v1\/accounts\/balances/)
+        .to_return(status: 200, body: Mocks.accounts_balances.to_json)
+    end
+
+    test "should return array" do
+      result = inst.accounts_balances(payload)
+      assert_instance_of(Array, result)
+    end
+  end
+
+  describe "#transactions" do
+    let(:payload) { "identifier" }
+    let(:publisher) { publishers(:default) }
+
+    before do
+      stub_request(:get, /v1\/accounts\/identifier\/transactions/)
+        .to_return(status: 200, body: Mocks.account_transactions.to_json)
+    end
+
+    test "should return array" do
+      result = inst.account_transactions(payload)
+      assert_instance_of(Array, result)
+    end
+  end
+end

--- a/test/test_helpers/eyeshade_helper.rb
+++ b/test/test_helpers/eyeshade_helper.rb
@@ -1,5 +1,9 @@
 # typed: false
 module EyeshadeHelper
+  def self.balances(rates: Ratio.rates, transactions: Transactions.transactions, accounts: Balances.accounts)
+    Eyeshade::Balances.new(rates: rates, transactions: transactions, accounts: accounts)
+  end
+
   def stub_eyeshade_transactions_response(publisher:, transactions: [])
     stub_request(:get, "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/accounts/#{URI.encode_www_form_component(publisher.owner_identifier)}/transactions")
       .to_return(status: 200, body: transactions.to_json, headers: {})
@@ -15,5 +19,197 @@ module EyeshadeHelper
   def stub_all_eyeshade_wallet_responses(publisher:, wallet: {}, balances: [], transactions: [])
     stub_eyeshade_transactions_response(publisher: publisher, transactions: transactions)
     stub_eyeshade_balances_response(publisher: publisher, balances: balances)
+  end
+
+  module Ratio
+    extend T::Sig
+    include Eyeshade::Types
+
+    sig { returns(EyeshadeObject) }
+    # Note: I'm defining easily reasonable fixed rates for use in calculations/speccing.
+    # It was very difficult to reason about where/how values were being calculated.
+    def self.rates
+      {
+        "BTC" => "10",
+        "ETH" => "1",
+        "USD" => "100",
+        "EUR" => "0.1",
+        "GBP" => "0.01"
+      }
+    end
+  end
+
+  module Balances
+    extend T::Sig
+    include Eyeshade::Types
+
+    sig { returns(EyeshadeArray) }
+    def self.accounts
+      [
+        {
+          "account_id" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+          "account_type" => "channel",
+          "balance" => "10"
+        },
+        {
+          "account_id" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+          "account_type" => "channel",
+          "balance" => "20"
+        },
+        {
+          "account_id" => "publishers#uuid:ef060682-bafc-4f9b-acc7-77baec5e8d50",
+          "account_type" => "owner",
+          "balance" => "30"
+        }
+      ]
+    end
+  end
+
+  module Transactions
+    include Eyeshade::Types
+    extend T::Sig
+
+    sig { params(settlement_amount: String, amount: String).returns(EyeshadeArray) }
+    def self.referral_payout(settlement_amount: "10", amount: "-10")
+      [{"created_at" => "2018-11-07 00:00:00 -0800",
+        "description" => "payout for referrals",
+        "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
+        "amount" => amount,
+        "settlement_currency" => "ETH",
+        "settlement_amount" => settlement_amount,
+        "type" => "referral_settlement"}]
+    end
+
+    sig { returns(EyeshadeArray) }
+    def self.transactions
+      [{"created_at" => "2018-11-07 00:00:00 -0800",
+        "description" => "payout for referrals",
+        "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
+        "amount" => "-94.617182149806375904",
+        "settlement_currency" => "ETH",
+        "settlement_amount" => "18.81",
+        "type" => "referral_settlement"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "contributions in month x",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "294.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "contribution"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "settlement fees for contributions",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "-14.730859107490318795",
+         "settlement_currency" => "ETH",
+         "type" => "fee"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "payout for contributions",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "-279.886323042316057109",
+         "settlement_currency" => "ETH",
+         "settlement_amount" => "56.81",
+         "type" => "contribution_settlement"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "referrals in month x",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "94.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "referral"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "payout for referrals",
+         "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
+         "amount" => "-94.617182149806375904",
+         "settlement_currency" => "ETH",
+         "settlement_amount" => "18.81",
+         "type" => "referral_settlement"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "contributions in month x",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "294.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "contribution"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "settlement fees for contributions",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "-14.730859107490318795",
+         "settlement_currency" => "ETH",
+         "type" => "fee"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "payout for contributions",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "-279.886323042316057109",
+         "settlement_currency" => "ETH",
+         "settlement_amount" => "56.81",
+         "type" => "contribution_settlement"},
+        {"created_at" => "2018-11-07 00:00:00 -0800",
+         "description" => "referrals in month x",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "94.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "referral"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "payout for referrals",
+         "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
+         "amount" => "-94.617182149806375904",
+         "settlement_currency" => "ETH",
+         "settlement_amount" => "18.81",
+         "type" => "referral_settlement"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "settlement fees for contributions",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "-14.730859107490318795",
+         "settlement_currency" => "ETH",
+         "type" => "fee"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "payout for contributions",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "-279.886323042316057109",
+         "settlement_currency" => "ETH",
+         "settlement_amount" => "56.81",
+         "type" => "contribution_settlement"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "referrals in month x",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "94.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "referral"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "payout for referrals",
+         "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
+         "amount" => "-94.617182149806375904",
+         "settlement_currency" => "ETH",
+         "settlement_amount" => "18.81",
+         "type" => "referral_settlement"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "contributions in month x",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "294.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "contribution"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "settlement fees for contributions",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "-14.730859107490318795",
+         "settlement_currency" => "ETH",
+         "type" => "fee"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "payout for contributions",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "-279.886323042316057109",
+         "settlement_currency" => "ETH",
+         "settlement_amount" => "56.81",
+         "type" => "contribution_settlement"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "referrals in month x",
+         "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
+         "amount" => "94.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "referral"},
+        {"created_at" => "2018-12-07 00:00:00 -0800",
+         "description" => "contributions in month x",
+         "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
+         "amount" => "294.617182149806375904",
+         "settlement_currency" => "ETH",
+         "type" => "contribution"}]
+    end
   end
 end

--- a/test/test_helpers/eyeshade_helper.rb
+++ b/test/test_helpers/eyeshade_helper.rb
@@ -1,9 +1,5 @@
 # typed: false
 module EyeshadeHelper
-  def self.balances(rates: Ratio.rates, transactions: Transactions.transactions, accounts: Balances.accounts)
-    Eyeshade::Balances.new(rates: rates, transactions: transactions, accounts: accounts)
-  end
-
   def stub_eyeshade_transactions_response(publisher:, transactions: [])
     stub_request(:get, "#{Rails.application.secrets[:api_eyeshade_base_uri]}/v1/accounts/#{URI.encode_www_form_component(publisher.owner_identifier)}/transactions")
       .to_return(status: 200, body: transactions.to_json, headers: {})
@@ -21,9 +17,9 @@ module EyeshadeHelper
     stub_eyeshade_balances_response(publisher: publisher, balances: balances)
   end
 
-  module Ratio
-    extend T::Sig
+  module Mocks
     include Eyeshade::Types
+    extend T::Sig
 
     sig { returns(EyeshadeObject) }
     # Note: I'm defining easily reasonable fixed rates for use in calculations/speccing.
@@ -37,14 +33,9 @@ module EyeshadeHelper
         "GBP" => "0.01"
       }
     end
-  end
-
-  module Balances
-    extend T::Sig
-    include Eyeshade::Types
 
     sig { returns(EyeshadeArray) }
-    def self.accounts
+    def self.accounts_balances
       [
         {
           "account_id" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
@@ -63,11 +54,6 @@ module EyeshadeHelper
         }
       ]
     end
-  end
-
-  module Transactions
-    include Eyeshade::Types
-    extend T::Sig
 
     sig { params(settlement_amount: String, amount: String).returns(EyeshadeArray) }
     def self.referral_payout(settlement_amount: "10", amount: "-10")
@@ -77,139 +63,159 @@ module EyeshadeHelper
         "amount" => amount,
         "settlement_currency" => "ETH",
         "settlement_amount" => settlement_amount,
-        "type" => "referral_settlement"}]
+        "transaction_type" => "referral_settlement"}]
     end
 
+    # See https://github.com/brave-intl/bat-ledger/blob/dfa58715e1e14278a7dde545c7dd3fe68621deff/eyeshade/controllers/accounts.js#L159-L175
+    # for schema
     sig { returns(EyeshadeArray) }
-    def self.transactions
+    def self.account_transactions
       [{"created_at" => "2018-11-07 00:00:00 -0800",
         "description" => "payout for referrals",
         "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
         "amount" => "-94.617182149806375904",
         "settlement_currency" => "ETH",
         "settlement_amount" => "18.81",
-        "type" => "referral_settlement"},
+        "transaction_type" => "referral_settlement"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "contributions in month x",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "294.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "contribution"},
+         "transaction_type" => "contribution"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "settlement fees for contributions",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "-14.730859107490318795",
          "settlement_currency" => "ETH",
-         "type" => "fee"},
+         "transaction_type" => "fee"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "payout for contributions",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "-279.886323042316057109",
          "settlement_currency" => "ETH",
          "settlement_amount" => "56.81",
-         "type" => "contribution_settlement"},
+         "transaction_type" => "contribution_settlement"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "referrals in month x",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "94.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "referral"},
+         "transaction_type" => "referral"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "payout for referrals",
          "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
          "amount" => "-94.617182149806375904",
          "settlement_currency" => "ETH",
          "settlement_amount" => "18.81",
-         "type" => "referral_settlement"},
+         "transaction_type" => "referral_settlement"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "contributions in month x",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "294.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "contribution"},
+         "transaction_type" => "contribution"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "settlement fees for contributions",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "-14.730859107490318795",
          "settlement_currency" => "ETH",
-         "type" => "fee"},
+         "transaction_type" => "fee"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "payout for contributions",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "-279.886323042316057109",
          "settlement_currency" => "ETH",
          "settlement_amount" => "56.81",
-         "type" => "contribution_settlement"},
+         "transaction_type" => "contribution_settlement"},
         {"created_at" => "2018-11-07 00:00:00 -0800",
          "description" => "referrals in month x",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "94.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "referral"},
+         "transaction_type" => "referral"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "payout for referrals",
          "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
          "amount" => "-94.617182149806375904",
          "settlement_currency" => "ETH",
          "settlement_amount" => "18.81",
-         "type" => "referral_settlement"},
+         "transaction_type" => "referral_settlement"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "settlement fees for contributions",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "-14.730859107490318795",
          "settlement_currency" => "ETH",
-         "type" => "fee"},
+         "transaction_type" => "fee"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "payout for contributions",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "-279.886323042316057109",
          "settlement_currency" => "ETH",
          "settlement_amount" => "56.81",
-         "type" => "contribution_settlement"},
+         "transaction_type" => "contribution_settlement"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "referrals in month x",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "94.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "referral"},
+         "transaction_type" => "referral"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "payout for referrals",
          "channel" => "publishers#uuid:8a16cdb5-90c4-437a-b4fd-1445f82b2f6b",
          "amount" => "-94.617182149806375904",
          "settlement_currency" => "ETH",
          "settlement_amount" => "18.81",
-         "type" => "referral_settlement"},
+         "transaction_type" => "referral_settlement"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "contributions in month x",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "294.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "contribution"},
+         "transaction_type" => "contribution"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "settlement fees for contributions",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "-14.730859107490318795",
          "settlement_currency" => "ETH",
-         "type" => "fee"},
+         "transaction_type" => "fee"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "payout for contributions",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "-279.886323042316057109",
          "settlement_currency" => "ETH",
          "settlement_amount" => "56.81",
-         "type" => "contribution_settlement"},
+         "transaction_type" => "contribution_settlement"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "referrals in month x",
          "channel" => "youtube#channel:UCtsfHRe2WQnkNH5WYJWL-Yw",
          "amount" => "94.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "referral"},
+         "transaction_type" => "referral"},
         {"created_at" => "2018-12-07 00:00:00 -0800",
          "description" => "contributions in month x",
          "channel" => "youtube#channel:UCOo92t8m-tWKgmw256q7mxw",
          "amount" => "294.617182149806375904",
          "settlement_currency" => "ETH",
-         "type" => "contribution"}]
+         "transaction_type" => "contribution"}]
+    end
+
+    module Structs
+      extend T::Sig
+      include Eyeshade::Types
+
+      def self.account_balances
+        Mocks.accounts_balances.map { |obj| AccountBalance.new(**obj.symbolize_keys!) }
+      end
+
+      def self.transactions
+        Mocks.account_transactions.map { |obj| Transaction.new(**obj.symbolize_keys!) }
+      end
+    end
+
+    # Primary balances mock object
+    def self.balances(rates: Mocks.rates, transactions: Structs.transactions, account_balances: Structs.account_balances)
+      Eyeshade::Balances.new(rates: rates, transactions: transactions, account_balances: account_balances)
     end
   end
 end


### PR DESCRIPTION
## Pull Request Name

Typed Eyeshade::Client and Eyeshade::Balances

#### Features

I'm effectively V2'ing Eyeshade::Wallet, PublisherBalancesGetter, and PublishersTransactionsGetter (among others) in favor of typed objects with immutable data containers.  The financial aspect of the eyeshade interactions is far too important to leave untyped and in it's current format.

#### How To Test

1. Step one
2. Step two
3. Step three

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
