### PR TITLE
Production Release: Refactor Uphold Card create job/Fix assignment of wrong currency to connection

### DIFF
--- a/app/jobs/create_uphold_cards_job.rb
+++ b/app/jobs/create_uphold_cards_job.rb
@@ -4,59 +4,11 @@ class CreateUpholdCardsJob < ApplicationJob
   queue_as :default
 
   def perform(uphold_connection_id:)
-    uphold_connection = UpholdConnection.find(uphold_connection_id)
+    conn = UpholdConnection.find(uphold_connection_id)
+    card = Uphold::FindOrCreateCardService.build.call(conn)
+    return conn if card&.id == conn.address
 
-    unless uphold_connection.can_create_uphold_cards?
-      Rails.logger.info("Could not create uphold card for publisher #{uphold_connection.publisher_id}. Uphold Verified: #{uphold_connection.uphold_verified}")
-      return
-    end
-
-    return if uphold_connection.valid_card?
-
-    card = find_existing_card(uphold_connection)
-
-    # If the card doesn't exist so we should create it
-    if card.blank?
-      Rails.logger.info("Could not find existing card for #{uphold_connection.default_currency} - Creating a new card")
-      card = UpholdClient.card.create(uphold_connection: uphold_connection)
-    end
-
-    # Finally let's update the address with the id of the card
-    uphold_connection.update(address: card.id)
-  end
-
-  # Iterates through the existing cards for an Uphold Account to find if we've already created a card
-  #
-  # Returns nil, or the card that was found
-  def find_existing_card(uphold_connection)
-    cards = UpholdClient.card.where(uphold_connection: uphold_connection)
-
-    return if cards.nil?
-
-    # This is the default label that we apply to a card. If we find it then it's safe to assume that this was one we've created prior.
-    card = cards&.detect { |c| c.label.eql?("Brave Rewards") }
-
-    # User's can change the label's on their cards so if we couldn't find it, we'll have to iterate until we find a card.
-    # We want to make sure isn't the browser's wallet card and isn't a channel card. We can do this by checking the private address
-    cards.each do |c|
-      break if card.present?
-      next if has_private_address?(uphold_connection, c.id)
-
-      card = c
-    end
-
-    card
-  end
-
-  # Makes an HTTP Call to the Uphold card/:id/address endpoint to determine if the card has a private address
-  #
-  # Returns true if the card has a private address
-  def has_private_address?(uphold_connection, card_id)
-    @existing_private_cards ||= UpholdConnectionForChannel.select(:card_id).where(uphold_connection: uphold_connection, uphold_id: uphold_connection.uphold_id).to_a
-    return true if @existing_private_cards.include?(card_id)
-
-    addresses = UpholdClient.address.all(uphold_connection: uphold_connection, id: card_id)
-
-    addresses.detect { |a| a.type == UpholdConnectionForChannel::NETWORK }.present?
+    conn.update!(address: card.id)
+    conn
   end
 end

--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -309,6 +309,10 @@ class UpholdConnection < Oauth2::AuthorizationCodeBase
     self
   end
 
+  def uphold_client
+    @_uphold_client ||= Uphold::ConnectionClient.new(self)
+  end
+
   class << self
     def provider_name
       "Uphold"

