### PR TITLE
refactor: Abstract deposit id into service and add specs/types

### DIFF
--- a/app/jobs/sync/bitflyer/update_missing_deposit_job.rb
+++ b/app/jobs/sync/bitflyer/update_missing_deposit_job.rb
@@ -1,36 +1,10 @@
 # typed: ignore
+
 class Sync::Bitflyer::UpdateMissingDepositJob
-  # FIXME: This should probably be it's own independent service
   include Sidekiq::Worker
   sidekiq_options queue: :default, retry: true
 
   def perform(channel_id, notify: false)
-    channel = channel.find(channel_id)
-    return if channel.deposit_id.present?
-
-    conn = channel.publisher.bitflyer_connection
-
-    # Check all possible refresh options, notify user if  failure is known type
-    # and they need to refresh their wallets.
-    result = Wallet::RefreshFailureNotificationService.build.call(conn, notify: notify)
-
-    # If the result is a failure, the user's connection has been marked as failed and the deposit id cannot be retrieve
-    case result
-    when Oauth2::Responses::ErrorResponse
-      return
-    end
-
-    # FIXME: This should be incoroporated into an HTTP client
-    # request a deposit id from bitflyer.
-    url = uri.parse(rails.application.secrets[:bitflyer_host] + "/api/link/v1/account/create-deposit-id?request_id=" + securerandom.uuid)
-    request = net.http.get.new(url.to_s)
-
-    request["authorization"] = "bearer " + conn.access_token
-    response = net.http.start(url.host, url.port, use_ssl: url.scheme == "https") do |http|
-      http.request(request)
-    end
-
-    deposit_id = json.parse(response.body)["deposit_id"]
-    channel.update(deposit_id: deposit_id)
+    Wallet::UpdateBitflyerDepositIdService.build.call(Channel.find_by_id!(channel_id), notify: notify)
   end
 end

--- a/app/jobs/sync/bitflyer/update_missing_deposits_job.rb
+++ b/app/jobs/sync/bitflyer/update_missing_deposits_job.rb
@@ -2,7 +2,7 @@
 class Sync::Bitflyer::UpdateMissingDepositsJob < ApplicationJob
   queue_as :low
 
-  def perform
+  def perform(notify: false)
     Publisher
       .joins(:bitflyer_connection)
       .joins(:channels)
@@ -13,7 +13,7 @@ class Sync::Bitflyer::UpdateMissingDepositsJob < ApplicationJob
       .select("channels.id")
       .each do |result|
       channel_id = result["id"]
-      Sync::Bitflyer::UpdateMissingDepositJob.perform_async(channel_id)
+      Sync::Bitflyer::UpdateMissingDepositJob.perform_async(channel_id, notify: notify)
     end
   end
 end

--- a/app/services/bitflyer/update_deposit_id_service.rb
+++ b/app/services/bitflyer/update_deposit_id_service.rb
@@ -1,0 +1,41 @@
+# typed: true
+
+class Bitflyer::UpdateDepositIdService < BuilderBaseService
+  include Wallet::Structs
+
+  def self.build
+    new
+  end
+
+  def call(channel, notify: false)
+    return shrug("NOOP: Deposit id was present on the channel somehow") if channel.deposit_id.present?
+
+    conn = channel.publisher.bitflyer_connection
+
+    return shrug("NOOP: No bitflyer connection detected somehow") if conn.nil?
+
+    result = Wallet::RefreshFailureNotificationService.build.call(conn, notify: notify)
+
+    case result
+    when FailedWithoutNotification, FailedWithNotification
+      return result
+    end
+
+    # FIXME: Ideally this would be part of it's own client
+    url = URI.parse(Rails.application.secrets[:bitflyer_host] + "/api/link/v1/account/create-deposit-id?request_id=" + SecureRandom.uuid)
+    request = Net::HTTP::Get.new(url.to_s)
+
+    request["Authorization"] = "Bearer " + conn.access_token
+    response = Net::HTTP.start(url.host, url.port, use_ssl: url.scheme == "https") do |http|
+      http.request(request)
+    end
+
+    deposit_id = JSON.parse(response.body)["deposit_id"]
+    channel.update!(deposit_id: deposit_id)
+
+    # Passing the channel along mostly for debugging purposes
+    # If I really care about/want the channel I will create an explicit
+    # result type and pass it with a static type of Channel
+    pass([channel])
+  end
+end

