### PR TITLE
add catch for blank gemini recipient_id

### DIFF
--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -66,10 +66,10 @@ class Cache::BrowserChannels::ResponsesForPrefix
 
           if !Rails.env.production?
             if connection.country && allowed_regions[:bitflyer][:allow].include?(connection.country.upcase)
-              bitflyer_wallet.address = site_banner_lookup.channel.deposit_id
+              bitflyer_wallet.address = site_banner_lookup.channel.deposit_id || ""
             end
           else
-            gemini_wallet.address = site_banner_lookup.channel.gemini_connection&.recipient_id || connection.recipient_id
+            bitflyer_wallet.address = site_banner_lookup.channel.deposit_id || ""
           end
 
           wallet.bitflyer_wallet = bitflyer_wallet
@@ -83,10 +83,10 @@ class Cache::BrowserChannels::ResponsesForPrefix
 
           if !Rails.env.production?
             if connection.country && allowed_regions[:gemini][:allow].include?(connection.country.upcase)
-              gemini_wallet.address = site_banner_lookup.channel.gemini_connection&.recipient_id || connection.recipient_id
+              gemini_wallet.address = site_banner_lookup.channel.gemini_connection&.recipient_id || connection.recipient_id || ""
             end
           else
-            gemini_wallet.address = site_banner_lookup.channel.gemini_connection&.recipient_id || connection.recipient_id
+            gemini_wallet.address = site_banner_lookup.channel.gemini_connection&.recipient_id || connection.recipient_id || ""
           end
 
           wallet.gemini_wallet = gemini_wallet


### PR DESCRIPTION
When the recipient_id is blank, errors are sent to newrelic because nil is not the correct type for address, it needs to be a string.  Similar to how we handle blank uphold addresses, missing recipient_ids for gemini wallets will be set to empty strings.
