### PR TITLE
improvement: Notify commit and environment after initialiation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,5 +52,11 @@ module Publishers
     config.generators do |generator|
       generator.orm :active_record, primary_key_type: :uuid
     end
+
+    config.after_initialize do
+      commit = `git rev-parse HEAD`.chomp
+      message = "Successfully Initialized commit '#{commit}' in #{Rails.env}"
+      SlackMessenger.new(message: message).perform
+    end
   end
 end


### PR DESCRIPTION
This actually notifies in the sidekiq container instead of web... but it is more than nothing.  Also having a clear notice of when a build has actually succeeded would be really helpful in general.