### PR TITLE
Use the selected_wallet_provider for country validation check

### DIFF
--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -12,11 +12,13 @@ class Api::V3::ChannelsController < Api::BaseController
       publisher = channel_obj[:channel].publisher
 
       wallet = publisher.selected_wallet_provider
-      response[channel_obj[:channel_identifier]] = case wallet.class
+      response[channel_obj[:channel_identifier]] = case wallet
       when GeminiConnection, UpholdConnection
         wallet.valid_country?
-      else
+      when BitflyerConnection
         wallet.present?
+      else
+        raise "Unknown wallet connection"
       end
     end
 

--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -11,9 +11,11 @@ class Api::V3::ChannelsController < Api::BaseController
     channels.each do |channel_obj|
       publisher = channel_obj[:channel].publisher
 
-      response[channel_obj[:channel_identifier]] = if publisher.uphold_connection.present?
+      wallet = publisher.selected_wallet_provider
+      response[channel_obj[:channel_identifier]] = case wallet.class
+      when UpholdConnection
         publisher.uphold_connection.valid_country?
-      elsif publisher.gemini_connection.present?
+      when GeminiConnection
         publisher.gemini_connection.valid_country?
       else
         publisher.bitflyer_connection.present?

--- a/app/controllers/api/v3/channels_controller.rb
+++ b/app/controllers/api/v3/channels_controller.rb
@@ -13,12 +13,10 @@ class Api::V3::ChannelsController < Api::BaseController
 
       wallet = publisher.selected_wallet_provider
       response[channel_obj[:channel_identifier]] = case wallet.class
-      when UpholdConnection
-        publisher.uphold_connection.valid_country?
-      when GeminiConnection
-        publisher.gemini_connection.valid_country?
+      when GeminiConnection, UpholdConnection
+        wallet.valid_country?
       else
-        publisher.bitflyer_connection.present?
+        wallet.present?
       end
     end
 


### PR DESCRIPTION
Looks like there may a few accounts with older, non-functional wallets (to be cleaned up) which for a small number made the old logic here invalid.
