### PR TITLE
Run security audits on production/master PR. Run tests/lint on push

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,16 +5,12 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Lint
-
+name: Audit
 on:
-  push:
-    branches: [ master, staging, dev ]
   pull_request:
-    branches: [ master, staging ]
-
+    branches: [ master ]
 jobs:
-  lint:
+  audit:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -29,7 +25,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
@@ -62,11 +57,8 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Yarn install
         run: yarn --frozen-lockfile
-      - name: Sorbet Linter
-        run: bundle exec rubocop --require rubocop-sorbet -c .rubocop-sorbet.yml
-      - name: Sorbet Type Check
-        run: bundle exec srb tc
-      - name: Standard
-        run: bundle exec standardrb
-      - name: Brakeman
-        run: bundle exec brakeman
+      - name: Yarn audit
+        run: npx audit-ci --config .audit-ci.json && (cd public/creators-landing && npx audit-ci --config ../../.audit-ci.json)
+      - name: Bundler Audit
+        run: bundle exec bundle-audit check --update
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,8 +70,10 @@ jobs:
         run: bundle exec standardrb
       - name: Brakeman
         run: bundle exec brakeman
-      - name: Yarn audit
-        run: npx audit-ci --config .audit-ci.json && (cd public/creators-landing && npx audit-ci --config ../../.audit-ci.json)
+      - name: Yarn audit js assets
+        run: yarn audit --groups dependencies
+      - name: Yarn audit landing-page
+        run: cd public/creators-landing && yarn audit --groups dependencies
       - name: Bundler Audit
         run: bundle exec bundle-audit check --update
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,7 @@
 
 name: Lint
 
-on:
-  push:
-    branches: [ master, staging, dev ]
-  pull_request:
-    branches: [ master, staging ]
-
+on: [push]
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I closed the previous PR as I was testing triggers, but I think the changes here should satisfy the concerns.  We can merge/deploy into staging so we can iterate quickly, but to deploy to prod we need to have passing builds on PR for security audits.