### PR TITLE
Production Release: Bug fix 6/27/22

### DIFF
--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -67,6 +67,10 @@ class Oauth2Controller < ApplicationController
             generic_error
           end
         end
+      when Oauth2::Responses::ErrorResponse
+        # Evidently log_exception needs an actual exception
+        record_error(Oauth2::Errors::ConnectionError.new("Oauth2 Grant Failed with #{resp}"))
+        error = generic_error
       else
         record_error(resp)
         error = generic_error


### PR DESCRIPTION
Handles a case where uphold wallet creation returns an invalid grant (somehow) and returns a t struct rather than error.