### PR TITLE
fix: Raise instance instead of class

### DIFF
--- a/app/models/oauth2/authorization_code_base.rb
+++ b/app/models/oauth2/authorization_code_base.rb
@@ -64,7 +64,7 @@ class Oauth2::AuthorizationCodeBase < ApplicationRecord
       record_refresh_failure!
       result
     when UnknownError
-      raise UnknownError
+      raise result
     else
       T.absurd(result)
     end

--- a/test/jobs/oauth2_refresh_job_test.rb
+++ b/test/jobs/oauth2_refresh_job_test.rb
@@ -14,6 +14,10 @@ class Oauth2RefreshJobTest < ActiveJob::TestCase
   end
 
   describe "when record found" do
+    before do
+      ActionMailer::Base.deliveries.clear
+    end
+
     describe "when successful" do
       before do
         mock_refresh_token_success(UpholdConnection.oauth2_client.token_url)

--- a/test/models/gemini_connection_test.rb
+++ b/test/models/gemini_connection_test.rb
@@ -27,6 +27,16 @@ class GeminiConnectionTest < SidekiqTestCase
           assert_instance_of(klass, conn.refresh_authorization!)
         end
       end
+
+      describe "when unsuccessful" do
+        before do
+          mock_unknown_failure(klass.oauth2_client.token_url)
+        end
+
+        test "it should raise an error" do
+          assert_raises(Oauth2::Errors::UnknownError) { conn.refresh_authorization! }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Several new relic errors were being raised because UnknownError takes params and rather than raising the result/instance I was raising the class.