### PR TITLE
Production Release: Fixes and artifacts

### DIFF
--- a/app/controllers/publishers/statements_controller.rb
+++ b/app/controllers/publishers/statements_controller.rb
@@ -9,7 +9,7 @@ module Publishers
     def index
       @cannot_read_uphold_transactions = false
       if publisher.is_selected_wallet_provider_uphold?
-        if !publisher.uphold_connection.can_read_transactions?
+        if !publisher.uphold_connection&.can_read_transactions?
           @cannot_read_uphold_transactions = true
         end
       end

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -161,9 +161,6 @@ class PublishersController < ApplicationController
     @publisher = current_publisher
 
     uphold_connection = current_publisher.uphold_connection
-    if uphold_connection.blank?
-      uphold_connection = UpholdConnection.create!(publisher: current_publisher)
-    end
 
     if payout_in_progress?(current_publisher) && Date.today.day < 12 # Let's display the payout for 5 days after it should complete (on the 8th)
       @payout_report = PayoutReport.where(final: true, manual: false).order(created_at: :desc).first
@@ -173,7 +170,7 @@ class PublishersController < ApplicationController
     @channels = @publisher.channels.visible.paginate(page: params[:page], per_page: 10)
     @publisher_unattached_promo_registrations = @publisher.promo_registrations.unattached_only
 
-    if uphold_connection.uphold_details.present?
+    if uphold_connection&.uphold_details.present?
       @possible_currencies = uphold_connection.uphold_details&.currencies
     end
 

--- a/lib/oauth2/config.rb
+++ b/lib/oauth2/config.rb
@@ -59,7 +59,7 @@ module Oauth2::Config
       def base_redirect_url
         uri = case env
         when "production"
-          "https://creators.brave.com"
+          "https://publishers.basicattentiontoken.org" # FIXME: THis is what bitflyer uses and we can't see it.  Make sure to review the prod env values.
         when "staging"
           "https://publishers-staging.basicattentiontoken.org"
         else

--- a/test/lib/oauth2/config_test.rb
+++ b/test/lib/oauth2/config_test.rb
@@ -36,7 +36,7 @@ class Oauth2ConfigTest < ActiveSupport::TestCase
           let(:redirect_url_values) do
             case environment
             when "production"
-              "creators.brave"
+              "publishers.basicattentiontoken"
             when "staging"
               "publishers"
             else


### PR DESCRIPTION
1. Removes the action that creates an empty uphold connection for every user in the system.
2. Fixes a call to the statements controller that expects a truthy uphold connection for all users
3. Fix the oauth2 production config for bitflyer redirect url.  Valid redirect url at bitflyer users publishers.basicattentiontoken.org

Closes #3668 
Fixes brave-intl/creators-private-issues#93