### PR TITLE
task: Implement failure recording API

### DIFF
--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -307,7 +307,7 @@ class UpholdConnection < ApplicationRecord
   end
 
   def record_refresh_failure!
-    # TODO: Update connection when refresh has failed
+    update!(oauth_refresh_failed: true)
     self
   end
 

--- a/test/models/uphold_connection_test.rb
+++ b/test/models/uphold_connection_test.rb
@@ -162,6 +162,20 @@ class UpholdConnectionTest < ActiveSupport::TestCase
       end
     end
 
+    describe "record_refresh_failure!" do
+      let(:verified_connection) { uphold_connections(:verified_connection) }
+
+      before do
+        assert !verified_connection.oauth_refresh_failed
+        verified_connection.record_refresh_failure!
+        verified_connection.reload
+      end
+
+      it "should update" do
+        assert verified_connection.oauth_refresh_failed
+      end
+    end
+
     describe "when uphold_code is set but the other parameters are nil" do
       before do
         uphold_connection.uphold_code = "foo"


### PR DESCRIPTION
This just implements the actual pieces required to denote an authentication failure.  I forgot to add it before because I originally didn't have the database migrations.