### PR TITLE
Feat/refresh job

### DIFF
--- a/app/jobs/oauth2_batch_refresh_job.rb
+++ b/app/jobs/oauth2_batch_refresh_job.rb
@@ -1,0 +1,24 @@
+class Oauth2BatchRefreshJob < ApplicationJob
+  queue_as :scheduler
+
+  def perform(wait: 0, limit: nil)
+    count = 0
+    [UpholdConnection].each do |klass|
+      base_query = limit.present? ? klass.limit(limit) : klass
+
+      # The idea here is I'm filling a queue to refresh tokens from each connection type
+      # while adding a delay so I do not overwhelm the API rate limit of a given provider
+      base_query.select(:id).find_in_batches do |batch|
+        batch.each do |connection|
+          count += 1
+          # I'm using this job to call individual jobs so I can take advantage of retries/failover due to thinks like rate limits
+          # I've used exactly this pattern before to handle mass email jobs, though I don't always wait between enqueing tasks.
+          Oauth2RefreshJob.perform_later(connection.id, klass.name)
+          sleep(wait)
+        end
+      end
+    end
+
+    count
+  end
+end

--- a/app/jobs/oauth2_refresh_job.rb
+++ b/app/jobs/oauth2_refresh_job.rb
@@ -1,0 +1,11 @@
+class Oauth2RefreshJob < ApplicationJob
+  extend T::Sig
+  queue_as :default
+
+  # Serialization of the model is awkward here. Will need to look into it
+  sig { params(connection_id: String, model: Class).returns(Oauth2RefresherService::TYPES) }
+  def perform(connection_id, model)
+    connection = model.find_by_id!(connection_id)
+    Oauth2RefresherService.build.call(connection)
+  end
+end

--- a/app/jobs/oauth2_refresh_job.rb
+++ b/app/jobs/oauth2_refresh_job.rb
@@ -1,11 +1,20 @@
+# typed: true
+
 class Oauth2RefreshJob < ApplicationJob
-  extend T::Sig
   queue_as :default
 
-  # Serialization of the model is awkward here. Will need to look into it
-  sig { params(connection_id: String, model: Class).returns(Oauth2RefresherService::TYPES) }
-  def perform(connection_id, model)
-    connection = model.find_by_id!(connection_id)
-    Oauth2RefresherService.build.call(connection)
+  def perform(connection_id, klass_name)
+    case klass_name
+    when "UpholdConnection"
+      klass = UpholdConnection
+    when "GeminiConnection"
+      klass = GeminiConnection
+    when "BitflyerConnection"
+      klass = BitflyerConnection
+    else
+      raise StandardError.new("Invalid klass_name: #{klass_name}")
+    end
+
+    Oauth2RefresherService.build.call(klass.find_by_id!(connection_id))
   end
 end

--- a/test/jobs/oauth2_batch_refresh_job_test.rb
+++ b/test/jobs/oauth2_batch_refresh_job_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Oauth2BatchRefreshJobTest < ActiveJob::TestCase
+  let(:limit) { 10 }
+
+  describe "#perform" do
+    describe "without args" do
+      test "it should return an integer" do
+        result = Oauth2BatchRefreshJob.perform_now
+        assert result > limit
+      end
+    end
+
+    describe "witht args" do
+      test "it should return limit" do
+        result = Oauth2BatchRefreshJob.perform_now(wait: 0.01, limit: limit)
+        assert result == limit
+      end
+    end
+  end
+end

--- a/test/jobs/oauth2_refresh_job_test.rb
+++ b/test/jobs/oauth2_refresh_job_test.rb
@@ -1,12 +1,13 @@
-require 'test_helper'
+require "test_helper"
 
 class Oauth2RefreshJobTest < ActiveJob::TestCase
   include MockOauth2Responses
   let(:connection) { uphold_connections(:google_connection) }
+  let(:klass) { UpholdConnection.name }
 
   describe "when record !found" do
     test "it should raise an exception" do