--- a/app/services/builder_base_service.rb
+++ b/app/services/builder_base_service.rb
@@ -13,12 +13,33 @@ class BuilderBaseService
   def call(args)
   end
 
+  sig { params(val: T.untyped).returns(BSuccess) }
   def pass(val = true)
     T.must(val)
     BSuccess.new(result: val)
   end
 
+  sig { params(e: T.any(String, T::Array[T.untyped])).returns(BFailure) }
   def problem(e)
-    BFailure.new(errors: [e])
+    case e
+    when String
+      BFailure.new(errors: [e])
+    when Array
+      BFailure.new(errors: e)
+    else
+      T.absurd(e)
+    end
+  end
+
+  sig { params(result: T.any(String, T::Array[T.untyped])).returns(BIndeterminate) }
+  def shrug(result)
+    case result
+    when String
+      BIndeterminate.new(result: [result])
+    when Array
+      BIndeterminate.new(result: result)
+    else
+      T.absurd(result)
+    end
   end
 end

--- a/app/services/wallet/refresh_failure_notification_service.rb
+++ b/app/services/wallet/refresh_failure_notification_service.rb
@@ -1,4 +1,10 @@
+# typed: true
+
 class Wallet::RefreshFailureNotificationService < BuilderBaseService
+  extend T::Sig
+  extend T::Helpers
+  include Wallet::Structs
+
   # This was abstracted from oauth2_refresh_job and thus
   # the relevant spec is oauth2_refresh_job_test.rb
 
@@ -9,14 +15,18 @@ class Wallet::RefreshFailureNotificationService < BuilderBaseService
   def call(connection, notify: false)
     result = connection.refresh_authorization!
 
-    return result if !notify
-
     case result
     when Oauth2::Responses::ErrorResponse
-      PublisherMailer.wallet_refresh_failure(connection.publisher, connection.class.provider_name).deliver_now
       connection.record_refresh_failure_notification!
+
+      if notify
+        PublisherMailer.wallet_refresh_failure(connection.publisher, connection.class.provider_name).deliver_now
+        return FailedWithNotification.new(result: result)
+      else
+        return FailedWithoutNotification.new(result: result)
+      end
     end
 
-    result
+    pass([result])
   end
 end

--- a/app/services/wallet/structs.rb
+++ b/app/services/wallet/structs.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+module Wallet::Structs
+  class FailedWithNotification < T::Struct
+    prop :result, Oauth2::Responses::ErrorResponse
+  end
+
+  class FailedWithoutNotification < T::Struct
+    prop :result, Oauth2::Responses::ErrorResponse
+  end
+end

--- a/config/initializers/service_result_types.rb
+++ b/config/initializers/service_result_types.rb
@@ -1,9 +1,20 @@
+# I've updated the typing here because it turns out that it's not actually very helpful.
+# The only cases where I'm using BSuccess or BFailure instead of an explicit response
+# object are when I'm solely interested in whether another service has succeeded or failed.
+#
+# If I need an explicit type, I am going to define it as a response from the service in question
+# and pattern match against that type, not dig around in a generic response object.
 class BSuccess < T::Struct
   prop :result, T.any(T::Hash[T.untyped, T.untyped], T::Array[T.untyped], Integer, Float, T::Boolean)
 end
 
 class BFailure < T::Struct
-  prop :errors, T::Array[String]
+  prop :errors, T::Array[T.untyped]
 end
 
-BServiceResult = T.type_alias { T.any(BSuccess, BFailure, T::Struct) }
+# There are definitely cases where "Success" and "Failure" are not exactly correct and we should be explicit about it.
+class BIndeterminate < T::Struct
+  prop :result, T::Array[T.untyped]
+end
+
+BServiceResult = T.type_alias { T.any(BSuccess, BFailure, T::Struct, BIndeterminate) }

