### PR TITLE
Task/disable chromium arm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -231,7 +231,7 @@ group :development, :test do
   gem "minitest"
   gem "minitest-rails"
   gem "mocha"
-  gem "chromedriver-helper"
+  gem "chromedriver-helper", require: false if not_arm?
   gem "simplecov", require: false, group: :test
   gem "selenium-webdriver", "~> 3.142.0"
   gem "solargraph"


### PR DESCRIPTION
This is an unfortunate action that needs to be taken for the moment.  We are going to need to identify a set of dependencies and a chromium version that works both with the ARM/x86 architectures.  Unfortunately, chromedriver/helper is not available for aarch64 and unless we conditionally require it as such you cannot run _any tests_ at all locally in a docker context with the m1.

This is a temporary task I need to implement to be able to get any work done without getting sideswiped again by the ARM architecture problems.