### PR TITLE
fix: adapt to explicit types

### DIFF
--- a/test/lib/oauth2/authorization_code_client_test.rb
+++ b/test/lib/oauth2/authorization_code_client_test.rb
@@ -20,6 +20,26 @@ class OAuth2AuthorizationCodeTest < ActiveSupport::TestCase
   end
 
   describe "#refresh_token" do
+    describe "when success not-to-spec partially known" do
+      before do
+        mock_refresh_token_success(token_url, to_spec: false)
+      end
+
+      test "it should return error responsep" do
+        assert_instance_of(Oauth2::Responses::RefreshTokenResponse, klass.new(**config).refresh_token(refresh_token))
+      end
+    end
+
+    describe "when failure not-to-spec partially known" do
+      before do
+        mock_token_failure(token_url, to_spec: false)
+      end
+
+      test "it should return error responsep" do
+        assert_instance_of(Oauth2::Responses::ErrorResponse, klass.new(**config).refresh_token(refresh_token))
+      end
+    end
+
     describe "when not-to-spec unknown with 400 status" do
       before do
         stub_request(:post, token_url)

--- a/test/test_helpers/mock_oauth2_responses.rb
+++ b/test/test_helpers/mock_oauth2_responses.rb
@@ -6,13 +6,25 @@ module MockOauth2Responses
       .to_return(status: 500, body: "any possible value")
   end
 
-  def mock_token_failure(token_url)
+  def mock_token_failure(token_url, to_spec: true)
+    payload = {error: "invalid_grant", error_description: "Ann error occurred"}
+
+    if !to_spec
+      payload[:another] = "value"
+    end
+
     stub_request(:post, token_url)
-      .to_return(status: 400, body: {error: "invalid_grant", error_description: "Ann error occurred"}.to_json)
+      .to_return(status: 400, body: payload.to_json)
   end
 
-  def mock_refresh_token_success(token_url)
+  def mock_refresh_token_success(token_url, to_spec: true)
+    payload = {access_token: "access_token", expires_in: 10.minutes.to_i, refresh_token: "refresh_token", token_type: "example", scope: "create"}
+
+    if !to_spec
+      payload[:another] = "value"
+    end
+
     stub_request(:post, token_url)
-      .to_return(status: 200, body: {access_token: "access_token", expires_in: 10.minutes.to_i, refresh_token: "refresh_token", token_type: "example", scope: "create"}.to_json)
+      .to_return(status: 200, body: payload.to_json)
   end
 end


### PR DESCRIPTION
This handles one of the more awkward elements of using statically defined response objects. I.e. their lack of flexibility when it comes to differences in actual vs. expected response values.

To handle this I just filter down to only the values I care about.