### PR TITLE
task: Ignore known failure states for uphold connections

### DIFF
--- a/app/models/uphold_connection.rb
+++ b/app/models/uphold_connection.rb
@@ -6,6 +6,8 @@ class UpholdConnection < Oauth2::AuthorizationCodeBase
   # a connection.
   class_attribute :strict_create, default: true
 
+  class UnknownWalletCreationError < Oauth2::Errors::ConnectionError; end
+
   class WalletCreationError < Oauth2::Errors::ConnectionError; end
 
   class UnverifiedConnectionError < WalletCreationError; end
@@ -409,7 +411,7 @@ class UpholdConnection < Oauth2::AuthorizationCodeBase
       result
     else
       LogException.perform("Uphold wallet creation failed for publisher #{publisher_id} with #{result}")
-      raise WalletCreationError.new("Could not configure #{default_currency} deposits for Uphold")
+      raise UnknownWalletCreationError.new("Could not configure #{default_currency} deposits for Uphold")
     end
   end
 

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -25,6 +25,8 @@ common: &default_settings
   log_level: info
 
   attributes.include: job.sidekiq.args.*
+  error_collector:
+    - 'UpholdConnection::WalletCreationError'
 
   # Don't log sensitive things to New Relic
 #  high_security: true

--- a/test/models/uphold_connection_test.rb
+++ b/test/models/uphold_connection_test.rb
@@ -138,7 +138,7 @@ class UpholdConnectionTest < ActiveSupport::TestCase
               end
 
               it "it should raise an error" do
-                assert_raises(UpholdConnection::WalletCreationError) { UpholdConnection.create_new_connection!(publisher, access_token_response) }
+                assert_raises(UpholdConnection::UnknownWalletCreationError) { UpholdConnection.create_new_connection!(publisher, access_token_response) }
               end
             end
 


### PR DESCRIPTION
I think this should do it for the majority of errors we see in newrelic.  They were not excluded originally because it was important to have visibility into them while I rewrote the entire set of oauth integrations.