### PR TITLE
Don't include Potential Payments from wallets in unallowed countries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,8 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.8)
+    nokogiri (1.13.9-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.10)
@@ -778,4 +780,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.3.24
+   2.3.18

--- a/app/services/enqueue_publishers_for_payout_service.rb
+++ b/app/services/enqueue_publishers_for_payout_service.rb
@@ -1,10 +1,10 @@
 class EnqueuePublishersForPayoutService
   def call(payout_report,
-           final: true,
-           manual: false,
-           publisher_ids: [],
-           allowed_regions: Rewards::Parameters.new.fetch_allowed_regions,
-           args: [])
+    final: true,
+    manual: false,
+    publisher_ids: [],
+    allowed_regions: Rewards::Parameters.new.fetch_allowed_regions,
+    args: [])
     unless payout_report.is_a?(PayoutReport)
       # Wondering if sorbet can just do stuff like this?
       raise ArgumentError.new("Invalid argument type. Must be PayoutReport")
@@ -33,8 +33,7 @@ class EnqueuePublishersForPayoutService
       base_publishers.where(id: @publisher_ids)
     else
       base_publishers.with_verified_channel.not_in_top_referrer_program
-                          end
-
+    end
 
     # DEAL WITH MANUAL CASE AND SET UP EACH WALLETS VARS
     wallet_providers_to_insert = if @manual
@@ -57,7 +56,7 @@ class EnqueuePublishersForPayoutService
         {
           service: Payout::BitflyerService.build,
           initial_publishers: filtered_publishers
-            .valid_payable_bitflyer_creators,
+            .valid_payable_bitflyer_creators
         }
       ]
     end

--- a/app/services/payout/bitflyer_service.rb
+++ b/app/services/payout/bitflyer_service.rb
@@ -11,7 +11,7 @@ module Payout
     end
 
     # Change to call as soon as we refactor the other services
-    def perform(publisher:, payout_report:)
+    def perform(publisher:, payout_report:, allowed_regions: [])
       return [] if skip_publisher?(payout_report: payout_report, publisher: publisher)
 
       potential_payments = []

--- a/app/services/payout/gemini_service.rb
+++ b/app/services/payout/gemini_service.rb
@@ -2,11 +2,10 @@
 
 module Payout
   class GeminiService < Service
-    def perform(payout_report:, publisher:)
-      return [] if skip_publisher?(payout_report: payout_report, publisher: publisher)
-
+    def perform(payout_report:, publisher:, allowed_regions: [])
       potential_payments = []
       connection = publisher.gemini_connection
