### PR TITLE
fix: Redirect instead of raise when state token mismatches

### DIFF
--- a/test/controllers/payment/connection/bitflyer_connections_controller_test.rb
+++ b/test/controllers/payment/connection/bitflyer_connections_controller_test.rb
@@ -26,8 +26,21 @@ class BitflyerConnectionsControllerTest < ActionDispatch::IntegrationTest
     describe "when invalid state" do
       let(:cookie) { "another value" }
 
-      it "should raise an error" do
-        assert_raises(ActionController::BadRequest) { get path, params: {code: "value", state: state} }
+      before do
+        I18n.locale = :ja
+        get path, params: {code: "value", state: state}
+      end
+
+      after do
+        I18n.locale = :en
+      end
+
+      it "should redirect" do
+        assert_equal(response.status, 302)
+      end
+
+      it "should redirect with a generic message" do
+        assert_equal(I18n.t("shared.error"), flash.alert)
       end
 
       it "should not create a connection" do

--- a/test/controllers/payment/connection/uphold_connections_controller_test.rb
+++ b/test/controllers/payment/connection/uphold_connections_controller_test.rb
@@ -24,8 +24,16 @@ class UpholdConnectionsControllerTest < ActionDispatch::IntegrationTest
     describe "when invalid state" do
       let(:cookie) { "another value" }
 
-      it "should raise an error" do
-        assert_raises(ActionController::BadRequest) { get "/publishers/uphold_verified", params: {code: "value", state: state} }
+      before do
+        get "/publishers/uphold_verified", params: {code: "value", state: state}
+      end
+
+      it "should redirect" do
+        assert_equal(response.status, 302)
+      end
+
+      it "should redirect with a generic message" do
+        assert_equal(I18n.t("shared.error"), flash.alert)
       end
 
       it "should not create a connection" do


### PR DESCRIPTION
If the state token has expired just redirect and give a generic flash message and log it.