### PR TITLE
Task/handle 401 refresh

### DIFF
--- a/test/models/gemini_connection_test.rb
+++ b/test/models/gemini_connection_test.rb
@@ -37,6 +37,34 @@ class GeminiConnectionTest < SidekiqTestCase
           assert_raises(Oauth2::Errors::UnknownError) { conn.refresh_authorization! }
         end
       end
+
+      describe "when 401" do
+        describe "when valid oauth2 response" do
+          let(:payload) { {error: "invalid_token", error_description: "Refresh token can only be used once"} }
+
+          before do
+            stub_request(:post, klass.oauth2_client.token_url)
+              .to_return(status: 401, body: payload.to_json)
+          end
+
+          test "it return an error response" do
+            assert_instance_of(Oauth2::Responses::ErrorResponse, conn.refresh_authorization!)
+          end
+        end
+
+        describe "when invalid oauth2 response" do
+          let(:payload) { {derp: "invalid_token", error_description: "Refresh token can only be used once"} }
+
+          before do
+            stub_request(:post, klass.oauth2_client.token_url)
+              .to_return(status: 401, body: payload.to_json)
+          end
+
+          test "it raises an error" do
+            assert_raises(Oauth2::Errors::UnknownError) { conn.refresh_authorization! }
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This one requires some additional context.

We are seeing a lot of UnknownErrors in production related to gemini wallets.  This is because gemini sends a not to spec status code (401 rather than 400) when a refresh failure occurs.  I went the route of using a block because 401 is not a valid oauth2 spec response code and I do not want to continue polluting Oauth2::AuthenticationCodeClient because of every deviation from spec that a given oauth2 provider initializes.  Instead, I am providing an (explicitly typed) interface that allows one off handling of known not-to-spec error responses.  This ensures we label these connections as failed, handles the known case, and raises the Unknown error if this happens to be an actual unknown 401 case.