### PR TITLE
Task/disable requests

### DIFF
--- a/test/services/bitflyer/update_deposit_id_service_test.rb
+++ b/test/services/bitflyer/update_deposit_id_service_test.rb
@@ -25,7 +25,7 @@ class BitflyerUpdateDepositIdService < ActiveSupport::TestCase
 
       describe "when connection is already failure" do
         before do
-          connection.oauth_refresh_failed = true
+          connection.update!(oauth_refresh_failed: true)
         end
 
         test "it should BFailure" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -103,7 +103,7 @@ VCR.configure do |config|
     i.request.headers.delete("Authorization")
   end
   config.ignore_hosts "127.0.0.1", "localhost"
-  config.allow_http_connections_when_no_cassette = true
+  config.allow_http_connections_when_no_cassette = false
   config.default_cassette_options = {match_requests_on: [:method, :uri, :body], decode_compressed_response: true}
 end
 


### PR DESCRIPTION
Disabling this line cut our run runtime in half, it also successfully picked up a spec that was invisibly running failed http requests against bitflyer.