### PR TITLE
fix: allow endpoint to return values when a channel identifier is not…

### DIFF
--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -9,7 +9,9 @@ class Api::V3::ChannelsController < Api::BaseController
 
     response = {}
     channels.each do |channel_obj|
-      publisher = channel_obj[:channel].publisher
+      publisher = channel_obj[:channel]&.publisher
+
+      next response[channel_obj[:channel_identifier]] = false if !publisher
 
       response[channel_obj[:channel_identifier]] = if publisher.uphold_connection.present?
         publisher.uphold_connection.valid_country?

--- a/test/controllers/api/v3/channels_controller_test.rb
+++ b/test/controllers/api/v3/channels_controller_test.rb
@@ -20,4 +20,15 @@ class Api::V3::ChannelsControllerTest < ActionDispatch::IntegrationTest
     assert_equal(200, response.status)
     assert_equal(JSON.parse(response.body), {channel1.details.channel_identifier => true, channel2.details.channel_identifier => false, channel3.details.channel_identifier => true})
   end
+
+  test "/api/v3/channels/allowed_countries returns blank information for channels that are not found" do
+    channel1 = channels(:verified)
+    channel2 = channels(:verified_blocked_country)
+
+    post "/api/v3/channels/allowed_countries", headers: {"HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token"},
+      params: {channel_ids: [channel1.details.channel_identifier, channel2.details.channel_identifier, "twitter#channel:totesNotReal"]}
+
+    assert_equal(200, response.status)
+    assert_equal(JSON.parse(response.body), {channel1.details.channel_identifier => true, channel2.details.channel_identifier => false, "twitter#channel:totesNotReal" => false})
+  end
 end


### PR DESCRIPTION
Addresses https://github.com/brave-intl/creators-private-issues/issues/121