### PR TITLE
Update email only after a successful step-up (if a step-up method is available).

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -224,18 +224,7 @@ class PublishersController < ApplicationController
 
   class SignIn < StepUpAction
     call do |publisher_id, confirm_email|
-      current_publisher = Publisher.find(publisher_id)
-
-      pending_email = current_publisher.pending_email
-      if pending_email.present?
-        if current_publisher.email.blank?
-          current_publisher.email = pending_email
-        elsif confirm_email.present? && confirm_email == pending_email
-          current_publisher.email = pending_email
-        end
-        current_publisher.pending_email = nil
-        current_publisher.save!
-      end
+      current_publisher = Publisher.find(publisher_id).confirm_pending_email!(confirm_email)
 
       if confirm_email.present? && current_publisher.email == confirm_email && !publisher_created_through_youtube_auth?(current_publisher)
         flash[:notice] = t("publishers.show.email_confirmed", email: current_publisher.email)

--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -223,8 +223,24 @@ class PublishersController < ApplicationController
   private
 
   class SignIn < StepUpAction
-    call do |publisher_id|
+    call do |publisher_id, confirm_email|
       current_publisher = Publisher.find(publisher_id)
+
+      pending_email = current_publisher.pending_email
+      if pending_email.present?
+        if current_publisher.email.blank?
+          current_publisher.email = pending_email
+        elsif confirm_email.present? && confirm_email == pending_email
+          current_publisher.email = pending_email
+        end
+        current_publisher.pending_email = nil
+        current_publisher.save!
+      end
+
+      if confirm_email.present? && current_publisher.email == confirm_email && !publisher_created_through_youtube_auth?(current_publisher)
+        flash[:notice] = t("publishers.show.email_confirmed", email: current_publisher.email)
+      end
+
       sign_in(:publisher, current_publisher)
       redirect_to publisher_next_step_path(current_publisher) if two_factor_enabled?(current_publisher)
     end
@@ -253,12 +269,8 @@ class PublishersController < ApplicationController
       return
     end
 
-    if PublisherTokenAuthenticator.new(publisher: publisher, token: token, confirm_email: confirm_email).perform
-      if confirm_email.present? && publisher.email == confirm_email && !publisher_created_through_youtube_auth
-        flash[:notice] = t(".email_confirmed", email: publisher.email)
-      end
-
-      SignIn.new(publisher_id).step_up! self
+    if PublisherTokenAuthenticator.new(publisher: publisher, token: token).perform
+      SignIn.new(publisher_id, confirm_email).step_up! self
     else
       flash[:alert] = t(".token_invalid")
       redirect_to expired_authentication_token_publishers_path(id: publisher.id)

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -468,6 +468,21 @@ class Publisher < ApplicationRecord
     provider_country.to_s.upcase
   end
 
+  def confirm_pending_email!(confirm_email = nil)
+    if pending_email.present?
+      if email.blank?
+        self.email = pending_email
+      elsif confirm_email.present? && confirm_email == pending_email
+        self.email = pending_email
+      end
+
+      self.pending_email = nil
+      save!
+    end
+
+    self
+  end
+
   private
 
   def cleanup_name

--- a/app/services/publisher_token_authenticator.rb
+++ b/app/services/publisher_token_authenticator.rb
@@ -2,12 +2,11 @@
 # Authenticate a Publisher by #authentication_token, which are consumed on use
 # and expires after 3 hours. New ones can be sent to your email.
 class PublisherTokenAuthenticator < BaseService
-  attr_reader :publisher, :token, :confirm_email
+  attr_reader :publisher, :token
 
-  def initialize(publisher:, token:, confirm_email:)
+  def initialize(publisher:, token:)
     @publisher = publisher
     @token = token
-    @confirm_email = confirm_email
   end
 
   # Note: If the token was valid, this consumes it.
@@ -23,16 +22,6 @@ class PublisherTokenAuthenticator < BaseService
       ::Digest::SHA256.hexdigest(publisher.user_authentication_token.authentication_token)
     )
     if result