+      return [] if skip_publisher?(payout_report: payout_report, publisher: publisher, allowed_regions: allowed_regions, connection: connection)
 
       if publisher.may_create_referrals?
         potential_payments << PotentialPayment.new(

--- a/app/services/payout/service.rb
+++ b/app/services/payout/service.rb
@@ -15,7 +15,14 @@ module Payout
     # Internal: Creates entries for any reason for not paying out a publisher.
     #
     # Returns a boolean
-    def skip_publisher?(payout_report:, publisher:)
+    def skip_publisher?(payout_report:, publisher:, allowed_regions: [], connection: nil)
+      if !allowed_regions.blank? && connection.present?
+        if !allowed_regions.include?(connection.country&.upcase)
+          create_message(message: "Publisher's wallet connection is in an unallowed country: #{connection.country&.upcase}. Allowlist: #{allowed_regions}", payout_report: payout_report, publisher: publisher)
+          return true
+        end
+      end
+
       if !publisher.has_verified_channel?
         create_message(message: "Publisher has no verified channels", payout_report: payout_report, publisher: publisher)
         return true

--- a/app/services/payout/uphold_service.rb
+++ b/app/services/payout/uphold_service.rb
@@ -2,11 +2,10 @@
 
 module Payout
   class UpholdService < Service
-    def perform(payout_report:, publisher:)
-      return [] if skip_publisher?(payout_report: payout_report, publisher: publisher)
-
+    def perform(payout_report:, publisher:, allowed_regions: [])
       potential_payments = []
       uphold_connection = publisher.uphold_connection
+      return [] if skip_publisher?(payout_report: payout_report, publisher: publisher, allowed_regions: allowed_regions, connection: uphold_connection)
 
       # Create the referral payment for the owner
       if publisher.may_create_referrals?

--- a/test/controllers/admin/payout_reports_controller_test.rb
+++ b/test/controllers/admin/payout_reports_controller_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 require "webmock/minitest"
 
 class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
+  include MockRewardsResponses
+
   self.use_transactional_tests = false
 
   include Devise::Test::IntegrationHelpers
@@ -20,6 +22,8 @@ class PayoutReportsControllerTest < ActionDispatch::IntegrationTest
     stub_request(:get, /cards/).to_return(body: [id: "fb25048b-79df-4e64-9c4e-def07c8f5c04"].to_json)
     stub_request(:post, /cards/).to_return(body: {id: "fb25048b-79df-4e64-9c4e-def07c8f5c04"}.to_json)
     stub_request(:get, /address/).to_return(body: [{formats: [{format: "uuid", value: "e306ec64-461b-4723-bf75-015ffc99ebe1"}], type: "anonymous"}].to_json)
+
+    stub_rewards_parameters
 
     Rails.cache.clear
   end

--- a/test/fixtures/uphold_connections.yml
+++ b/test/fixtures/uphold_connections.yml
@@ -37,6 +37,7 @@ suspended_connection:
 
 youtube_initial_connection:
   publisher: youtube_initial
+  country: 'US'
   uphold_verified: true
   encrypted_uphold_access_parameters: "<%= TotpRegistration.encrypt_secret(
     '{}',

--- a/test/jobs/enqueue_publishers_for_payout_job_test.rb
+++ b/test/jobs/enqueue_publishers_for_payout_job_test.rb
@@ -17,7 +17,7 @@ class EnqueuePublishersForPayoutJobTest < NoTransactDBBleanupTest
     Payout::GeminiService.any_instance.expects(:perform).at_least_once.returns([])
     Payout::BitflyerService.any_instance.expects(:perform).at_least_once.returns([])
     EnqueuePublishersForPayoutJob.new.perform(
-      final: false,
+      final: false
     )
     assert_equal prc + 1, PayoutReport.count
   end

--- a/test/jobs/enqueue_publishers_for_payout_job_test.rb
+++ b/test/jobs/enqueue_publishers_for_payout_job_test.rb
@@ -3,7 +3,13 @@
 require "test_helper"
 
 class EnqueuePublishersForPayoutJobTest < NoTransactDBBleanupTest
+  include MockRewardsResponses
+
   self.use_transactional_tests = false
+
+  before do
+    stub_rewards_parameters
+  end
 
   test "launches a job per payout type (strategy: :deletion)" do
     prc = PayoutReport.count
@@ -11,7 +17,7 @@ class EnqueuePublishersForPayoutJobTest < NoTransactDBBleanupTest
     Payout::GeminiService.any_instance.expects(:perform).at_least_once.returns([])
     Payout::BitflyerService.any_instance.expects(:perform).at_least_once.returns([])
     EnqueuePublishersForPayoutJob.new.perform(
-      final: false
+      final: false,
     )
     assert_equal prc + 1, PayoutReport.count
   end

--- a/test/jobs/payout/enqueue_top_referrer_payout_job_test.rb
+++ b/test/jobs/payout/enqueue_top_referrer_payout_job_test.rb
@@ -4,7 +4,13 @@ require "test_helper"
 require "jobs/sidekiq_test_case"
 
 class EnqueueTopReferrerPayoutJobTest < NoTransactDBBleanupTest
+  include MockRewardsResponses
+
   self.use_transactional_tests = false
+
+  before do
+    stub_rewards_parameters
+  end
 
   test "it enqueues only top referrers to to call EnqueuePublishersForPayoutJob (strategy: :deletion)" do
     top_publisher_ids = Publisher.with_verified_channel.in_top_referrer_program.pluck(:id)

--- a/test/services/enqueue_publishers_for_payout_service_test.rb
+++ b/test/services/enqueue_publishers_for_payout_service_test.rb
@@ -3,23 +3,30 @@
 require "test_helper"
 
 class EnqueuePublishersForPayoutServiceTest < NoTransactDBBleanupTest
+  include MockRewardsResponses
+
   self.use_transactional_tests = false
+
+  before do
+    stub_rewards_parameters
+  end
 
   test "validates type" do
     assert_raises(ArgumentError) {
       EnqueuePublishersForPayoutService.new.call(
         "string",
-        final: false
+        final: false,
       )
     }
   end
 
   test "status is set" do
     payout_report = payout_reports(:one)
-    assert EnqueuePublishersForPayoutService.new.call(
+    report = EnqueuePublishersForPayoutService.new.call(
       payout_report,
       final: false
-    ).status == "Complete"
+    )
+    assert report.status == "Complete"
   end
 
   test "status is set when enqueing fails" do
@@ -28,7 +35,7 @@ class EnqueuePublishersForPayoutServiceTest < NoTransactDBBleanupTest
 
     assert EnqueuePublishersForPayoutService.new.call(
       payout_report,
-      final: false
+      final: false,
     ).status.start_with?("Error")
   end
 end

--- a/test/services/enqueue_publishers_for_payout_service_test.rb
+++ b/test/services/enqueue_publishers_for_payout_service_test.rb
@@ -15,7 +15,7 @@ class EnqueuePublishersForPayoutServiceTest < NoTransactDBBleanupTest
     assert_raises(ArgumentError) {
       EnqueuePublishersForPayoutService.new.call(
         "string",
-        final: false,
+        final: false
       )
     }
   end
@@ -35,7 +35,7 @@ class EnqueuePublishersForPayoutServiceTest < NoTransactDBBleanupTest
 
     assert EnqueuePublishersForPayoutService.new.call(
       payout_report,
-      final: false,
+      final: false
     ).status.start_with?("Error")
   end
 end

--- a/test/services/payout/uphold_service_test.rb
+++ b/test/services/payout/uphold_service_test.rb
@@ -212,14 +212,14 @@ class UpholdServiceTest < ActiveJob::TestCase
       let(:publisher) { publishers(:youtube_initial) }
       it "does generate a potential payment" do
         payout_message_count = PayoutMessage.count
-        result = Payout::UpholdService.new.perform(payout_report: PayoutReport.last, publisher: publisher, allowed_regions: ['US'])
+        result = Payout::UpholdService.new.perform(payout_report: PayoutReport.last, publisher: publisher, allowed_regions: ["US"])
         assert result[0].publisher_id == publisher.id
         assert PayoutMessage.count == payout_message_count
       end
 
       it "does not generate a potential payment" do
         payout_message_count = PayoutMessage.count
-        result = Payout::UpholdService.new.perform(payout_report: PayoutReport.last, publisher: publisher, allowed_regions: ['CN'])
+        result = Payout::UpholdService.new.perform(payout_report: PayoutReport.last, publisher: publisher, allowed_regions: ["CN"])
         assert result == []
         assert PayoutMessage.count == payout_message_count + 1
         assert PayoutMessage.last.message =~ /unallowed/


### PR DESCRIPTION
Ensure that Potential Payments don't get generated for wallets in unallowed countries.

Closes https://github.com/brave-intl/creators-private-issues/issues/108