### PR TITLE
fix: Do not retry

### DIFF
--- a/app/jobs/create_gemini_recipient_ids_job.rb
+++ b/app/jobs/create_gemini_recipient_ids_job.rb
@@ -2,7 +2,8 @@
 # Creates the Gemini Recipient IDs for a publisher
 class CreateGeminiRecipientIdsJob
   include Sidekiq::Worker
-  sidekiq_options queue: :scheduler
+  # Retry on this creates the possibility of race conditions that accidentally break refreshs.
+  sidekiq_options queue: :scheduler, retry: false
 
   def perform(gemini_connection_id)
     gemini_connection = GeminiConnection.find(gemini_connection_id)


### PR DESCRIPTION
We are calling a lot of jobs including cases that may be redundant/async and cause race conditions.   I don't think there is a ton of reason to retry this over and over again as these jobs get executed A LOT.