### PR TITLE
Deposits job fixes and channel improvements.

### DIFF
--- a/app/jobs/sync/bitflyer/update_missing_deposits_job.rb
+++ b/app/jobs/sync/bitflyer/update_missing_deposits_job.rb
@@ -5,11 +5,12 @@ class Sync::Bitflyer::UpdateMissingDepositsJob
 
   def perform(async: true)
     Channel.missing_deposit_id.using_active_bitflyer_connection.select(:id).find_in_batches do |batch|
-      batch.each do |id|
+      batch.each do |channel|
+        # FML
         if async
-          Sync::Bitflyer::UpdateMissingDepositJob.perform_async(id)
+          Sync::Bitflyer::UpdateMissingDepositJob.perform_async(channel.id)
         else
-          Sync::Bitflyer::UpdateMissingDepositJob.new.perform(id)
+          Sync::Bitflyer::UpdateMissingDepositJob.new.perform(channel.id)
         end
       end
     end

--- a/app/jobs/sync/bitflyer/update_missing_deposits_job.rb
+++ b/app/jobs/sync/bitflyer/update_missing_deposits_job.rb
@@ -3,7 +3,9 @@ class Sync::Bitflyer::UpdateMissingDepositsJob
   include Sidekiq::Worker
   sidekiq_options queue: :default, retry: false
 
-  def perform(async: true)
+  # THere is definitely a rate limit here despite being told there wasn't.  I manually
+  # executed the service because the wrong id value was being passed to the job and it succeeded and eventually hit a 429.
+  def perform(async: true, wait: 0.1)
     Channel.missing_deposit_id.using_active_bitflyer_connection.select(:id).find_in_batches do |batch|
       batch.each do |channel|
         # FML
@@ -12,6 +14,8 @@ class Sync::Bitflyer::UpdateMissingDepositsJob
         else
           Sync::Bitflyer::UpdateMissingDepositJob.new.perform(channel.id)
         end
+
+        sleep(wait) if wait
       end
     end
   end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -346,7 +346,9 @@ class Channel < ApplicationRecord
     self.verified_at = nil if verified == false && verified_at.present?
   end
 
+  # This literally runs for all channels because we create an uphold connection for all users.
   def create_channel_card
+    return if !publisher.uphold_connection&.uphold_id
     CreateUpholdChannelCardJob.perform_later(uphold_connection_id: publisher.uphold_connection&.id, channel_id: id)
   end
 

--- a/test/controllers/channel_transfer_controller_test.rb
+++ b/test/controllers/channel_transfer_controller_test.rb
@@ -14,7 +14,7 @@ class ChannelTransferControllerTest < ActionDispatch::IntegrationTest
     # contest channel
     Channels::ContestChannel.new(channel: channel, contested_by: contested_by_channel).perform
 
-    assert_enqueued_jobs(5) do
+    assert_enqueued_jobs(4) do
       get token_reject_transfer_path(channel, channel.contest_token)
     end
 

--- a/test/controllers/site_channels_controller_test.rb
+++ b/test/controllers/site_channels_controller_test.rb
@@ -228,8 +228,7 @@ class SiteChannelsControllerTest < ActionDispatch::IntegrationTest
 
       new_channel = publisher.channels.order(created_at: :asc).last
 
-      # Triggering an update to test if the promo was created
-      assert_enqueued_jobs(1) do
+      assert_enqueued_jobs(0) do
         new_channel.update(verified: true)
       end
     ensure

--- a/test/jobs/channels/transfer_channels_job_test.rb
+++ b/test/jobs/channels/transfer_channels_job_test.rb
@@ -45,7 +45,7 @@ class Channels::TransferChannelsJobTest < ActiveJob::TestCase
 
       # There are 5 jobs enqueued (4 emails and a slack message) when a channel completes transfer
       # and another for Publishers' List
-      assert_performed_jobs 6
+      assert_performed_jobs 5 # lol, again with the commentary
 
       contested_by_channel.reload
       assert contested_by_channel.verified

--- a/test/services/channels/contest_channel_test.rb
+++ b/test/services/channels/contest_channel_test.rb
@@ -7,7 +7,8 @@ class ContestChannelTest < ActiveJob::TestCase
     channel = channels(:fraudulently_verified_site)
     contested_by_channel = channels(:locked_out_site)
 
-    assert_enqueued_jobs(3) do
+    # lol, the name of this spec is pretty funny
+    assert_enqueued_jobs(2) do
       Channels::ContestChannel.new(channel: channel, contested_by: contested_by_channel).perform
     end
   end


### PR DESCRIPTION
1. The wrong value was being passed into the update deposits job and was failing in the async context (despite actually having synchronous specs that pass...)
2. Uphold card jobs are enqueued for all channels because all publishers have an uphold connection (😮‍💨 )
3. Bitflyer clearly does rate limit deposit id requests because I hit it when manually debugging in prod.

Should finally fix the issue with brave-intl/creators-private-issues#62 which has been very difficult to debug.