### PR TITLE
Task/minor followups

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -159,8 +159,6 @@ class PublishersController < ApplicationController
   # Domain verified. See balance and submit payment info.
   def home
     @publisher = current_publisher
-    # Kick off jobs to resync our data with the wallet providers information.
-    @publisher.sync_wallet_connections
 
     uphold_connection = current_publisher.uphold_connection
     if uphold_connection.blank?

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -383,8 +383,6 @@ class Channel < ApplicationRecord
     case wallet
     when BitflyerConnection
       Sync::Bitflyer::UpdateMissingDepositJob.perform_async(id) if deposit_id.nil?
-    when GeminiConnection
-      wallet.sync_connection! if gemini_connection_for_channel.blank?
     end
   end
 


### PR DESCRIPTION
I'm just doing some follow up tasks related to all of the oauth2 connection work I've been doing as well as the bitflyer updates.  For now I'm adding a global exception handler and logging for any oauth2 controller connections that fail (Currently only bitflyer, but will eventually apply to all wallet connections).

For bitflyer specifically this sends up a generic flash message for any failure related to creating a bitflyer connection.  

![Screen Shot 2022-06-06 at 5 24 48 PM](https://user-images.githubusercontent.com/8813557/172251846-a596e2d8-641d-4fc2-a9b6-c0c7ca78f62f.png)

Part of brave-intl/creators-private-issues#62