### PR TITLE
fix: Ensure note is properly set

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -360,12 +360,11 @@ class Publisher < ApplicationRecord
 
       reason = "User has an active uphold connection that has been  previously suspended at least #{MAX_SUSPENSIONS} times."
       note = "Automated suspension: #{Time.now.to_datetime.to_formatted_s(:long)}: #{reason}"
-      publisher_note = PublisherNote.create(note: note)
 
       PublisherNote.create!(
         created_by: self,
         publisher: self,
-        note: publisher_note
+        note: note
       )
     end
 


### PR DESCRIPTION
I must have been sleepy when I wrote the previous implementation, this sets a proper message in admin so indicate suspension rationale.

<img width="1207" alt="Screen Shot 2022-08-16 at 12 31 15 PM" src="https://user-images.githubusercontent.com/8813557/184931813-6bfacf3f-aa68-4328-8431-0e92c4b846a6.png">

