### PR TITLE
Production Release 5.17.22 - Re-enable Bitflyer deposit id update task

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -115,8 +115,7 @@ class Channel < ApplicationRecord
 
   scope :missing_deposit_id, -> { where(deposit_id: nil) }
   scope :using_active_bitflyer_connection, -> {
-    joins(:publisher)
-      .joins(:bitflyer_connection)
+    joins(:bitflyer_connection)
       .where.not(publisher: {selected_wallet_provider_id: nil})
       .where(
         publisher: {selected_wallet_provider_type: BitflyerConnection.name},

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -62,10 +62,10 @@
     cron: "50 2 * * *"
     description: "Refreshes the redis cache for eyeshade stats information"
     queue: scheduler
-#  Sync::Bitflyer::UpdateMissingDepositsJob:
-#    cron: "0 4 * * *"
-#    description: "For bitflyer channels missing their deposit IDs"
-#    queue: low
+  Sync::Bitflyer::UpdateMissingDepositsJob:
+    cron: "0 4 * * *"
+    description: "For bitflyer channels missing their deposit IDs"
+    queue: low
   EnqueuePublishersForPayoutJob:
     cron: "0 0 23 * *"
     args: ['send_notifications']

--- a/sorbet/rails-rbi/models/bitflyer_connection.rbi
+++ b/sorbet/rails-rbi/models/bitflyer_connection.rbi
@@ -11,6 +11,9 @@ module BitflyerConnection::GeneratedAttributeMethods
   sig { returns(T.nilable(ActiveSupport::TimeWithZone)) }
   def access_expiration_time; end
 
+  sig { returns(T.nilable(String)) }
+  def access_token; end
+
   sig { params(value: T.nilable(T.any(Date, Time, ActiveSupport::TimeWithZone))).void }
   def access_expiration_time=(value); end
 

--- a/sorbet/rails-rbi/models/channel.rbi
+++ b/sorbet/rails-rbi/models/channel.rbi
@@ -163,6 +163,24 @@ module Channel::GeneratedAttributeMethods
 end
 
 module Channel::GeneratedAssociationMethods
+  sig { returns(T.nilable(::BitflyerConnection)) }
+  def bitflyer_connection; end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::BitflyerConnection).void)).returns(::BitflyerConnection) }
+  def build_bitflyer_connection(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::BitflyerConnection).void)).returns(::BitflyerConnection) }
+  def create_bitflyer_connection(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.nilable(T.proc.params(object: ::BitflyerConnection).void)).returns(::BitflyerConnection) }
+  def create_bitflyer_connection!(*args, &block); end
+
+  sig { params(value: T.nilable(::BitflyerConnection)).void }
+  def bitflyer_connection=(value); end
+
+  sig { returns(T.nilable(::BitflyerConnection)) }
+  def reload_bitflyer_connection; end
+
   sig { returns(T.nilable(::Channel)) }
   def contested_by_channel; end
 
@@ -483,6 +501,9 @@ class Channel < ApplicationRecord
   def self.github_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
+  def self.missing_deposit_id(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
   def self.not_visible_site_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
@@ -517,6 +538,9 @@ class Channel < ApplicationRecord
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
   def self.twitter_channels(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
+  def self.using_active_bitflyer_connection(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
   def self.verified(*args); end
@@ -565,6 +589,9 @@ class Channel::ActiveRecord_Relation < ActiveRecord::Relation
   def github_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
+  def missing_deposit_id(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
   def not_visible_site_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
@@ -599,6 +626,9 @@ class Channel::ActiveRecord_Relation < ActiveRecord::Relation
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
   def twitter_channels(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
+  def using_active_bitflyer_connection(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_Relation) }
   def verified(*args); end
@@ -647,6 +677,9 @@ class Channel::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelat
   def github_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
+  def missing_deposit_id(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
   def not_visible_site_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
@@ -681,6 +714,9 @@ class Channel::ActiveRecord_AssociationRelation < ActiveRecord::AssociationRelat
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
   def twitter_channels(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
+  def using_active_bitflyer_connection(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
   def verified(*args); end
@@ -728,6 +764,9 @@ class Channel::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associa
   def github_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
+  def missing_deposit_id(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
   def not_visible_site_channels(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
@@ -762,6 +801,9 @@ class Channel::ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associa
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
   def twitter_channels(*args); end
+
+  sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
+  def using_active_bitflyer_connection(*args); end
 
   sig { params(args: T.untyped).returns(Channel::ActiveRecord_AssociationRelation) }
   def verified(*args); end


### PR DESCRIPTION
This should hopefully resolve any outstanding bitflyer associated channels that are missing their deposit ids.  I've manually updated quite a few and they have been confirmed successful.  This runs daily and the number of possible updates after an initial run is very low.