### PR TITLE
Replace references to sentry with LogException

### DIFF
--- a/app/controllers/admin/payout_reports_controller.rb
+++ b/app/controllers/admin/payout_reports_controller.rb
@@ -80,8 +80,8 @@ class Admin::PayoutReportsController < AdminController
   rescue Faraday::ClientError
     redirect_to admin_payout_reports_path, flash: {alert: "Eyeshade responded with a 400 🤷‍️"}
   rescue => e
-    Raven.capture_exception(e)
-    redirect_to admin_payout_reports_path, flash: {alert: "Something bad happened! Please check Sentry for more details"}
+    LogException.perform(e)
+    redirect_to admin_payout_reports_path, flash: {alert: "Something bad happened! Please check New Relic for more details"}
   end
 
   def payouts_in_progress

--- a/app/controllers/api/v3/public/channels_controller.rb
+++ b/app/controllers/api/v3/public/channels_controller.rb
@@ -1,7 +1,5 @@
 # typed: ignore
 
-require "sentry-raven"
-
 class Api::V3::Public::ChannelsController < Api::V3::Public::BaseController
   include BrowserChannelsDynoCaching
   @@cached_payload = nil

--- a/app/controllers/api/v3_p1/public/channels_controller.rb
+++ b/app/controllers/api/v3_p1/public/channels_controller.rb
@@ -1,7 +1,5 @@
 # typed: true
 
-require "sentry-raven"
-
 class Api::V3P1::Public::ChannelsController < Api::V3::Public::BaseController
   include BrowserChannelsDynoCaching
   @@cached_payload = nil

--- a/app/controllers/concerns/browser_channels_dyno_caching.rb
+++ b/app/controllers/concerns/browser_channels_dyno_caching.rb
@@ -2,7 +2,6 @@
 
 module BrowserChannelsDynoCaching
   extend ActiveSupport::Concern
-  require "sentry-raven"
 
   PAGE_PREFIX = "_page_".freeze
 
@@ -60,7 +59,7 @@ module BrowserChannelsDynoCaching
 
   def update_dyno_cache
     redis_value = Rails.cache.fetch(self.class::REDIS_KEY, race_condition_ttl: 30) do
-      Raven.capture_message("Failed to use redis cache for Dyno cache: #{klass_dyno_cache}, continuing to read from cache instead")
+      LogException.perform("Failed to use redis cache for Dyno cache: #{klass_dyno_cache}, continuing to read from cache instead")
     end
     if redis_value.present?
       self.class.class_variable_set(klass_dyno_cache, redis_value)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,15 +1,14 @@
 # typed: true
 
 class ApplicationJob < ActiveJob::Base
-  # Send handled exceptions to Sentry (which normally only sends unhandled exceptions).
+  # Send handled exceptions to Sentry and New Relic (which normally only sends unhandled exceptions).
   require "error_handler_delegator"
   def self.new(*args, &block)
     ErrorHandlerDelegator.new(super)
   end
 
   rescue_from(ActiveRecord::RecordNotFound) do |exception|
-    require "sentry-raven"
-    Raven.capture_exception(exception)
+    LogException.perform(exception)
   end
 
   def self.instance

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -36,12 +36,11 @@ class PartnerMailer < ApplicationMailer
   private
 
   def ensure_fresh_token
-    # Check if we are missing the token and capture to sentry if we are. This should not happen.
+    # Check if we are missing the token and capture to New Relic if we are. This should not happen.
     begin
       raise "missing token" if @publisher.authentication_token.nil?
     rescue => e
-      require "sentry-raven"
-      Raven.capture_exception(e)
+      LogException.perform(e)
       raise
     end
 

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -88,8 +88,7 @@ class PublisherMailer < ApplicationMailer
       begin
         raise "SMTP To address must not be blank for PublisherMailer#verify_email for publisher #{@publisher.id}"
       rescue => e
-        require "sentry-raven"
-        Raven.capture_exception(e)
+        LogException.perform(e)
       end
     end
   end
@@ -339,8 +338,7 @@ class PublisherMailer < ApplicationMailer
       begin
         raise "#{@publisher.id}'s wallet is connected."
       rescue => e
