### PR TITLE
Production Release: Tweak Slack Notifications - 6/8/22

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -371,6 +371,7 @@ class Channel < ApplicationRecord
       end
 
     SlackMessenger.new(
+      channel: "publishers-bot",
       message: "#{emoji} *#{details.publication_title}* verified by owner #{publisher.owner_identifier}; id=#{details.channel_identifier}; url=#{details.url}"
     ).perform
   end


### PR DESCRIPTION
Points event stream back to previously configured channel.