### PR TITLE
Task/debugging

### DIFF
--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -1,0 +1,78 @@
+# typed: ignore
+# Sorbet doesn't recognize ApplicationController for some reason
+
+class Oauth2Controller < ApplicationController
+  # This implements a full Oauth2 Authorization Code flow
+  # for any descendant of Oauth2::AuthorizationCodeBase
+  # What is done on AccessTokenResponse is yet to be defined
+  #
+  # I had to build this just to debug the varying implementations
+  # of the Oauth2::AuthorizationCodebase children.
+  extend T::Sig
+  include Oauth2::Responses
+  include Oauth2::Errors
+
+  before_action :set_controller_state
+  before_action :set_request_state, only: [:code]
+  before_action :verify_state, only: [:callback]
+
+  def code
+    redirect_to(client.authorization_code_url(state: @state, scope: @klass.oauth2_scope))
+  end
+
+  def callback
+    resp = client.access_token(params.require(:code))
+
+    case resp
+    when AccessTokenResponse
+      data = resp.serialize
+    when ErrorResponse
+      data = resp.serialize
+    when UnknownError
+      data = UnknownError.response
+    else
+      T.absurd(resp)
+    end
+
+    render json: {data: data}
+  end
+
+  private
+
+  def client
+    @_client ||= @klass.oauth2_client
+  end
+
+  # This is how state verification is typically done in an oauth2 flow
+  def set_request_state
+    @state = @klass.state_value!
+    cookies[:_state] = {
+      value: @state,
+      expires: 5.minutes.from_now,
+      httponly: true
+    }
+  end
+
+  def verify_state
+    raise ActionController::BadRequest if permitted_params.fetch(:state) != cookies["_state"]
+  end
+
+  def set_controller_state
+    provider = permitted_params.fetch(:provider)
+
+    case provider
+    when "gemini"
+      @klass = GeminiConnection
+    when "uphold"
+      @klass = UpholdConnection
+    when "bitflyer"
+      @klass = BitflyerConnection
+    else
+      raise ActionController::RoutingError
+    end
+  end
+
+  def permitted_params
+    params.permit(:provider, :state, :code)
+  end
+end

--- a/app/models/bitflyer_connection.rb
+++ b/app/models/bitflyer_connection.rb
@@ -85,11 +85,16 @@ class BitflyerConnection < Oauth2::AuthorizationCodeBase
   end
 
   class << self
+    def oauth2_scope
+      Rails.application.secrets[:bitflyer_scope]
+    end
+
     def oauth2_client
       @_oauth_client ||= Oauth2::AuthorizationCodeClient.new(
         client_id: Rails.application.secrets[:bitflyer_client_id],
         client_secret: Rails.application.secrets[:bitflyer_client_secret],
         authorization_url: URI("#{Rails.application.secrets[:bitflyer_host]}/ex/OAuth/authorize"),
+        redirect_uri: URI("https://localhost:3000/oauth2/bitflyer/callback"),
         token_url: URI("#{Rails.application.secrets[:bitflyer_host]}/api/link/v1/token")
       )
     end

--- a/app/models/gemini_connection.rb
+++ b/app/models/gemini_connection.rb
@@ -88,12 +88,18 @@ class GeminiConnection < Oauth2::AuthorizationCodeBase
   end
 
   class << self
+    def oauth2_scope
+      "account:read"
+    end
+
     def oauth2_client
       @_oauth_client ||= Oauth2::AuthorizationCodeClient.new(
         client_id: Rails.application.config.services.gemini[:client_id],
         client_secret: Rails.application.config.services.gemini[:client_secret],
         authorization_url: URI("#{Rails.application.config.services.gemini[:oauth_uri]}/auth"),
-        token_url: URI("#{Rails.application.config.services.gemini[:oauth_uri]}/auth/token")
+        token_url: URI("#{Rails.application.config.services.gemini[:oauth_uri]}/auth/token"),
+        redirect_uri: URI("https://localhost:3000/oauth2/gemini/callback"),
+        content_type: "application/json" # See Oauth2::AuthorizationCode.new
       )
     end
 

--- a/app/models/oauth2/authorization_code_base.rb
+++ b/app/models/oauth2/authorization_code_base.rb
@@ -1,8 +1,8 @@
 # typed: true
 class Oauth2::AuthorizationCodeBase < ApplicationRecord
   self.abstract_class = true
