### PR TITLE
task: Delete "Direct User Tips" column in Statements

### DIFF
--- a/app/javascript/locale/en.ts
+++ b/app/javascript/locale/en.ts
@@ -226,7 +226,6 @@ export default {
         total: "Total",
         type: "Type"
       },
-      directUserTips: "Direct User Tips",
       download: "Download",
       earningPeriod: "Earning Period",
       fees: "Fees",

--- a/app/javascript/views/statements/Statements.tsx
+++ b/app/javascript/views/statements/Statements.tsx
@@ -188,9 +188,6 @@ class Statements extends React.Component<any, IStatementsState> {
               <TableHeader className="text-right" style={{ minWidth: "150px" }}>
                 <FormattedMessage id="statements.overview.totalBraveSettled" />
               </TableHeader>
-              <TableHeader className="text-right" style={{ minWidth: "150px" }}>
-                <FormattedMessage id="statements.overview.directUserTips" />
-              </TableHeader>
               <TableHeader className="text-right" style={{ minWidth: "175px" }}>
                 <FormattedMessage id="statements.overview.amountDeposited" />
               </TableHeader>
@@ -215,15 +212,6 @@ class Statements extends React.Component<any, IStatementsState> {
                   <td className="text-right">
                     <CurrencyNumber
                       value={statement.totals.totalBraveSettled}
-                    />
-                    <small>
-                      {" "}
-                      <FormattedMessage id="bat" />
-                    </small>
-                  </td>
-                  <td className="text-right">
-                    <CurrencyNumber
-                      value={statement.totals.upholdContributionSettlement}
                     />
                     <small>
                       {" "}

--- a/app/javascript/views/statements/statements/StatementDetails.tsx
+++ b/app/javascript/views/statements/statements/StatementDetails.tsx
@@ -259,21 +259,6 @@ const TotalSubTable = (props) => (
         </Total>
       </TotalCell>
     </tr>
-
-    <tr>
-      <TotalCell />
-      <TotalCell>
-        <Total isDark>
-          <FormattedMessage id="statements.overview.directUserTips" />
-        </Total>
-      </TotalCell>
-      <TotalCell textRight>
-        <Total isDark>
-          <CurrencyNumber value={props.upholdContributionSettlement} />{" "}
-          <FormattedMessage id="bat" />
-        </Total>
-      </TotalCell>
-    </tr>
   </React.Fragment>
 );
 


### PR DESCRIPTION
## Pull Request Name

#### Before:
<img width="980" alt="Screen Shot 2022-04-27 at 5 18 15 PM" src="https://user-images.githubusercontent.com/4231556/165649012-477a644f-cb09-4d29-bf11-c7f3556b826a.png">

<img width="1166" alt="Screen Shot 2022-04-27 at 5 18 05 PM" src="https://user-images.githubusercontent.com/4231556/165649026-ca170323-e53e-4184-88f0-7b0e828e94f8.png">

#### After:
<img width="973" alt="Screen Shot 2022-04-27 at 5 05 54 PM" src="https://user-images.githubusercontent.com/4231556/165649046-0cdbfe60-6828-4c6c-8860-891dc2699da9.png">
<img width="1188" alt="Screen Shot 2022-04-27 at 5 05 44 PM" src="https://user-images.githubusercontent.com/4231556/165649054-374732d3-6c9b-42d8-b597-9d8d2c9064e6.png">

### Features

Closes #3607 .  Because the app doesn't have access to direct tipping information, the values in that column will always be 0.  Removed both the 'Direct User Tips' column on the statements page, and the 'Direct User Tips' row on the statement detail view.
