### PR TITLE
Release 3/28/22: Addition of country dropdown data to Settings [ Feature Flagged ]

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,7 +29,7 @@ RUN RAILS_ENV=development
 
 # Install the gems.
 RUN gem install nokogiri
-RUN bundle check || bundle install --jobs 20 --retry 5
+RUN bundle install --jobs 20
 
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 14.16.1

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -1,5 +1,6 @@
 # typed: ignore
 require "digest/md5"
+require "countries"
 
 class Publisher < ApplicationRecord
   include UserFeatureFlags
@@ -510,6 +511,10 @@ class Publisher < ApplicationRecord
   end
 
   class << self
+    def available_countries
+      ISO3166::Country.all_names_with_codes
+    end
+
     def encryption_key(key: Rails.application.secrets[:attr_encrypted_key])
       # Truncating the key due to legacy OpenSSL truncating values to 32 bytes.
       # New implementations should use [Rails.application.secrets[:attr_encrypted_key]].pack("H*")

--- a/app/views/publishers/settings/index.html.slim
+++ b/app/views/publishers/settings/index.html.slim
@@ -20,6 +20,10 @@
 - if @publisher.location_enabled?
   .single-panel--wrapper.single-panel--wrapper--large.single-panel--wrapper--short.mb-4
     .single-panel--padded-content--short-padding#publishers_location
+      h5 Location (Needs Locales)
+      = form_with(model: @publisher, url: "/", html: { id: "update_location_selection", class: 'mt-4' }) do |f|
+        = select_tag :update_location, options_for_select(@publisher.class.available_countries)
+
 
 .single-panel--wrapper.single-panel--wrapper--large.single-panel--wrapper--short.mb-4
   .single-panel--padded-content--short-padding#publishers_contact

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -14,3 +14,7 @@ task :create_admin_user, [:email] => [:environment] do |task, args|
     end
   end
 end
+
+task :enable_location_feature, [:email] => [:environment] do |task, args|
+  Publisher.update_all(feature_flags: {location_enabled: true})
+end


### PR DESCRIPTION
* task: Update dev Dockerfile

The previous command seemed to be overly complicated and I suspect that
it was masking failures.  This seems to work just fine

* feat: Countries Dropdown and minimal location form

Testing: Should be fully backwards compatible/feature flagged.  Settings section should not be visible for staging/production users unless feature is enabled via rake task or console.