### PR TITLE
fix: This is why we shouldn't write services this way

### DIFF
--- a/app/services/promo/unattached_registrar.rb
+++ b/app/services/promo/unattached_registrar.rb
@@ -49,6 +49,10 @@ class Promo::UnattachedRegistrar < BaseApiClient
 
   private
 
+  def proxy_url
+    nil
+  end
+
   def api_base_uri
     Rails.application.secrets[:api_promo_base_uri]
   end


### PR DESCRIPTION
Who knows how many instances of this are present in creators.  Http clients should be clients that handle the entirety of their configuration, services should implement clients, models, and other services and mediate their interactions.