-
   include Oauth2::Responses
+  include Oauth2::Errors
   extend T::Sig
   extend T::Helpers
 
@@ -20,6 +20,14 @@ class Oauth2::AuthorizationCodeBase < ApplicationRecord
     # (which we do for this particular case), you have to implement your interface as a base class
     sig { abstract.returns(Oauth2::AuthorizationCodeClient) }
     def oauth2_client
+    end
+
+    sig { abstract.returns(String) }
+    def oauth2_scope
+    end
+
+    def state_value!
+      SecureRandom.hex(64).to_s
     end
   end
 
@@ -52,6 +60,8 @@ class Oauth2::AuthorizationCodeBase < ApplicationRecord
     when ErrorResponse
       record_refresh_failure!
       result
+    when UnknownError
+      raise UnknownError
     else
       T.absurd(result)
     end

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -298,12 +298,17 @@ class UpholdConnection < Oauth2::AuthorizationCodeBase
   end
 
   class << self
+    def oauth2_scope
+      Rails.application.secrets[:uphold_scope]
+    end
+
     def oauth2_client
       @_oauth_client ||= Oauth2::AuthorizationCodeClient.new(
         client_id: Rails.application.secrets[:uphold_client_id],
         client_secret: Rails.application.secrets[:uphold_client_secret],
         token_url: URI("#{Rails.application.secrets[:uphold_api_uri]}/oauth2/token"),
-        authorization_url: URI("#{Rails.application.secrets[:uphold_api_uri]}/auth")
+        authorization_url: URI("#{Rails.application.secrets[:uphold_api_uri]}/auth"),
+        redirect_uri: URI("https://localhost:3000/oauth2/uphold/callback")
       )
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,16 @@ Rails.application.routes.draw do
     put :accept_tos
   end
 
+  # This implements basic callback urls for initiating oauth flows.
+  # It could endup being a base/abstract controller for any authorization code flow
+  # For right now I needed it to test/debug flows locally
+  if Rails.env.development?
+    namespace :oauth2 do
+      get ":provider/code", action: :code
+      get ":provider/callback", action: :callback
+    end
+  end
+
   # These routes are for connecting to 3rd-party payment providers.
   namespace :connection, module: "payment/connection" do
     resource :currency, only: [:show, :update]

--- a/config/services.yml
+++ b/config/services.yml
@@ -3,8 +3,8 @@ default: &default
   gemini:
     api_uri: <%= ENV["GEMINI_API"] || "https://api.sandbox.gemini.com" %>
     oauth_uri: <%= ENV["GEMINI_OAUTH_API"] || "https://exchange.sandbox.gemini.com" %>
-    client_id: <%= ENV["GEMINI_CLIENT_ID"] %> 
-    client_secret: <%= ENV["GEMINI_CLIENT_SECRET"] %> 
+    client_id: <%= ENV["GEMINI_CLIENT_ID"] || 'fake-client-id' %> 
+    client_secret: <%= ENV["GEMINI_CLIENT_SECRET"] || 'fake-client-secret' %> 
   stripe:
     publishable_key: <%= ENV["STRIPE_PUBLISHABLE_KEY"] %>
     client_id: <%= ENV["STRIPE_CLIENT_ID"] %>
@@ -12,13 +12,6 @@ default: &default
 
 test:
   <<: *default
-  # In our test files we should ensure we're mocking all these requests.
-  # So we're going to be passing invalid URLs so if any of our tests aren't mocked then Faraday will raise an exception.
-  gemini:
-    api_uri: https://api.gemini.fake
-    oauth_uri: https://exchange.gemini.fake
-    client_id: <%= ENV["GEMINI_CLIENT_ID"] || "fake-client-id" %> 
-    client_secret: <%= ENV["GEMINI_CLIENT_SECRET"] || "fake-client-secret" %> 
 
 development:
   <<: *default

--- a/lib/oauth2/authorization_code_client.rb
+++ b/lib/oauth2/authorization_code_client.rb
@@ -10,45 +10,80 @@ class Oauth2::AuthorizationCodeClient
   extend T::Sig
   include Oauth2::Responses
   include Oauth2::Errors
