### PR TITLE
improvement: Actually notify IP address so action can be taken

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -33,7 +33,7 @@ class Api::BaseController < ActionController::API
     if token_authenticated && !ip_authenticated
       # Message slack per security team's recommendation https://github.com/brave/security/issues/201#issuecomment-666501816
       SlackMessenger.new(
-        message: "#🚨 Publishers API auth token used from a non whitelisted IP address 🚨",
+        message: "#🚨 Publishers API auth token used from a non whitelisted IP address - #{request.remote_ip} 🚨",
         channel: SlackMessenger::ALERTS
       ).perform
     end


### PR DESCRIPTION
Without this it's unclear what value this alert actually provides.  Including the IP address allows us to immediately sleuth it out and determine if it needs to be added to the whitelist, or helps us determine that a token has been compromised.