### PR TITLE
Hide statements from non-referrers

### DIFF
--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -181,7 +181,7 @@ class Publisher < ApplicationRecord
     gemini_selected_provider
       .where(gemini_connections: {is_verified: true})
       .where.not(gemini_connections: {recipient_id: nil})
-      .where.not(gemini_connections: {country: GeminiConnection::JAPAN})
+      .where(gemini_connections: {country: "US"})
   }
 
   store_accessor :feature_flags, VALID_FEATURE_FLAGS

--- a/app/views/publishers/home.html.slim
+++ b/app/views/publishers/home.html.slim
@@ -26,7 +26,7 @@ noscript
         .col.mb-4.payouts class="#{@publisher.no_grants? ? 'col-md-7' : '' }"
           = render_async home_balances_publishers_path, container_class: 'balance-panel align-items-center' do
             .spinner-border.center.text-primary role="status"
-        - if !@publisher.bitflyer_locale?(params[:locale])
+        - if @publisher.may_create_referrals?
           .col-md.mb-4
             .dashboard-panel--wrapper
               .dashboard-panel--header#publishers_statements

--- a/test/features/locale_test.rb
+++ b/test/features/locale_test.rb
@@ -16,25 +16,25 @@ class LocaleTest < Capybara::Rails::TestCase
 
   test "login with EN accept language and no locale shows english" do
     visit home_publishers_path
-    assert_content page, "Statements"
+    assert_content page, "Add Channel"
   end
 
   test "login with EN accept language and JA locale shows Japanese" do
     visit home_publishers_path(locale: "ja")
-    assert_content page, "の広告を配信"
+    assert_content page, "チャンネルを追加"
   end
 
   test "login with JA accept language and no locale shows Japanese" do
     Capybara.using_driver("firefoxja") do
       visit home_publishers_path
-      assert_content page, "の広告を配信"
+      assert_content page, "チャンネルを追加"
     end
   end
 
   test "login with JA accept language and EN locale shows Japanese" do
     Capybara.using_driver("firefoxja") do
       visit home_publishers_path(locale: "EN")
-      assert_content page, "の広告を配信"
+      assert_content page, "チャンネルを追加"
     end
   end
 end

--- a/test/features/log_in_test.rb
+++ b/test/features/log_in_test.rb
@@ -136,7 +136,7 @@ class LogInTest < Capybara::Rails::TestCase
     # Simulate U2F device usage, which submits the form on success
     page.execute_script("document.querySelector('input[name=\"webauthn_u2f_response\"]').value = '#{u2f_response}';")
     page.execute_script("document.querySelector('form.js-authenticate-u2f').submit();")
-    assert_content page, "View statements"
+    assert_content page, "+ Add Channel"
   end
 
   test "a user with U2F enabled can choose to use TOTP if they don't have their device" do

--- a/test/features/statements_test.rb
+++ b/test/features/statements_test.rb
@@ -12,8 +12,14 @@ class StatementTest < Capybara::Rails::TestCase
     stub_rewards_parameters
   end
 
+  test "statements only show for referrers" do
+    publisher = publishers(:verified)
+    sign_in publisher
+    refute_content "View statements"
+  end
+
   test "statements page doesnt show uphold message for gemini user" do
-    publisher = publishers(:gemini_completed)
+    publisher = publishers(:top_referrer_gemini)
     sign_in publisher
 
     visit statements_path
@@ -21,7 +27,7 @@ class StatementTest < Capybara::Rails::TestCase
   end
 
   test "statements page shows uphold message for uphold user" do
-    publisher = publishers(:uphold_connected)
+    publisher = publishers(:top_referrer)
     sign_in publisher
 
     visit statements_path


### PR DESCRIPTION
hiding the statements panel from non-referrers, since it is no longer relevant to them.  Also noticed some legacy code in the `valid_payable_gemini_creators` scope that could be updated.