### PR TITLE
fix: Add scope as optional for refresh token response

### DIFF
--- a/lib/oauth2/structs.rb
+++ b/lib/oauth2/structs.rb
@@ -22,6 +22,7 @@ module Oauth2
       const :access_token, String
       const :expires_in, Integer
       const :refresh_token, String
+      prop :scope, T.nilable(String)
     end
   end
 end

--- a/test/test_helpers/mock_oauth2_responses.rb
+++ b/test/test_helpers/mock_oauth2_responses.rb
@@ -13,6 +13,6 @@ module MockOauth2Responses
 
   def mock_refresh_token_success(token_url)
     stub_request(:post, token_url)
-      .to_return(status: 200, body: {access_token: "access_token", expires_in: 10.minutes.to_i, refresh_token: "refresh_token", token_type: "example"}.to_json)
+      .to_return(status: 200, body: {access_token: "access_token", expires_in: 10.minutes.to_i, refresh_token: "refresh_token", token_type: "example", scope: "create"}.to_json)
   end
 end


### PR DESCRIPTION
Scope is being returned from the refresh token response and the struct is failing to initialize because of it (scope is optional) in response types.