### PR TITLE
feat: Uphold.users.get_capability

### DIFF
--- a/lib/uphold/types.rb
+++ b/lib/uphold/types.rb
@@ -1,5 +1,14 @@
 module Uphold
   module Types
+    class UpholdUserCapability < T::Struct
+      const :category, String
+      const :enabled, T::Boolean
+      const :key, String
+      const :name, String
+      const :requirements, T::Array[T.nilable(String)]
+      const :restrictions, T::Array[T.nilable(String)]
+    end
+
     class UpholdUser < T::Struct
       const :status, String
       const :memberAt, T.nilable(String)

--- a/lib/uphold/users.rb
+++ b/lib/uphold/users.rb
@@ -21,5 +21,19 @@ module Uphold
         T.absurd(result)
       end
     end
+
+    sig { params(capability: String).returns(T.any(UpholdUserCapability, Faraday::Response)) }
+    def get_capability(capability)
+      result = request_and_return(:get, "/v0/me/capabilities/#{capability}", UpholdUserCapability)
+
+      case result
+      when UpholdUserCapability, Faraday::Response
+        result
+      when Array, T::Struct
+        raise ResultError
+      else
+        T.absurd(result)
+      end
+    end
   end
 end

--- a/test/lib/uphold/users_test.rb
+++ b/test/lib/uphold/users_test.rb
@@ -26,4 +26,16 @@ class UpholdUsersClientTest < ActiveSupport::TestCase
       assert_instance_of(UpholdUser, inst.get)
     end
   end
+
+  describe "#get_capabilities" do
+    let(:capability) { "deposits" }
+
+    before do
+      stub_get_user_capability(capability: capability)
+    end
+
+    it "should return an UpholdUserCapability" do
+      assert_instance_of(UpholdUserCapability, inst.get_capability(capability))
+    end
+  end
 end

--- a/test/test_helpers/mock_uphold_responses.rb
+++ b/test/test_helpers/mock_uphold_responses.rb
@@ -211,6 +211,19 @@ module MockUpholdResponses
     stub_request(:get, /v0\/me/).to_return(body: body.to_json)
   end
 
+  def stub_get_user_capability(capability: "deposits", http_status: 200)
+    body = {
+      category: "permissions",
+      enabled: false,
+      key: capability,
+      name: capability.capitalize,
+      requirements: ["user-must-submit-due-dilligence"],
+      restrictions: []
+    }
+
+    stub_request(:get, "#{Oauth2::Config::Uphold.base_token_url}/v0/me/capabilities/#{capability}").to_return(status: http_status, body: body.to_json)
+  end
+
   def stub_list_card_addresses(id: "024e51fc-5513-4d82-882c-9b22024280cc", type: UpholdConnectionForChannel::NETWORK, empty: false, http_status: 200)
     body = [{
       formats: [{


### PR DESCRIPTION
Adds basic client support.  I have no real ability to test this ATM because of some temporary account limitations with uphold sandbox.