### PR TITLE
feat: Redis counter

### DIFF
--- a/app/services/redis_count_service.rb
+++ b/app/services/redis_count_service.rb
@@ -1,0 +1,50 @@
+# typed: true
+
+class RedisCountService < BuilderBaseService
+  class BelowLimit < T::Struct
+    const :limit, Integer
+    const :interval, Integer
+    const :count, Integer
+  end
+
+  class AboveLimit < T::Struct
+    const :limit, Integer
+    const :interval, Integer
+    const :count, Integer
+  end
+
+  def self.build
+    new
+  end
+
+  def initialize(limit: 10, interval: 60, host: "redis", port: 6379, client: nil)
+    @host = host
+    @port = port
+    @limit = limit
+    @interval = interval
+    @client = client
+
+    set_client
+  end
+
+  def call(key)
+    return unless @client
+
+    begin
+      count = @client.incr(key)
+      @client.expire(key, @interval) if count == 1
+
+      struct = count > @limit ? AboveLimit : BelowLimit
+      struct.new(limit: @limit, interval: @interval, count: count)
+    rescue Redis::CannotConnectError
+      BFailure.new(errors: ["Could not connect to Redis Client"])
+    end
+  end
+
+  private
+
+  def set_client
+    return if @client
+    @client = ::Redis.new(host: @host, port: @port)
+  end
+end

--- a/test/services/redis_count_service_test.rb
+++ b/test/services/redis_count_service_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class RedisCountServiceTest < ActiveSupport::TestCase
+  subject { RedisCountService }
+  let(:instance) { subject.new }
+  let(:key) { "test-key" }
+
+  describe "#initialize" do
+    describe "when successful" do
+      it "should return an instance" do
+        assert_instance_of(subject, instance)
+      end
+    end
+
+    describe "#call" do
+      describe "when server is !available" do
+        before do
+          Redis.any_instance.stubs(:incr).raises(Redis::CannotConnectError)
+        end
+
+        it "should return BFailure" do
+          assert_instance_of(BFailure, instance.call(key))
+        end
+      end
+
+      describe "when server is available" do
+        before do
+          Redis.any_instance.stubs(:incr).returns(10)
+        end
+
+        describe "when <= limit" do
+          it "should return falsey" do
+            assert_instance_of(RedisCountService::BelowLimit, instance.call(key))
+          end
+        end
+
+        describe "when > limit" do
+          before do
+            Redis.any_instance.stubs(:incr).returns(11)
+          end
+
+          it "should return truthy" do
+            assert_instance_of(RedisCountService::AboveLimit, instance.call(key))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Generally useful for caching values and keeping track of how many times they've been seen over an interval.  Can be used for rate limiting etc.