### PR TITLE
perf: Hopefully make this job not crash all the things

### DIFF
--- a/app/jobs/sync/promo_registration_stats_job.rb
+++ b/app/jobs/sync/promo_registration_stats_job.rb
@@ -2,6 +2,7 @@
 
 class Sync::PromoRegistrationStatsJob
   include Sidekiq::Worker
+  sidekiq_options queue: :low, retry: false
 
   def perform(promo_registration_ids)
     Promo::RegistrationsStatsFetcher.new(promo_registrations: PromoRegistration.where(id: promo_registration_ids), update_only: true).perform

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -59,6 +59,8 @@ class PromoRegistration < ApplicationRecord
   scope :unattached_only, -> { where(kind: UNATTACHED) }
   scope :channels_only, -> { where(kind: CHANNEL) }
   scope :has_stats, -> { where.not(stats: "[]").where.not("stats = '[]'") }
+  scope :with_valid_referrals, -> { channels_only.joins(:publisher).where(publisher: Publisher.not_suspended) }
+  scope :with_stale_valid_referrals, -> { with_valid_referrals.where("promo_registrations.updated_at < ?", 24.hours.ago) }
 
   before_destroy :delete_from_promo_server
 

--- a/app/services/promo/registrations_stats_fetcher.rb
+++ b/app/services/promo/registrations_stats_fetcher.rb
@@ -92,6 +92,10 @@ class Promo::RegistrationsStatsFetcher < BaseApiClient
     nil
   end
 
+  def retry_count
+    0
+  end
+
   def api_base_uri
     Rails.application.secrets[:api_promo_base_uri]
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -37,7 +37,7 @@
     cron: "0 8 * * *"
     description: "Complete transfer of channels that have exceeded their timeout time without being rejected"
   Sync::ChannelPromoRegistrationsStatsJob:
-    cron: "0 2 * * *"
+    cron: "*/2 * * * *"
     description: "Sync stats for channel owned referral codes with the promo server every morning."
   TwoFactorAuthenticationRemovalJob:
     cron: "0 12 * * *"

--- a/test/jobs/sync/channel_promo_registrations_stats_job.rb
+++ b/test/jobs/sync/channel_promo_registrations_stats_job.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class SyncChannelPromoRegistrationStatsJobTest < ActiveJob::TestCase
+  describe "#perform" do
+    let(:described_class) { Sync::ChannelPromoRegistrationsStatsJob }
+
+    describe "async" do
+      describe "when promos" do
+        let(:promos) { Promos.pluck(:id) }
+
+        it "should return a count" do
+          result = described_class.new.perform(async: false, wait: 0)
+          assert_instance_of(Integer, result)
+          assert result
+        end
+
+        it "should wait" do
+          result = described_class.new.perform(async: false, wait: 0.01)
+          assert_instance_of(Integer, result)
+          assert result
+        end
+
+        it "should async" do
+          result = described_class.new.perform(async: true, wait: 0)
+          assert_instance_of(Integer, result)
+          assert result
+        end
+      end
+    end
+  end
+end

--- a/test/jobs/sync/promo_registrations_stats_job_test.rb
+++ b/test/jobs/sync/promo_registrations_stats_job_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class SyncPromoRegistrationStatsJobTest < ActiveJob::TestCase
+  describe "#perform" do
+    let(:described_class) { Sync::PromoRegistrationStatsJob }
+
+    describe "async" do
+      describe "when false" do
+        let(:promos) { [] }
+        describe "when no promos" do
+          it "should return empty array" do
+            result = described_class.new.perform(PromoRegistration.where(id: promos))
+            assert_instance_of(Array, result)
+            assert_empty result
+          end
+        end
+
+        describe "when promos" do
+          it "should return empty array" do
+            result = described_class.new.perform(PromoRegistration.pluck(:id))
+            assert_instance_of(Array, result)
+            refute_empty result
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refactors the existing jobs to be generally more performant, trying to process fewer at a higher frequency.  This allows me to test out the full batch job in safety and also get a sense of how well promos handles consistent low volume requests.