### PR TITLE
task: Do not fail builds for dev dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,8 +70,10 @@ jobs:
         run: bundle exec standardrb
       - name: Brakeman
         run: bundle exec brakeman
-      - name: Yarn audit
-        run: npx audit-ci --config .audit-ci.json && (cd public/creators-landing && npx audit-ci --config ../../.audit-ci.json)
+      - name: Yarn audit js assets
+        run: yarn audit --groups dependencies
+      - name: Yarn audit landing-page
+        run: cd public/creators-landing && yarn audit --groups dependencies
       - name: Bundler Audit
         run: bundle exec bundle-audit check --update
 


### PR DESCRIPTION
We are getting smacked in the face WRT to momentum because we are blocking builds on audits of dev-dependencies that never leave the local stack.  I've updated the lint tasks to run against the actual production dependencies and removed the allowed CVE list.

We keep getting hit with vulnerabilities in `webpack-dev-server` which never leaves the local context.