--- a/app/services/uphold/find_or_create_card_service.rb
+++ b/app/services/uphold/find_or_create_card_service.rb
@@ -1,0 +1,153 @@
+# typed: true
+
+# Going to strict typing is a whole different ballgame.
+
+class Uphold::FindOrCreateCardService < BuilderBaseService
+  include Uphold::Types
+  include Oauth2::Responses
+  include Oauth2::Errors
+  extend T::Helpers
+  extend T::Sig
+
+  # This doesn't work. I keep running into all sorts of issues with inheritance and sorbet
+  #  sig { override.returns(T.self_type) }
+  def self.build
+    new
+  end
+
+  sig { override.params(conn: UpholdConnection).returns(BServiceResult) }
+  def call(conn)
+    result = conn.refresh_authorization!
+
+    case result
+    when UpholdConnection
+      @conn = result
+
+      if card_exists?
+        @card
+      elsif has_no_cards?
+        create_card
+      else
+        find_or_create_card
+      end
+    when BFailure
+      result
+    when ErrorResponse
+      BFailure.new(errors: [result])
+    else
+      T.absurd(result)
+    end
+  end
+
+  private
+
+  sig { returns(T::Boolean) }
+  def card_exists?
+    return false if @conn.address.nil?
+    result = client.cards.get(@conn.address)
+
+    case result
+    when UpholdCard
+      @card = result
+      true
+    when Faraday::Response
+      raise_unless_not_found(result)
+    else
+      T.absurd(result)
+    end
+  end
+
+  sig { returns(UpholdCard) }
+  def create_card
+    result = client.cards.create(
+      label: UpholdConnection::UPHOLD_CARD_LABEL,
+      currency: @conn.default_currency,
+      settings: {starred: true}
+    )
+
+    case result
+    when UpholdCard
+      result
+    when Faraday::Response
+      raise ClientError.new(response: result)
+    else
+      T.absurd(result)
+    end
+  end
+
+  sig { returns(T::Boolean) }
+  def has_no_cards?
+    result = client.cards.list
+
+    case result
+    when Faraday::Response
+      raise_unless_not_found(result)
+    when Array
+      if result.empty?
+        true
+      else
+        @cards = result
+        false
+      end
+    end
+  end
+
+  sig { returns(UpholdCard) }
+  def find_or_create_card
+    # User's can change the label's on their cards so if we couldn't find it, we'll have to iterate until we find a card.
+    # We want to make sure isn't the browser's wallet card and isn't a channel card. We can do this by checking the private address
+    #
+    # https://sorbet.org/docs/error-reference#7001
+    card = T.let(nil, T.nilable(UpholdCard))
+
+    @cards.each do |c|
+      if c.label.eql?(UpholdConnection::UPHOLD_CARD_LABEL) && c.currency == @conn.default_currency
+        card = c
+        break
+
+        # The implementation pulled from the create_uphold_card_job method assigned
+        # cards when the currency was mismatched.  This is probably the reason
+        # we have had bugs WRT to payouts.
+      elsif c.currency != @conn.default_currency || has_private_address?(c.id)
+        next
+      else
+        card = c
+      end
+    end
+
+    if card.nil?
+      create_card
+    else
+      card
+    end
+  end
+
+  sig { returns(Uphold::ConnectionClient) }
+  def client
+    @_client ||= Uphold::ConnectionClient.new(@conn)
+  end
+
+  sig { params(card_id: String).returns(T::Boolean) }
+  def has_private_address?(card_id)
+    existing_private_cards ||= T.unsafe(UpholdConnectionForChannel).select(:card_id).where(uphold_connection: @conn, uphold_id: @conn.uphold_id).to_a
+    return true if existing_private_cards.include?(card_id)
+
+    result = client.cards.list_addresses(card_id)
+
+    case result
+    when Array
+      result.detect { |a| a.type == UpholdConnectionForChannel::NETWORK }.present?
+    else
+      raise ClientError.new(response: result)
+    end
+  end
+
+  sig { params(response: Faraday::Response).returns(FalseClass) }
+  def raise_unless_not_found(response)
+    if response.status == 404
+      false
+    else
+      raise ClientError.new(response: response)
+    end
+  end
+end

--- a/lib/uphold/connection_client.rb
+++ b/lib/uphold/connection_client.rb
@@ -5,7 +5,7 @@ module Uphold
     extend T::Sig
 
     sig { params(conn: UpholdConnection).void }
-    def initialize(conn:)
+    def initialize(conn)
       @conn = conn
     end
 

--- a/test/lib/uphold/connection_client_test.rb
+++ b/test/lib/uphold/connection_client_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 class UpholdV2ClientTest < ActiveSupport::TestCase
   let(:conn) { uphold_connections(:basic_connection) }
   let(:described_class) { Uphold::ConnectionClient }
