### PR TITLE
task: Audit runtime dependencies only

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,9 +6,14 @@
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
 name: Audit
-on:
-  pull_request:
-    branches: [ master ]
+on: 
+  # We audit when code is integrated into staging so we continue to ensure any dependency updates
+  # are made prior to production
+  #
+  # We rely on dependabot to alert us to non-runtime/dev dependencies in the mean time
+  push:
+    branches: 
+      - staging
 jobs:
   audit:
     runs-on: ubuntu-latest
@@ -58,7 +63,7 @@ jobs:
       - name: Yarn install
         run: yarn --frozen-lockfile
       - name: Yarn audit
-        run: npx audit-ci --config .audit-ci.json && (cd public/creators-landing && npx audit-ci --config ../../.audit-ci.json)
+        run: yarn audit --groups dependencies && (cd public/creators-landing && yarn audit --groups dependencies)
       - name: Bundler Audit
         run: bundle exec bundle-audit check --update
 


### PR DESCRIPTION
Audit on staging push, check only runtime dependencies.

I updated the trigger to be any push/merge of code to staging to ensure it was always run.  I oddly enough I noticed that the audit task was run only on the initial PR to master, and not afterwards.  Github actions are sometimes difficult to reason about, but this definitely runs anytime code is integrated into stagnig.