-        require "sentry-raven"
-        Raven.capture_exception(e)
+        LogException.perform(e)
       end
     else
       mail_if_destination_exists(
@@ -407,12 +405,11 @@ class PublisherMailer < ApplicationMailer
   end
 
   def ensure_fresh_token
-    # Check if we are missing the token and capture to sentry if we are. This should not happen.
+    # Check if we are missing the token and capture to New Relic if we are. This should not happen.
     begin
       raise "missing token" if @publisher.authentication_token.nil?
     rescue => e
-      require "sentry-raven"
-      Raven.capture_exception(e)
+      LogException.perform(e)
       raise
     end
 

--- a/app/services/paypal/refresh_identity.rb
+++ b/app/services/paypal/refresh_identity.rb
@@ -12,7 +12,7 @@ class Paypal::RefreshIdentity < BaseService
       access_token = fetch_access_token
       raise_token_exception! if access_token.nil?
     rescue => e
-      Raven.capture_exception(e)
+      LogException.perform(e)
     end
 
     user_info_response = Faraday.get("#{Rails.application.secrets[:paypal_api_uri]}/v1/identity/oauth2/userinfo") do |req|

--- a/app/services/promo/assign_promo_to_channel_service.rb
+++ b/app/services/promo/assign_promo_to_channel_service.rb
@@ -40,10 +40,8 @@ class Promo::AssignPromoToChannelService < BaseApiClient
         end
       end
     rescue ActiveRecord::RecordInvalid => e
-      require "sentry-raven"
       Rails.logger.error("#{self.class.name} perform: #{referral_code} channel_id: #{channel.id} exception: #{e}")
-      Raven.extra_context referral_code: referral_code
-      Raven.capture_exception("Promo::PublisherChannelsRegistrar #perform error: #{e}")
+      LogException.perform("Promo::PublisherChannelsRegistrar #perform referral_code: #{referral_code}, error: #{e}")
     end
   rescue Faraday::Error::ClientError
     # When the owner is "no-ugp" the promo server will return 409.
@@ -68,9 +66,8 @@ class Promo::AssignPromoToChannelService < BaseApiClient
       change_ownership(channel)
     end
   rescue Faraday::Error => e
-    require "sentry-raven"
     Rails.logger.error("Promo::PublisherChannelsRegistrar #register_channel error: #{e}")
-    Raven.capture_exception("Promo::PublisherChannelsRegistrar #register_channel error: #{e}")
+    LogException.perform("Promo::PublisherChannelsRegistrar #register_channel error: #{e}")
     nil
   end
 

--- a/app/services/publisher_balance_getter.rb
+++ b/app/services/publisher_balance_getter.rb
@@ -26,8 +26,7 @@ class PublisherBalanceGetter < BaseApiClient
     Rails.logger.info("Error receiving eyeshade balance #{e.message}")
     :unavailable
   rescue => e
-    require "sentry-raven"
-    Raven.capture_exception(e)
+    LogException.perform(e)
     :unavailable
   end
 

--- a/app/services/youtube_channel_getter.rb
+++ b/app/services/youtube_channel_getter.rb
@@ -1,7 +1,5 @@
 # typed: true
 
-require "sentry-raven"
-
 class YoutubeChannelGetter < BaseApiClient
   attr_reader :token, :channel_id
 
@@ -25,7 +23,7 @@ class YoutubeChannelGetter < BaseApiClient
     end
   rescue Faraday::Error => e
     Rails.logger.warn("YoutubeChannelGetter #perform error: #{e}")
-    Raven.capture_exception(e)
+    LogException.perform(e)
     new_exception = case e.response[:status]
     when 403
       ChannelForbiddenError.new(e.response[:body])
@@ -34,7 +32,7 @@ class YoutubeChannelGetter < BaseApiClient
     else
       ChannelBadRequestError.new(e.response[:body])
     end
-    Raven.capture_exception(new_exception)
+    LogException.perform(new_exception)
     raise new_exception
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,5 @@
 # typed: ignore
-require "sentry-raven"
+require "newrelic_rpm"
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
@@ -82,7 +82,7 @@ Rails.application.configure do
     write_timeout: 10, # Defaults to 1 second
     error_handler: ->(method:, returning:, exception:) {
                      # Report errors to Sentry as warnings
-                     Raven.capture_exception(exception, level: "warning",
+                     NewRelic::Agent.notice_error(exception, level: "warning",
                                                           tags: {method: method, returning: returning})
                    }
   }

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,5 +1,5 @@
 # typed: ignore
-require "sentry-raven"
+require "newrelic_rpm"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -71,7 +71,7 @@ Rails.application.configure do
 
     error_handler: ->(method:, returning:, exception:) {
                      # Report errors to Sentry as warnings
-                     Raven.capture_exception exception, level: "warning",
+                     NewRelic::Agent.notice_error exception, level: "warning",
                                                         tags: {method: method, returning: returning}
                    }
   }

--- a/lib/error_handler_delegator.rb
+++ b/lib/error_handler_delegator.rb
@@ -1,6 +1,6 @@
 # typed: true
 
-# # Send handled exceptions to Sentry (which normally only sends unhandled exceptions).
+# # Send handled exceptions to New Relic (which normally only sends unhandled exceptions).
 # See https://stackoverflow.com/questions/16567243/rescue-all-errors-of-a-specific-type-inside-a-module
 class ErrorHandlerDelegator
   require "error_handler"

--- a/sorbet/rails-rbi/mailers/partner_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/partner_mailer.rbi
@@ -173,7 +173,7 @@ class PartnerMailer
   def self.select_year(date, options = {}, html_options = {}); end
 
   sig { returns(ActionMailer::MessageDelivery) }
-  def self.sentry_catcher; end
+  def self.error_catcher; end
 
   sig { params(channel: T.untyped).returns(ActionMailer::MessageDelivery) }
   def self.should_display_verification_token?(channel); end

--- a/sorbet/rails-rbi/mailers/publisher_mailer.rbi
+++ b/sorbet/rails-rbi/mailers/publisher_mailer.rbi
@@ -224,7 +224,7 @@ class PublisherMailer
   def self.select_year(date, options = {}, html_options = {}); end
 
   sig { returns(ActionMailer::MessageDelivery) }
-  def self.sentry_catcher; end
+  def self.error_catcher; end
 
   sig { params(channel: T.untyped).returns(ActionMailer::MessageDelivery) }
   def self.should_display_verification_token?(channel); end


### PR DESCRIPTION
Replaces sentry error logging with LogException, which logs to both sentry and new relic.  Sentry can be explicitly removed in another ticket.