-
   attr_reader :authorization_url
   attr_reader :token_url
 
-  sig { params(client_id: String, client_secret: String, authorization_url: URI, token_url: URI).void }
-  def initialize(client_id:, client_secret:, authorization_url:, token_url:)
+  sig { params(client_id: String, client_secret: String, authorization_url: URI, token_url: URI, redirect_uri: URI, content_type: String).void }
+  # In reality content type should not be a parameter, but we already have at least one case (Gemini) of an oauth flow that is not actually to spec.
+  def initialize(client_id:, client_secret:, authorization_url:, token_url:, redirect_uri:, content_type: "application/x-www-form-urlencoded")
     @client_id = client_id
     @client_secret = client_secret
     @authorization_url = authorization_url
     @token_url = token_url
+    @redirect_uri = redirect_uri
+    @content_type = content_type
+    @valid_content_type = "application/x-www-form-urlencoded"
+    @invalid_content_type = "application/json"
     @options = {use_ssl: true}
   end
 
   # Generates URI for redirect/initiation of the oauth2 authorization code flow.
   # I.e. redirects to uphold/gemini/bitflyer etc.
-  def authorization_code_url(redirect_uri:, scope:, state:)
-    raise NotImplementedError
+  sig { params(scope: String, state: String).returns(String) }
+  def authorization_code_url(scope:, state:)
+    query = {
+      response_type: "code",
+      redirect_uri: @redirect_uri,
+      scope: scope,
+      state: state,
+      client_id: @client_id
+    }.to_query
+
+    "#{@authorization_url}?#{query}"
   end
 
+  sig { params(authorization_code: String).returns(T.any(AccessTokenResponse, ErrorResponse, UnknownError)) }
   def access_token(authorization_code)
-    raise NotImplementedError
+    request = Net::HTTP::Post.new(@token_url)
+    request.content_type = @content_type
+
+    case @content_type
+    when @invalid_content_type
+      request.body = {
+        code: authorization_code,
+        client_id: @client_id,
+        client_secret: @client_secret,
+        grant_type: "authorization_code",
+        redirect_uri: @redirect_uri
+      }.to_json
+    else
+      raise NotImplementedError
+    end
+
+    handle_request(request, @token_url, AccessTokenResponse)
   end
 
-  sig { params(refresh_token: String, content_type: String).returns(T.any(RefreshTokenResponse, UnknownError, ErrorResponse)) }
-  def refresh_token(refresh_token, content_type: "application/x-www-form-urlencoded")
+  sig { params(refresh_token: String).returns(T.any(RefreshTokenResponse, UnknownError, ErrorResponse)) }
+  def refresh_token(refresh_token)
     request = Net::HTTP::Post.new(@token_url)
-    request.content_type = content_type
+    request.content_type = @content_type
 
-    case content_type
-    when "application/x-www-form-urlencoded"
+    case @content_type
+    when @valid_content_type
       request.set_form_data(
         "grant_type" => "refresh_token",
         "refresh_token" => refresh_token
       )
       request.basic_auth(@client_id, @client_secret)
-    when "application/json" # This is not valid for Oauth2 but Gemini does it anyway
-      request.body = {client_id: @client_id, client_secret: @client_secret, refresh_token: refresh_token, grant_type: "refresh_token"}.to_json
+    when @invalid_content_type
+      request.body = {
+        client_id: @client_id,
+        client_secret: @client_secret,
+        refresh_token: refresh_token,
+        grant_type: "refresh_token"
+      }.to_json
     else
-      raise "Invalid content_type #{content_type}"
+      raise "Unsupported content_type #{@content_type}"
     end
 
     handle_request(request, @token_url, RefreshTokenResponse)

--- a/lib/oauth2/errors.rb
+++ b/lib/oauth2/errors.rb
@@ -1,8 +1,12 @@
 module Oauth2::Errors
   class UnknownError < StandardError
-    def initialize(response)
+    attr_reader :response
+    attr_reader :request
+
+    def initialize(response:, request:)
       super
       @response = response
+      @request = request
     end
 
     def message

--- a/test/controllers/oauth2_controller_test.rb
+++ b/test/controllers/oauth2_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+describe Oauth2Controller do
+  # it "does a thing" do
+  #   value(1+1).must_equal 2
+  # end
+end