-      pending_email = publisher.pending_email
-      if pending_email.present?
-        if publisher.email.blank?
-          publisher.email = pending_email
-        elsif confirm_email.present? && confirm_email == pending_email
-          publisher.email = pending_email
-        end
-        publisher.pending_email = nil
-        publisher.save!
-      end
       publisher.user_authentication_token.update(authentication_token: nil) if consume
     end
     result

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -53,6 +53,42 @@ class PublisherTest < ActiveSupport::TestCase
       end
     end
   end
+  
+  describe "#confirm_pending_email!" do
+    let(:publisher) { publishers(:default) }
+    let(:confirm_email) { nil }
+
+    describe "confirm_email" do
+      describe "pending_email" do
+        describe "!email" do
+          it "should set email to pending_email" do
+          end
+        end
+
+        describe "confirm_email == pending_email" do
+          it "should set email to pending_email" do
+          end
+
+          it "should set pending_email to nil" do
+          end
+        end
+
+        describe "confirm_email != pending_email" do
+          it "should not change email" do
+          end
+
+          it "should set pending_email to nil" do
+          end
+        end
+      end
+
+      describe "!pending_email" do
+      end
+    end
+
+    describe "!confirm_email" do
+    end
+  end
 
   test "verified publishers have both a name and email and have agreed to the TOS" do
     publisher = Publisher.new

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -53,40 +53,57 @@ class PublisherTest < ActiveSupport::TestCase
       end
     end
   end
-  
+
   describe "#confirm_pending_email!" do
     let(:publisher) { publishers(:default) }
-    let(:confirm_email) { nil }
 
     describe "confirm_email" do
       describe "pending_email" do
         describe "!email" do
           it "should set email to pending_email" do
+            publisher.email = nil
+            publisher.pending_email = "test@email.com"
+            publisher.confirm_pending_email!(nil)
+            assert_equal publisher.email, "test@email.com"
           end
         end
 
         describe "confirm_email == pending_email" do
           it "should set email to pending_email" do
+            publisher.pending_email = "test@email.com"
+            publisher.confirm_pending_email!("test@email.com")
+            assert_equal publisher.email, "test@email.com"
           end
 
           it "should set pending_email to nil" do
+            publisher.pending_email = "test@email.com"
+            publisher.confirm_pending_email!("test@email.com")
+            assert_nil publisher.pending_email
           end
         end
 
         describe "confirm_email != pending_email" do
           it "should not change email" do
+            publisher_email_old = publisher.email
+            publisher.pending_email = "test@email.com"
+            publisher.confirm_pending_email!("test2@email.com")
+            assert_equal publisher.email, publisher_email_old
           end
 
           it "should set pending_email to nil" do
+            publisher.pending_email = "test@email.com"
+            publisher.confirm_pending_email!("test2@email.com")
+            assert_nil publisher.pending_email
           end
         end
       end
 
       describe "!pending_email" do
+        it "should not change the email" do
+          assert_equal publisher, publisher.confirm_pending_email!("test@email.com")
+          assert_equal publisher, publisher.confirm_pending_email!(nil)
+        end
       end
-    end
-
-    describe "!confirm_email" do
     end
   end
 


### PR DESCRIPTION
Do not update the email unless a successful step-up has occurred.
This allows securing the padlocked account from
session-hijacking+account takeover tentative.

Relates to https://github.com/brave-intl/publishers/issues/3616#issuecomment-1130264573

## Pull Request Name

*: update email only after step-up

#### Features

Update email only after a successful step-up (if a step-up method is available).

#### How To Test

1. Create an account
2. Click on the confirmation email to Login
3. Setup 2FA (WebAuthN or TOTP are either working good)
4. Change the email
5. Click on the confirmation email to change the email

A 2fa prompt should show and the email should not be changed unless the 2fa is successful

#### Pull Request Checklist

- [x] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [x] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [x] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [x] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
