### PR TITLE
.reviewdog: use commit as a source of truth for file selection

### DIFF
--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -13,8 +13,9 @@ runner:
         -c p/secrets \
         $(find semgrep_rules -name '*.yml' | sed 's/^/-c /g') \
         --metrics=off \
-        --json $(git --no-pager diff --name-only HEAD $(git merge-base HEAD origin/${GITHUB_BASE_REF:-staging}) | xargs ls -d 2>/dev/null) \
-        | jq -r '.results[] | "\(.extra.severity[0:1]):\(.path):\(.end.line) \(.extra.message)"' \
+        --baseline-commit origin/${GITHUB_BASE_REF:-staging} \
+        --json \
+        jq -r '.results[] | "\(.extra.severity[0:1]):\(.path):\(.end.line) \(.extra.message)"' \
         | sed 's/$/ (Cc @brave\/sec-team @thypon)/g' | tee semgrep.log &&\
         find semgrep.log -type f -empty -delete
     errorformat:


### PR DESCRIPTION
## .reviewdog: use commit as a source of truth for file selection

#### Features

Fix an issue with `semgrepignore` being ignored

#### Pull Request Checklist

- [x] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [x] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [x] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [x] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [x] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [x] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
