### PR TITLE
fix: Fix 500 error for invalid csp reports

### DIFF
--- a/app/controllers/csp_violations_report_controller.rb
+++ b/app/controllers/csp_violations_report_controller.rb
@@ -16,10 +16,10 @@ class CspViolationsReportController < ApplicationController
     #   "status-code"=>0,
     #   "script-sample"=>""}
     # We only care about the document-uri, blocked-uri, and directives for now
-    report = JSON.parse(request.body.read)["csp-report"]
-    sliced_report = report.slice("document-uri", "violated-directive", "effective-directive", "blocked-uri")
     begin
-      CspViolationReport.create(report: sliced_report)
+      report = JSON.parse(request.body.read)["csp-report"]
+      sliced_report = report.slice("document-uri", "violated-directive", "effective-directive", "blocked-uri")
+      CspViolationReport.create!(report: sliced_report)
     rescue
       nil
     end


### PR DESCRIPTION
Patches a JSON parser failure throwing 500s in staging. See newrelic for specific error log.