--- a/sorbet/rails-rbi/mailers/publisher_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/publisher_mailer.rbi
@@ -326,8 +326,8 @@ class PublisherMailer
   sig { params(publisher: T.untyped, total_amount: T.untyped).returns(ActionMailer::MessageDelivery) }
   def self.wallet_not_connected(publisher, total_amount); end
 
-  sig { params(publisher: T.untyped).returns(ActionMailer::MessageDelivery) }
-  def self.wallet_refresh_failure(publisher); end
+  sig { params(publisher: T.untyped, wallet_provider: T.untyped).returns(ActionMailer::MessageDelivery) }
+  def self.wallet_refresh_failure(publisher, wallet_provider); end
 
   sig { params(channel: T.untyped).returns(ActionMailer::MessageDelivery) }
   def self.youtube_channel_next_step_path(channel); end

--- a/test/services/bitflyer/update_deposit_id_service_test.rb
+++ b/test/services/bitflyer/update_deposit_id_service_test.rb
@@ -1,0 +1,88 @@
+# typed: false
+require "test_helper"
+
+class BitflyerUpdateDepositIdService < ActiveSupport::TestCase
+  include Wallet::Structs
+  include MockOauth2Responses
+
+  describe Bitflyer::UpdateDepositIdService.name do
+    let(:described_class) { Bitflyer::UpdateDepositIdService }
+    let(:inst) { Bitflyer::UpdateDepositIdService.build }
+    let(:publisher) { publishers(:bitflyer_pub) }
+    let(:channel) { publisher.channels.first }
+    let(:connection) { publisher.bitflyer_connection }
+
+    describe "#build" do
+      it "should return self" do
+        assert_instance_of(described_class, inst)
+      end
+    end
+
+    describe "#call" do
+      let(:notify) { true }
+      before do
+        channel.deposit_id = nil
+      end
+
+      describe "when notify" do
+        describe "when refresh" do
+          let(:deposit_id) { "a value" }
+
+          before do
+            assert !channel.deposit_id
+            mock_refresh_token_success(connection.class.oauth2_config.token_url)
+            stub_request(:get, /api\/link\/v1\/account\/create-deposit-id/)
+              .to_return(status: 200, body: {deposit_id: deposit_id}.to_json)
+          end
+
+          test "should return BSuccess" do
+            assert_instance_of(BSuccess, inst.call(channel, notify: notify))
+          end
+
+          test "should update deposit id" do
+            inst.call(channel, notify: notify)
+            channel.reload
+            assert channel.deposit_id == deposit_id
+          end
+        end
+
+        describe "when !refresh" do
+          before do
+            mock_token_failure(connection.class.oauth2_config.token_url)
+          end
+
+          test "should return FailedWithNotification" do
+            assert_instance_of(FailedWithNotification, inst.call(channel, notify: notify))
+          end
+        end
+      end
+
+      describe "when !notify" do
+        let(:notify) { false }
+        let(:deposit_id) { "a value" }
+
+        describe "when refresh" do
+          before do
+            mock_refresh_token_success(connection.class.oauth2_config.token_url)
+            stub_request(:get, /api\/link\/v1\/account\/create-deposit-id/)
+              .to_return(status: 200, body: {deposit_id: deposit_id}.to_json)
+          end
+
+          test "it should be BSuccess" do
+            assert_instance_of(BSuccess, inst.call(channel, notify: notify))
+          end
+        end
+
+        describe "when !refresh" do
+          before do
+            mock_token_failure(connection.class.oauth2_config.token_url)
+          end
+
+          test "it should be FailedWithoutNotification" do
+            assert_instance_of(FailedWithoutNotification, inst.call(channel, notify: notify))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I think I overdid it here.  Initially I was thinking the email notification service would be useful, but I'm not so sure it actually is.  Whatever, it's optional.  If it turns out to not be worth it I'll just drop it and use refresh_authorization! alone.