-      assert_instance_of(ActiveRecord::RecordNotFound, Oauth2RefreshJob.perform_now("fake identifier", UpholdConnection))
+      assert_instance_of(ActiveRecord::RecordNotFound, Oauth2RefreshJob.perform_now("fake identifier", klass))
     end
   end
 
@@ -17,7 +18,7 @@ class Oauth2RefreshJobTest < ActiveJob::TestCase
       end
 
       test "deletes a publisher and his or her channels" do
-        assert_instance_of(UpholdConnection, Oauth2RefreshJob.perform_now(connection.id, UpholdConnection).connection)
+        assert_instance_of(UpholdConnection, Oauth2RefreshJob.perform_now(connection.id, klass).connection)
       end
     end
 
@@ -27,7 +28,7 @@ class Oauth2RefreshJobTest < ActiveJob::TestCase
       end
 
       test "deletes a publisher and his or her channels" do
-        assert_instance_of(BFailure, Oauth2RefreshJob.perform_now(connection.id, UpholdConnection))
+        assert_instance_of(BFailure, Oauth2RefreshJob.perform_now(connection.id, klass))
       end
     end
   end

--- a/test/jobs/oauth2_refresh_job_test.rb
+++ b/test/jobs/oauth2_refresh_job_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Oauth2RefreshJobTest < ActiveJob::TestCase
+  include MockOauth2Responses
+  let(:connection) { uphold_connections(:google_connection) }
+
+  describe "when record !found" do
+    test "it should raise an exception" do
+      assert_instance_of(ActiveRecord::RecordNotFound, Oauth2RefreshJob.perform_now("fake identifier", UpholdConnection))
+    end
+  end
+
+  describe "when record found" do
+    describe "when successful" do
+      before do
+        mock_refresh_token_success(connection.token_url)
+      end
+
+      test "deletes a publisher and his or her channels" do
+        assert_instance_of(UpholdConnection, Oauth2RefreshJob.perform_now(connection.id, UpholdConnection).connection)
+      end
+    end
+
+    describe "when unsuccessful" do
+      before do
+        mock_token_failure(connection.token_url)
+      end
+
+      test "deletes a publisher and his or her channels" do
+        assert_instance_of(BFailure, Oauth2RefreshJob.perform_now(connection.id, UpholdConnection))
+      end
+    end
+  end
+end

--- a/test/lib/oauth2/client_credentials_test.rb
+++ b/test/lib/oauth2/client_credentials_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 class OAuth2ClientCredentialsTest < ActiveSupport::TestCase
   include Oauth2::Structs
   include MockOauth2Responses
+  extend T::Sig
+
   let(:klass) { Oauth2::ClientCredentials }
   let(:client_id) { "any value" }
   let(:client_secret) { "any secret value" }
@@ -17,7 +19,19 @@ class OAuth2ClientCredentialsTest < ActiveSupport::TestCase
   end
 
   describe "#refresh_token" do
-    describe "when unsuccessful" do
+    describe "when unknown unsuccessful" do
+      let(:response) { Net::HTTPInternalServerError }
+
+      before do
+        mock_unknown_failure(token_url)
+      end
+
+      test "it should raise exception" do
+        assert_raises(Oauth2::ClientCredentials::UnknownError) { klass.new(**payload).refresh_token(refresh_token) }
+      end
+    end
+
+    describe "when known unsuccessful" do
       let(:response) { ErrorResponse }
 
       before do

--- a/test/test_helpers/mock_oauth2_responses.rb
+++ b/test/test_helpers/mock_oauth2_responses.rb
@@ -1,6 +1,11 @@
 module MockOauth2Responses
   include Oauth2::Structs
 
+  def mock_unknown_failure(token_url)
+    stub_request(:post, token_url)
+      .to_return(status: 500, body: "any possible value")
+  end
+
   def mock_token_failure(token_url)
     stub_request(:post, token_url)
       .to_return(status: 400, body: {error: "invalid_grant", error_description: "Ann error occurred"}.to_json)


### PR DESCRIPTION
Oauth2BatchRefreshJob - Fills queue of RefreshJobs on schedule
Oauth2RefreshJob - Handles individual connections, handles retries/failures/parallelism