--- a/test/lib/oauth2/authorization_code_client_test.rb
+++ b/test/lib/oauth2/authorization_code_client_test.rb
@@ -20,39 +20,95 @@ class OAuth2AuthorizationCodeTest < ActiveSupport::TestCase
   end
 
   describe "#refresh_token" do
-    describe "when unknown unsuccessful" do
+
+    describe "when not-to-spec unknown with 400 status" do
       let(:response) { Net::HTTPInternalServerError }
 
       before do
-        mock_unknown_failure(token_url)
+        stub_request(:post, token_url)
+          .to_return(status: 400, body: {is_not: "a", valid_oauth: "response object"}.to_json)
       end
 
       test "it should raise exception" do
-        assert_raises(Oauth2::Errors::UnknownError) { klass.new(**config).refresh_token(refresh_token) }
+        assert_instance_of(Oauth2::Errors::UnknownError, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
       end
     end
 
-    describe "when known unsuccessful" do
-      let(:response) { Oauth2::Responses::ErrorResponse }
+    describe "when application/json" do
+      describe "when unknown unsuccessful" do
+        let(:response) { Net::HTTPInternalServerError }
 
-      before do
-        mock_token_failure(token_url)
+        before do
+          mock_unknown_failure(token_url)
+        end
+
+        test "it should raise exception" do
+          assert_instance_of(Oauth2::Errors::UnknownError, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
+        end
       end
 
-      test "it should return an ErrorResponse" do
-        assert_instance_of(response, klass.new(**config).refresh_token(refresh_token))
+      describe "when known unsuccessful" do
+        let(:response) { Oauth2::Responses::ErrorResponse }
+
+        before do
+          mock_token_failure(token_url)
+        end
+
+        test "it should return an ErrorResponse" do
+          assert_instance_of(response, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
+        end
+      end
+
+      describe "when successful" do
+        let(:response) { Oauth2::Responses::RefreshTokenResponse }
+
+        before do
+          mock_refresh_token_success(token_url)
+        end
+
+        test "it should return a RefreshTokenResponse" do
+          assert_instance_of(response, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
+        end
       end
     end
+  end
 
-    describe "when successful" do
-      let(:response) { Oauth2::Responses::RefreshTokenResponse }
+  describe "#refresh_token" do
+    describe "when application/x-www-form-urlencoded" do
+      describe "when unknown unsuccessful" do
+        let(:response) { Net::HTTPInternalServerError }
 
-      before do
-        mock_refresh_token_success(token_url)
+        before do
+          mock_unknown_failure(token_url)
+        end
+
+        test "it should raise exception" do
+          assert_instance_of(Oauth2::Errors::UnknownError, klass.new(**config).refresh_token(refresh_token))
+        end
       end
 
-      test "it should return a RefreshTokenResponse" do
-        assert_instance_of(response, klass.new(**config).refresh_token(refresh_token))
+      describe "when known unsuccessful" do
+        let(:response) { Oauth2::Responses::ErrorResponse }
+
+        before do
+          mock_token_failure(token_url)
+        end
+
+        test "it should return an ErrorResponse" do
+          assert_instance_of(response, klass.new(**config).refresh_token(refresh_token))
+        end
+      end
+
+      describe "when successful" do
+        let(:response) { Oauth2::Responses::RefreshTokenResponse }
+
+        before do
+          mock_refresh_token_success(token_url)
+        end
+
+        test "it should return a RefreshTokenResponse" do
+          assert_instance_of(response, klass.new(**config).refresh_token(refresh_token))
+        end
       end
     end
   end

--- a/test/lib/oauth2/authorization_code_client_test.rb
+++ b/test/lib/oauth2/authorization_code_client_test.rb
@@ -10,7 +10,7 @@ class OAuth2AuthorizationCodeTest < ActiveSupport::TestCase
   let(:client_secret) { "any secret value" }
   let(:authorization_url) { "https://example.com/oauth2/authorize" }
   let(:token_url) { "https://example.com/oauth2/token" }
-  let(:config) { {client_id: client_id, client_secret: client_secret, token_url: URI(token_url), authorization_url: URI(authorization_url)} }
+  let(:config) { {client_id: client_id, client_secret: client_secret, token_url: URI(token_url), authorization_url: URI(authorization_url), redirect_uri: URI("https://localhost:3000")} }
   let(:refresh_token) { "any stubbed token value" }
   let(:refresh_token_response) { {access_token: "access_token", expires_in: 10.minutes.to_i, refresh_token: "refresh_token", token_type: "example"} }
   let(:error_response) { {error: "invalid_grant", error_description: "Ann error occurred"} }
@@ -20,61 +20,22 @@ class OAuth2AuthorizationCodeTest < ActiveSupport::TestCase
   end
 
   describe "#refresh_token" do
-
     describe "when not-to-spec unknown with 400 status" do
-      let(:response) { Net::HTTPInternalServerError }
-
       before do
         stub_request(:post, token_url)
           .to_return(status: 400, body: {is_not: "a", valid_oauth: "response object"}.to_json)
       end
 
       test "it should raise exception" do
-        assert_instance_of(Oauth2::Errors::UnknownError, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
+        assert_instance_of(Oauth2::Errors::UnknownError, klass.new(**config).refresh_token(refresh_token))
       end
     end
 
     describe "when application/json" do
-      describe "when unknown unsuccessful" do
-        let(:response) { Net::HTTPInternalServerError }
-
-        before do
-          mock_unknown_failure(token_url)
-        end
-
-        test "it should raise exception" do
-          assert_instance_of(Oauth2::Errors::UnknownError, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
-        end
+      before do
+        config.merge!(content_type: "application/json")
       end
 
-      describe "when known unsuccessful" do
-        let(:response) { Oauth2::Responses::ErrorResponse }
-
-        before do
-          mock_token_failure(token_url)
-        end
-
-        test "it should return an ErrorResponse" do
-          assert_instance_of(response, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
-        end
-      end
-
-      describe "when successful" do
-        let(:response) { Oauth2::Responses::RefreshTokenResponse }
-
-        before do
-          mock_refresh_token_success(token_url)
-        end
-
-        test "it should return a RefreshTokenResponse" do
-          assert_instance_of(response, klass.new(**config).refresh_token(refresh_token, content_type: "application/json"))
-        end
-      end
-    end
-  end
-
-  describe "#refresh_token" do
-    describe "when application/x-www-form-urlencoded" do
       describe "when unknown unsuccessful" do
         let(:response) { Net::HTTPInternalServerError }
 
@@ -109,6 +70,44 @@ class OAuth2AuthorizationCodeTest < ActiveSupport::TestCase
         test "it should return a RefreshTokenResponse" do
           assert_instance_of(response, klass.new(**config).refresh_token(refresh_token))
         end
+      end
+    end
+  end
+
+  describe "when application/x-www-form-urlencoded" do
+    describe "when unknown unsuccessful" do
+      let(:response) { Net::HTTPInternalServerError }
+
+      before do
+        mock_unknown_failure(token_url)
+      end
+
+      test "it should raise exception" do
+        assert_instance_of(Oauth2::Errors::UnknownError, klass.new(**config).refresh_token(refresh_token))
+      end
+    end
+
+    describe "when known unsuccessful" do
+      let(:response) { Oauth2::Responses::ErrorResponse }
+
+      before do
+        mock_token_failure(token_url)
+      end
+
+      test "it should return an ErrorResponse" do
+        assert_instance_of(response, klass.new(**config).refresh_token(refresh_token))
+      end
+    end
+
+    describe "when successful" do
+      let(:response) { Oauth2::Responses::RefreshTokenResponse }
+
+      before do
+        mock_refresh_token_success(token_url)
+      end
+
+      test "it should return a RefreshTokenResponse" do
+        assert_instance_of(response, klass.new(**config).refresh_token(refresh_token))
       end
     end
   end


### PR DESCRIPTION
Adds a development only Oauth2 controller that implements each auth code flow for each of the child Oauth2::AuthenticationBase implementations.  This was necessary for debugging locally.

Updates the Oauth2::AuthorizationCodeClient to handle `application/json` based auth flows though they are not to spec.

Relaxes the error handling a bit.  Bitflyer threw a 400 that didn't follow oauth2 error specifications and was masking the input.  I modified some things to make it easier to debug the individual requests.