### PR TITLE
fix: Set default to true

### DIFF
--- a/app/jobs/oauth2_batch_refresh_job.rb
+++ b/app/jobs/oauth2_batch_refresh_job.rb
@@ -3,7 +3,7 @@ class Oauth2BatchRefreshJob < ApplicationJob
 
   # https://docs.gemini.com/rest-api/#rate-limits
   # 0.1 requests/second
-  def perform(wait: 0.1, limit: 5000, notify: false, async: false)
+  def perform(wait: 0.1, limit: 5000, notify: false, async: true)
     klass = set_klass
 
     count = 0

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -80,6 +80,14 @@
     cron: "0 0 12 * *"
     description: "Sets a flag in redis which tells the app to display 'payout in progress' at the beginning of the month."
     queue: scheduler
+  BitflyerRefreshJob:
+    cron: "0 4 * * *"
+    description: "Refresh n expired wallet connections per interval at a rate of r requests/min"
+    queue: scheduler
+  UpholdRefreshJob:
+    cron: "0 0 * * *"
+    description: "Refresh n expired wallet connections per interval at a rate of r requests/min"
+    queue: scheduler
   GeminiRefreshJob:
     cron: "0 2 * * *"
     description: "Refresh n expired wallet connections per interval at a rate of r requests/min"


### PR DESCRIPTION
Default should be async otherwise we end up blocking for a long time on our refresh tasks.