### PR TITLE
task: Re-enable deposit sync job

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -62,10 +62,10 @@
     cron: "50 2 * * *"
     description: "Refreshes the redis cache for eyeshade stats information"
     queue: scheduler
-#  Sync::Bitflyer::UpdateMissingDepositsJob:
-#    cron: "0 4 * * *"
-#    description: "For bitflyer channels missing their deposit IDs"
-#    queue: low
+  Sync::Bitflyer::UpdateMissingDepositsJob:
+    cron: "0 4 * * *"
+    description: "For bitflyer channels missing their deposit IDs"
+    queue: low
   EnqueuePublishersForPayoutJob:
     cron: "0 0 23 * *"
     args: ['send_notifications']


### PR DESCRIPTION
Runs every day at 4, will only run against missing deposit ids that have not failed an oauth2 connection attempt.  Retry it set to 0 so maximum impact is low.  Will monitor once deployed.