### PR TITLE
PublisherController should confirm pending emails (test)

### DIFF
--- a/test/controllers/publishers_controller_test.rb
+++ b/test/controllers/publishers_controller_test.rb
@@ -33,24 +33,22 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
   }.freeze
 
   describe "whatever the publishers/:id/ensure_email route does" do
-    let(:token) { nil }
+    let(:token) { "token" }
 
-    describe "when !token" do
-      it "should redirect" do
-        publisher = publishers(:completed)
-        sign_in publisher
-        get "/publishers/#{publisher.id}/ensure_email", params: {token: token}
+    it "should invoke confirm_pending_email!" do
+      PublisherTokenAuthenticator.any_instance.stubs(:perform).returns(true)
+      publisher = publishers(:completed)
 
-        assert_response 302
-      end
+      expect(publisher).to receive(:confirm_pending_email!)
+
+      sign_in publisher
+
+      get "/publishers/#{publisher.id}/ensure_email", params: {token: token}
+
+      assert_response 200
     end
 
     describe "when token" do
-      let(:token) { "token" }
-
-      before do
-      end
-
       it "should redirect" do
         PublisherTokenAuthenticator.any_instance.stubs(:perform).returns(true)
         publisher = publishers(:completed)
@@ -59,6 +57,18 @@ class PublishersControllerTest < ActionDispatch::IntegrationTest
         get "/publishers/#{publisher.id}/ensure_email", params: {token: token}
 
         assert_response 200
+      end
+    end
+
+    describe "when !token" do
+      let(:token) { nil }
+
+      it "should redirect" do
+        publisher = publishers(:completed)
+        sign_in publisher
+        get "/publishers/#{publisher.id}/ensure_email", params: {token: token}
+
+        assert_response 302
       end
     end
   end


### PR DESCRIPTION
#### Features

Fix a new issue introduced by #3765 .
The newly enrolled users are now not confirmed on the `ensure_email` endpoint.
They should do that to respect the old implementation (or shouldn't they?).

#### Pull Request Checklist

- [x] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
