### PR TITLE
Feat/gemini recipient id duplicate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-darwin)
     hashdiff (1.0.1)
     hashie (4.1.0)
@@ -314,6 +315,8 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.8)
+    nokogiri (1.13.6-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     oauth (0.5.10)
@@ -433,11 +436,6 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbi (0.0.14)
-      ast
-      parser (>= 2.6.4.0)
-      sorbet-runtime (>= 0.5.9204)
-      unparser
     recaptcha (3.4.0)
       json
     redis (4.2.5)
@@ -550,8 +548,6 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
-    sorbet (0.5.9538)
-      sorbet-static (= 0.5.9538)
     sorbet-coerce (0.5.0)
       polyfill (~> 1.8)
       safe_type (~> 1.1, >= 1.1.1)
@@ -563,11 +559,6 @@ GEM
       sorbet-coerce (>= 0.2.6)
       sorbet-runtime (>= 0.5)
     sorbet-runtime (0.5.9538)
-    sorbet-static (0.5.9538-universal-darwin-20)
-    spoom (1.1.11)
-      sorbet (>= 0.5.9204)
-      sorbet-runtime (>= 0.5.9204)
-      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -580,15 +571,6 @@ GEM
       rubocop (= 1.28.2)
       rubocop-performance (= 1.13.3)
     stripe (5.55.0)
-    tapioca (0.6.1)
-      bundler (>= 1.17.3)
-      pry (>= 0.12.2)
-      rbi (~> 0.0.0, >= 0.0.9)
-      sorbet-runtime (>= 0.5.9204)
-      sorbet-static (>= 0.5.9204)
-      spoom (~> 1.1.0, >= 1.1.4)
-      thor (>= 0.19.2)
-      yard-sorbet
     temping (3.10.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
@@ -649,9 +631,6 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.27)
       webrick (~> 1.7.0)
-    yard-sorbet (0.6.1)
-      sorbet-runtime (>= 0.5)
-      yard (>= 0.9)
     yt (0.33.4)
       activesupport
     zeitwerk (2.3.1)
@@ -663,6 +642,7 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -744,13 +724,11 @@ DEPENDENCIES
   simplecov
   slim-rails (~> 3.1)
   solargraph
-  sorbet (= 0.5.9538)
   sorbet-rails (= 0.7.27)
   sorbet-runtime (= 0.5.9538)
   ssrf_filter
   standard
   stripe (~> 5.1, >= 5.1.1)
-  tapioca (= 0.6.1)
   temping
   tzinfo-data
   u2f (~> 1.0)
@@ -771,4 +749,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.30
+   2.3.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,6 @@ GEM
       raabro (~> 1.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-protobuf (3.19.4)
     google-protobuf (3.19.4-x86_64-darwin)
     hashdiff (1.0.1)
     hashie (4.1.0)
@@ -315,8 +314,6 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.8)
-    nokogiri (1.13.6-aarch64-linux)
-      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     oauth (0.5.10)
@@ -436,6 +433,11 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbi (0.0.14)
+      ast
+      parser (>= 2.6.4.0)
+      sorbet-runtime (>= 0.5.9204)
+      unparser
     recaptcha (3.4.0)
       json
     redis (4.2.5)
@@ -548,6 +550,8 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
+    sorbet (0.5.9538)
+      sorbet-static (= 0.5.9538)
     sorbet-coerce (0.5.0)
       polyfill (~> 1.8)
       safe_type (~> 1.1, >= 1.1.1)
@@ -559,6 +563,11 @@ GEM
       sorbet-coerce (>= 0.2.6)
       sorbet-runtime (>= 0.5)
     sorbet-runtime (0.5.9538)
+    sorbet-static (0.5.9538-universal-darwin-20)
+    spoom (1.1.11)
+      sorbet (>= 0.5.9204)
+      sorbet-runtime (>= 0.5.9204)
+      thor (>= 0.19.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -571,6 +580,15 @@ GEM
       rubocop (= 1.28.2)
       rubocop-performance (= 1.13.3)
     stripe (5.55.0)
+    tapioca (0.6.1)
+      bundler (>= 1.17.3)
+      pry (>= 0.12.2)
+      rbi (~> 0.0.0, >= 0.0.9)
+      sorbet-runtime (>= 0.5.9204)
+      sorbet-static (>= 0.5.9204)
+      spoom (~> 1.1.0, >= 1.1.4)
+      thor (>= 0.19.2)
+      yard-sorbet
     temping (3.10.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
@@ -631,6 +649,9 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.27)
       webrick (~> 1.7.0)
+    yard-sorbet (0.6.1)
+      sorbet-runtime (>= 0.5)
+      yard (>= 0.9)
     yt (0.33.4)
       activesupport
     zeitwerk (2.3.1)
@@ -642,7 +663,6 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
-  aarch64-linux
   x86_64-darwin-20
 
 DEPENDENCIES
@@ -724,11 +744,13 @@ DEPENDENCIES
   simplecov
   slim-rails (~> 3.1)
   solargraph
+  sorbet (= 0.5.9538)
   sorbet-rails (= 0.7.27)
   sorbet-runtime (= 0.5.9538)
   ssrf_filter
   standard
   stripe (~> 5.1, >= 5.1.1)
+  tapioca (= 0.6.1)
   temping
   tzinfo-data
   u2f (~> 1.0)
@@ -749,4 +771,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.3.13
+   2.2.30

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ If for any reason some step in the command chain breaks, simply review the [Make
 
 ## Gotchas
 
+### Feature Flags
+
+When logging in as a creator, you may need to enable feature flags on that creator's account to be able to access the full set of UI options on the site.  Feature flags are stored as a json object on the Publisher model.  To update the flags for a user, run something like:
+```
+$ make docker-shell
+$ rails c
+$ p = Publisher.where(email: 'gemini@completed.org').first
+$ p.update!({ feature_flags: {"gemini_enabled"=>true, "bitflyer_enabled"=>true, "promo_lockout_time"=>"2020-11-23", "referral_kyc_required"=>true}})
+```
+
+
 ### Macbook M1, Docker-compose, and Sorbet
 
 We recommend both the usage of Sorbet for static analysis/linting as well as `docker-compose` for local development, however at the time of writing (3/21/22) the Sorbet binary is not available for Linux running on ARM processes (i.e. within docker-compose).

--- a/app/controllers/publishers/wallets_controller.rb
+++ b/app/controllers/publishers/wallets_controller.rb
@@ -47,7 +47,7 @@ module Publishers
     # Returns a hash
     def gemini_wallet
       current_publisher.gemini_connection.as_json(
-        only: [:default_currency, :display_name, :recipient_id],
+        only: [:default_currency, :display_name, :recipient_id, :recipient_id_status],
         methods: [:payable?, :verify_url]
       )
     end

--- a/app/javascript/locale/en.ts
+++ b/app/javascript/locale/en.ts
@@ -276,6 +276,7 @@ export default {
       disconnect: "Disconnect",
       notPayable: "To receive your payments, you'll need to verify your identity on Gemini.",
       title: "Gemini Wallet",
+      duplicateRecipient: "Gemini is reporting to us that this wallet is already in use with another Brave Creators account. Please try disconnecting the original wallet, and then disconnect and reconnect the wallet on this account."
     },
     lastDeposit: "Last Deposit: <span>{value}</span>",
     lastDepositDate: "Last Deposit Date: <span>{value}</span>",

--- a/app/javascript/views/walletServices/BraveConnection.tsx
+++ b/app/javascript/views/walletServices/BraveConnection.tsx
@@ -59,6 +59,7 @@ class BraveConnection extends React.Component<any, any> {
           defaultCurrency={this.state.geminiConnection.default_currency}
           displayName={this.state.geminiConnection.display_name}
           isPayable={this.state.geminiConnection["payable?"]}
+          recipientIdStatus={this.state.geminiConnection['recipient_id_status']}
           verifyUrl={this.state.geminiConnection.verify_url}
           loadData={this.loadData}
         />

--- a/app/javascript/views/walletServices/braveConnection/GeminiConnection.tsx
+++ b/app/javascript/views/walletServices/braveConnection/GeminiConnection.tsx
@@ -105,9 +105,14 @@ class GeminiConnection extends React.Component<any, any> {
             </Modal>
           </div>
         </div>
-        {!this.props.isPayable && (
+        {!this.props.isPayable && this.props.recipientIdStatus !== 'duplicate' && (
           <VerifyButton verifyUrl={this.props.verifyUrl}>
             <FormattedMessage id="walletServices.gemini.notPayable" />
+          </VerifyButton>
+        )}
+        {this.props.recipientIdStatus === 'duplicate' && (
+          <VerifyButton>
+            <FormattedMessage id="walletServices.gemini.duplicateRecipient" />
           </VerifyButton>
         )}
       </div>

--- a/app/jobs/create_gemini_recipient_ids_job.rb
+++ b/app/jobs/create_gemini_recipient_ids_job.rb
@@ -8,24 +8,27 @@ class CreateGeminiRecipientIdsJob
   def perform(gemini_connection_id)
     gemini_connection = GeminiConnection.find(gemini_connection_id)
     # Users aren't able to create a recipient id if they are not fully verified
-    if gemini_connection.payable?
+    if gemini_connection.is_verified? && gemini_connection.status == "Active"
       recipient = Gemini::RecipientId.find_or_create(token: gemini_connection.access_token)
-      gemini_connection.update(recipient_id: recipient.recipient_id)
+      
+      if gemini_connection.update(recipient_id: recipient.recipient_id, recipient_id_status: 'present')
+        gemini_connection.publisher.channels.each do |channel|
+          gemini_connection_for_channel = GeminiConnectionForChannel.where(
+            gemini_connection: gemini_connection,
+            channel_identifier: channel.details.channel_identifier
+          ).find_or_initialize_by(channel_id: channel.id)
 
-      gemini_connection.publisher.channels.each do |channel|
-        gemini_connection_for_channel = GeminiConnectionForChannel.where(
-          gemini_connection: gemini_connection,
-          channel_identifier: channel.details.channel_identifier
-        ).find_or_initialize_by(channel_id: channel.id)
+          channel_recipient = Gemini::RecipientId.find_or_create(token: gemini_connection.access_token, label: channel.id)
 
-        channel_recipient = Gemini::RecipientId.find_or_create(token: gemini_connection.access_token, label: channel.id)
-
-        # If the channel was deleted and then recreated we should update this to be the new channel id
-        gemini_connection_for_channel.update(
-          recipient_id: channel_recipient.recipient_id,
-          # It's possible a channel can be removed, so this covers re-linking an existing gemini_connection_for_channel to the re-added channel.
-          channel_id: channel.id
-        )
+          # If the channel was deleted and then recreated we should update this to be the new channel id
+          gemini_connection_for_channel.update(
+            recipient_id: channel_recipient.recipient_id,
+            # It's possible a channel can be removed, so this covers re-linking an existing gemini_connection_for_channel to the re-added channel.
+            channel_id: channel.id
+          )
+        end
+      else
+        gemini_connection.update(recipient_id_status: 'duplicate', recipient_id: nil)
       end
     end
   end

--- a/app/jobs/create_gemini_recipient_ids_job.rb
+++ b/app/jobs/create_gemini_recipient_ids_job.rb
@@ -10,8 +10,8 @@ class CreateGeminiRecipientIdsJob
     # Users aren't able to create a recipient id if they are not fully verified
     if gemini_connection.is_verified? && gemini_connection.status == "Active"
       recipient = Gemini::RecipientId.find_or_create(token: gemini_connection.access_token)
-      
-      if gemini_connection.update(recipient_id: recipient.recipient_id, recipient_id_status: 'present')
+
+      if gemini_connection.update(recipient_id: recipient.recipient_id, recipient_id_status: "present")
         gemini_connection.publisher.channels.each do |channel|
           gemini_connection_for_channel = GeminiConnectionForChannel.where(
             gemini_connection: gemini_connection,
@@ -28,7 +28,7 @@ class CreateGeminiRecipientIdsJob
           )
         end
       else
-        gemini_connection.update(recipient_id_status: 'duplicate', recipient_id: nil)
+        gemini_connection.update(recipient_id_status: "duplicate", recipient_id: nil)
       end
     end
   end

--- a/app/models/gemini_connection.rb
+++ b/app/models/gemini_connection.rb
@@ -19,14 +19,21 @@ class GeminiConnection < Oauth2::AuthorizationCodeBase
   scope :payable, -> {
     where(is_verified: true)
       .where(status: "Active")
+      .where.not(recipient_id: nil)
   }
+
+  enum recipient_id_status: {
+    pending: 0,
+    duplicate: 1,
+    present: 2
+  }, _prefix: :recipient_id
 
   def prepare_state_token!
     update(state_token: SecureRandom.hex(64).to_s)
   end
 
   def payable?
-    is_verified? && status == "Active"
+    is_verified? && status == "Active" && recipient_id
   end
 
   def default_currency

--- a/db/migrate/20220512064026_add_recipient_id_status_to_gemini_connections.rb
+++ b/db/migrate/20220512064026_add_recipient_id_status_to_gemini_connections.rb
@@ -1,0 +1,5 @@
+class AddRecipientIdStatusToGeminiConnections < ActiveRecord::Migration[6.1]
+  def change
+    add_column :gemini_connections, :recipient_id_status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_14_225313) do
+ActiveRecord::Schema.define(version: 2022_05_12_064026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -225,6 +225,7 @@ ActiveRecord::Schema.define(version: 2022_03_14_225313) do
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.boolean "oauth_refresh_failed", default: false, null: false
     t.boolean "oauth_failure_email_sent", default: false, null: false
+    t.integer "recipient_id_status", default: 0, null: false
     t.index ["encrypted_access_token_iv"], name: "index_gemini_connections_on_encrypted_access_token_iv", unique: true
     t.index ["encrypted_refresh_token_iv"], name: "index_gemini_connections_on_encrypted_refresh_token_iv", unique: true
     t.index ["is_verified"], name: "index_gemini_connections_on_is_verified"

--- a/test/jobs/create_gemini_recipient_ids_job_test.rb
+++ b/test/jobs/create_gemini_recipient_ids_job_test.rb
@@ -68,5 +68,18 @@ class CreateGeminiRecipientIdsJobTest < ActiveJob::TestCase
         recipient_id: recipient_id_channel
       )
     end
+
+    it "removes the updates the recipient ID status if there's a duplicate recipient_id" do
+      subject
+
+      second_connection = gemini_connections(:default_connection)
+      second_connection.update(recipient_id: nil, is_verified: true,
+        status: "Active")
+
+      CreateGeminiRecipientIdsJob.new.perform(second_connection.id)
+
+      assert second_connection.reload.recipient_id_duplicate? == true
+      refute second_connection.reload.payable?
+    end
   end
 end

--- a/test/jobs/create_gemini_recipient_ids_job_test.rb
+++ b/test/jobs/create_gemini_recipient_ids_job_test.rb
@@ -78,8 +78,11 @@ class CreateGeminiRecipientIdsJobTest < ActiveJob::TestCase
 
       CreateGeminiRecipientIdsJob.new.perform(second_connection.id)
 
-      assert second_connection.reload.recipient_id_duplicate? == true
+      assert second_connection.reload.recipient_id_duplicate?
       refute second_connection.reload.payable?
+      assert gemini_connection.reload.recipient_id == recipient_id
+      assert gemini_connection.reload.payable?
+      refute second_connection.reload.recipient_id_duplicate?
     end
   end
 end

--- a/test/jobs/create_gemini_recipient_ids_job_test.rb
+++ b/test/jobs/create_gemini_recipient_ids_job_test.rb
@@ -82,7 +82,7 @@ class CreateGeminiRecipientIdsJobTest < ActiveJob::TestCase
       refute second_connection.reload.payable?
       assert gemini_connection.reload.recipient_id == recipient_id
       assert gemini_connection.reload.payable?
-      refute second_connection.reload.recipient_id_duplicate?
+      refute gemini_connection.reload.recipient_id_duplicate?
     end
   end
 end


### PR DESCRIPTION
## Display error message when trying to connect Gemini Wallet that has same recipient ID as another

<img width="579" alt="Screen Shot 2022-05-17 at 8 09 39 PM" src="https://user-images.githubusercontent.com/4231556/168940768-8128c248-4851-4d8e-bfcb-1d0e20d9247f.png">

#### Features
Closes issue #3625.  
I added in a new column, `recipient_id_status` to `GeminiConnection`. This keeps track of the recipient id's status so that proper error messages can be displayed on the front end.  I also updated the definition of `#payable?` for `GeminiConnection`, because accounts should not be payable if there is no recipient ID present.

#### How To Test

1. Connect a gemini account to one of the creators
2. Connect the same gemini account to a different creator
3. Confirm that the duplicate error message is shown after connection
