### PR TITLE
fix: Ensure content type header is passed to create card call

### DIFF
--- a/lib/uphold/cards.rb
+++ b/lib/uphold/cards.rb
@@ -59,7 +59,9 @@ module Uphold
     # https://uphold.com/en/developer/api/documentation/#create-card
     sig { params(label: String, currency: String, settings: T::Hash[T.any(String, Symbol), T.untyped]).returns(T.any(UpholdCard, Faraday::Response)) }
     def create(label:, currency:, settings:)
-      result = request_and_return(:post, "/v0/me/cards", UpholdCard, payload: {label: label, currency: currency, settings: settings})
+      headers = {"Content-Type" => "application/json"}
+      result = request_and_return(:post, "/v0/me/cards", UpholdCard, payload: {label: label, currency: currency, settings: settings}, headers: headers)
+
       case result
       when UpholdCard, Faraday::Response
         result


### PR DESCRIPTION
Calls to create card were failing with a seemingly impossible error, the issue was that the content-type was not set for the POST request and the resulting error was a missing param 400.