### PR TITLE
Production Release: Scope to only users in referral program (#3847)

### DIFF
--- a/app/jobs/sync/channel_promo_registrations_stats_job.rb
+++ b/app/jobs/sync/channel_promo_registrations_stats_job.rb
@@ -13,7 +13,7 @@ class Sync::ChannelPromoRegistrationsStatsJob < ApplicationJob
     # If we run this on Every 2 minutes we can refresh all existing referrals every 24 hours continuously.
     #
     # It also allows me to test this without swamping the entire sidekiq queue
-    PromoRegistration.with_stale_valid_referrals.limit(limit).select(:id).find_in_batches(batch_size: 50) do |batch|
+    PromoRegistration.from_referrer_program.where("promo_registrations.updated_at < ?", 24.hours.ago).select(:id).find_in_batches(batch_size: 50) do |batch|
       ids = batch.map(&:id)
       count += ids.length
 

--- a/app/models/promo_registration.rb
+++ b/app/models/promo_registration.rb
@@ -59,8 +59,7 @@ class PromoRegistration < ApplicationRecord
   scope :unattached_only, -> { where(kind: UNATTACHED) }
   scope :channels_only, -> { where(kind: CHANNEL) }
   scope :has_stats, -> { where.not(stats: "[]").where.not("stats = '[]'") }
-  scope :with_valid_referrals, -> { channels_only.joins(:publisher).where(publisher: Publisher.not_suspended) }
-  scope :with_stale_valid_referrals, -> { with_valid_referrals.where("promo_registrations.updated_at < ?", 24.hours.ago) }
+  scope :from_referrer_program, -> { channels_only.joins(:publisher).where(publisher: Publisher.in_top_referrer_program) }
 
   before_destroy :delete_from_promo_server
 


### PR DESCRIPTION
I tested the previous merge in prod and it worked as expected, but evidently like it was still doing 99% more than it needed to.  This should strongly cut down on any scheduled burden coming from this side of things.