### PR TITLE
fix: Proxies are being phased out as most services are now off of heroku

### DIFF
--- a/app/services/base_api_client.rb
+++ b/app/services/base_api_client.rb
@@ -81,7 +81,8 @@ class BaseApiClient < BaseService
     @connection ||= begin
       require "faraday"
       Faraday.new(url: api_base_uri) do |faraday|
-        faraday.proxy = proxy_url if proxy_url.present?
+        # yolo
+        # faraday.proxy = proxy_url if proxy_url.present?
         faraday.request :retry, max: retry_count, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2
 
         # Log level info: Brief summaries


### PR DESCRIPTION
I believe this should resolve the issue with promo/referrals.  The promo side has been fixed/confirmed in production but we are still getting timeouts in the service, I believe it is because of this.  Will test/evaluate in staging.