### PR TITLE
Task/relax restriction on block

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -345,7 +345,12 @@ class Publisher < ApplicationRecord
     uphold_id = uphold_connection&.uphold_id
     return false if !uphold_id
 
-    UpholdConnection.where(uphold_id: uphold_id, publisher_id: Publisher.suspended.select(:id)).count > 0
+    UpholdConnection.where(uphold_id: uphold_id, publisher_id: Publisher.suspended.select(:id)).count > 1
+  end
+
+  def suspend!
+    PublisherStatusUpdate.create!(publisher_id: id, status: PublisherStatusUpdate::SUSPENDED)
+    self
   end
 
   def authorized_to_act?

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -349,11 +349,7 @@ class Publisher < ApplicationRecord
   end
 
   def authorized_to_act?
-    if suspended? || uphold_connection&.blocked? || is_associated_with_suspended_uphold_ids?
-      false
-    else
-      true
-    end
+    !suspended? && !is_associated_with_suspended_uphold_ids?
   end
 
   def verified?

--- a/test/models/publisher_test.rb
+++ b/test/models/publisher_test.rb
@@ -35,16 +35,18 @@ class PublisherTest < ActiveSupport::TestCase
     describe "when publisher has a blocked uphold connection" do
       let(:publisher) { publishers(:uphold_connected_blocked) }
 
-      it "should be false" do
-        refute publisher.authorized_to_act?
+      it "should be true" do
+        assert publisher.authorized_to_act?
       end
     end
 
-    describe "when publisher is using an uphold_id associated with suspended accounts" do
+    describe "when publisher is using an uphold_id associated with >1 suspended accounts" do
       let(:publisher) { publishers(:verified) }
       let(:uphold_id) { "024e51fc-5513-4d82-882c-9b22024280cc" }
 
       before do
+        publishers(:verified).suspend!
+        publishers(:verified).suspend!
         UpholdConnection.update_all(uphold_id: uphold_id)
       end
 


### PR DESCRIPTION
This is mostly based on a request from customer support.  I added some restrictions as part of the uphold refactor that are perhaps too stringent and are causing confusion on the customer support side of things. 