### PR TITLE
task: Persist node_modules on container

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Development with Docker and `docker-compose` is recommended for anyone just gett
 1. Ensure `openssl` is installed. `brew install openssl`
 1. In your browser, navigate to `brave://flags`.  Make sure `Allow invalid certificates for resources loaded from localhost.
 ` is enabled. 
-1. Ensure `yarn` is installed. `npm install --global yarn`
-1. Run `yarn`
 1. Run `make`
 1. Create an admin user. `make admin EMAIL="email@example.com"`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - redis
     volumes:
       - .:/var/www
+      - /var/www/node_modules
     ports:
       - "3000:3000"
     env_file: .env.docker.dev


### PR DESCRIPTION
Ensures local directory does not override content of node_modules installed by docker.  I rebuilt from scratch several times and confirmed though I did not test what the behavior was when you had a pre-existing node-modules directory.

See: https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder

Closes #3651