-  let(:inst) { described_class.new(conn: conn) }
+  let(:inst) { described_class.new(conn) }
 
   describe "#init" do
     it "should return self" do

--- a/test/services/uphold/find_or_create_card_service_test.rb
+++ b/test/services/uphold/find_or_create_card_service_test.rb
@@ -1,0 +1,120 @@
+# typed: false
+require "test_helper"
+
+class UpholdFindOrCreateCardService < ActiveSupport::TestCase
+  include MockOauth2Responses
+  include MockUpholdResponses
+  include Oauth2::Responses
+  include Uphold::Types
+
+  describe Uphold::FindOrCreateCardService.name do
+    let(:described_class) { Uphold::FindOrCreateCardService }
+    let(:inst) { described_class.build }
+    let(:connection) { uphold_connections(:google_connection) }
+
+    describe "#build" do
+      it "should return self" do
+        assert_instance_of(described_class, inst)
+      end
+    end
+
+    describe "#call" do
+      describe "when connection is active" do
+        describe "when card exists" do
+          before do
+            mock_refresh_token_success(connection.class.oauth2_config.token_url)
+            stub_get_card(id: connection.address)
+          end
+
+          it "it should UpholdCard" do
+            result = inst.call(connection)
+            assert_instance_of(UpholdCard, result)
+          end
+        end
+
+        describe "when !card exists" do
+          describe "when some cards exist" do
+            describe "when !matches label" do
+              describe "when default_currency matches" do
+                before do
+                  mock_refresh_token_success(connection.class.oauth2_config.token_url)
+                  connection.address = nil
+                  connection.default_currency = "BAT"
+                  connection.save!
+
+                  # Brutal.
+                  stub_list_cards(label: "derp", currency: "BAT")
+                  stub_list_cards(label: "derp", currency: "BAT", stub: false).each do |card|
+                    stub_list_card_addresses(id: card[:id])
+                  end
+                  stub_create_card
+                end
+
+                it "it should UpholdCard" do
+                  result = inst.call(connection)
+                  assert_instance_of(UpholdCard, result)
+                end
+              end
+
+              describe "when default_currency !matches" do
+                before do
+                  mock_refresh_token_success(connection.class.oauth2_config.token_url)
+                  connection.address = nil
+                  connection.save!
+                  stub_list_cards(label: "derp")
+                  stub_create_card
+                end
+
+                it "it should UpholdCard" do
+                  result = inst.call(connection)
+                  assert_instance_of(UpholdCard, result)
+                end
+              end
+            end
+
+            describe "when matches label" do
+              before do
+                mock_refresh_token_success(connection.class.oauth2_config.token_url)
+                connection.address = nil
+                connection.default_currency = "BAT"
+                connection.save!
+                stub_list_cards(currency: "BAT")
+              end
+
+              it "it should UpholdCard" do
+                result = inst.call(connection)
+                assert_instance_of(UpholdCard, result)
+              end
+            end
+          end
+
+          describe "when no cards exist" do
+            before do
+              mock_refresh_token_success(connection.class.oauth2_config.token_url)
+              connection.address = nil
+              connection.save!
+
+              stub_list_cards(empty: true)
+              stub_create_card
+            end
+
+            it "it should UpholdCard" do
+              result = inst.call(connection)
+              assert_instance_of(UpholdCard, result)
+            end
+          end
+        end
+      end
+
+      describe "when connection is already failure" do
+        before do
+          connection.update!(oauth_refresh_failed: true)
+        end
+
+        it "it should BFailure" do
+          assert_instance_of(BFailure, inst.call(connection))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
1. Refactors uphold card create job (which is critical for payout), extends specs, adds typing and exhaustiveness checks.
2. Resolves a bug where a connection could be set to a value other than it's default_currency due to a bad matching condition.

Fixes brave-intl/creators-private-issues#94