### PR TITLE
task: Do not create empty connection

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -161,9 +161,6 @@ class PublishersController < ApplicationController
     @publisher = current_publisher
 
     uphold_connection = current_publisher.uphold_connection
-    if uphold_connection.blank?
-      uphold_connection = UpholdConnection.create!(publisher: current_publisher)
-    end
 
     if payout_in_progress?(current_publisher) && Date.today.day < 12 # Let's display the payout for 5 days after it should complete (on the 8th)
       @payout_report = PayoutReport.where(final: true, manual: false).order(created_at: :desc).first
@@ -173,7 +170,7 @@ class PublishersController < ApplicationController
     @channels = @publisher.channels.visible.paginate(page: params[:page], per_page: 10)
     @publisher_unattached_promo_registrations = @publisher.promo_registrations.unattached_only
 
-    if uphold_connection.uphold_details.present?
+    if uphold_connection&.uphold_details.present?
       @possible_currencies = uphold_connection.uphold_details&.currencies
     end
 


### PR DESCRIPTION
Removes the arbitrary empty uphold connection step that happens whenever a user logs in.

I tested this locally with a brand new user and didn't encounter any issues on a cursory glance.  Probably worth exploring channel creation etc, but I had some difficulty doing that in local dev.

#3668 