### PR TITLE
Add status updater rake task

### DIFF
--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -1,9 +1,7 @@
 # typed: ignore
 
 class Api::V1::PublishersController < Api::BaseController
-  class InvalidNote < StandardError; end
 
-  class InvalidAdmin < StandardError; end
 
   def show
     publisher = Publisher.find(params[:id])
@@ -38,23 +36,11 @@ class Api::V1::PublishersController < Api::BaseController
     status = params[:status]
     note = params[:note]
 
-    # We should not automatically move publishers out of this status.
-    if user.only_user_funds?
-      render(status: 200, json: {publisher_status_updates_id: user.last_status_update.id}) and return
-    end
-
-    raise InvalidNote if note.blank?
-    raise InvalidAdmin if admin.blank?
-
-    if user.last_whitelist_update&.enabled && [PublisherStatusUpdate::NO_GRANTS, PublisherStatusUpdate::SUSPENDED].include?(status)
-      render(status: 403, json: {reason: "Cannot suspend whitelisted publisher"}) and return
-    end
-
-    status_update = PublisherStatusUpdate.create!(publisher: user, status: status)
-    PublisherNote.create!(note: note, publisher: user, created_by: admin)
-
-    # Email users who were put on hold via the API
-    PublisherMailer.email_user_on_hold(@publisher).deliver_later if status == PublisherStatusUpdate::HOLD
+    status_update = PublisherStatusUpdater.new.perform(
+      user: user,
+      admin: admin,
+      status: status,
+      note: note)
 
     render(status: 200, json: {publisher_status_updates_id: status_update.id}) and return
   rescue ActiveRecord::RecordInvalid
@@ -62,28 +48,30 @@ class Api::V1::PublishersController < Api::BaseController
       error: "Status Invalid",
       detail: "Status #{params[:status]} is not valid, please use one of the following: #{PublisherStatusUpdate::ALL_STATUSES.join(", ")}"
     }
-
     render(status: 404, json: error_response) and return
+
+  rescue CannotSuspendWhitelisted
+    render(status: 403, json: {reason: "Cannot suspend whitelisted publisher"}) and return
+
   rescue InvalidNote
     error_response = {
       error: "Note Invalid",
       detail: "Note cannot be null, please provide justification for status update"
     }
-
     render(status: 404, json: error_response) and return
+
   rescue InvalidAdmin
     error_response = {
       error: "Admin Invalid",
       detail: "Admin field cannot be null, please provide e-mail of an admin"
     }
-
     render(status: 404, json: error_response) and return
+
   rescue ActiveRecord::RecordNotFound
     error_response = {
       error: "Not Found",
       detail: "Publisher with id #{params[:publisher_id]} not found"
     }
-
     render(status: 404, json: error_response) and return
   end
 end

--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -1,8 +1,6 @@
 # typed: ignore
 
 class Api::V1::PublishersController < Api::BaseController
-
-
   def show
     publisher = Publisher.find(params[:id])
     current_status_update = publisher.last_status_update
@@ -40,7 +38,8 @@ class Api::V1::PublishersController < Api::BaseController
       user: user,
       admin: admin,
       status: status,
-      note: note)
+      note: note
+    )
 
     render(status: 200, json: {publisher_status_updates_id: status_update.id}) and return
   rescue ActiveRecord::RecordInvalid
@@ -49,24 +48,20 @@ class Api::V1::PublishersController < Api::BaseController
       detail: "Status #{params[:status]} is not valid, please use one of the following: #{PublisherStatusUpdate::ALL_STATUSES.join(", ")}"
     }
     render(status: 404, json: error_response) and return
-
-  rescue CannotSuspendWhitelisted
+  rescue PublisherStatusUpdater::CannotSuspendWhitelisted
     render(status: 403, json: {reason: "Cannot suspend whitelisted publisher"}) and return
-
-  rescue InvalidNote
+  rescue PublisherStatusUpdater::InvalidNote
     error_response = {
       error: "Note Invalid",
       detail: "Note cannot be null, please provide justification for status update"
     }
     render(status: 404, json: error_response) and return
-
-  rescue InvalidAdmin
+  rescue PublisherStatusUpdater::InvalidAdmin
     error_response = {
       error: "Admin Invalid",
       detail: "Admin field cannot be null, please provide e-mail of an admin"
     }
     render(status: 404, json: error_response) and return
-
   rescue ActiveRecord::RecordNotFound
     error_response = {
       error: "Not Found",

--- a/app/services/publisher_status_updater.rb
+++ b/app/services/publisher_status_updater.rb
@@ -1,0 +1,29 @@
+# typed: true
+
+class PublisherStatusUpdater < BaseService
+  class InvalidNote < StandardError; end
+  class InvalidAdmin < StandardError; end
+  class CannotSuspendWhitelisted < StandardError; end
+
+  def perform(user:, admin:, status:, note:)
+    # We should not automatically move publishers out of this status.
+    if user.only_user_funds?
+      return user.last_status_update
+    end
+
+    raise InvalidNote if note.blank?
+    raise InvalidAdmin if admin.blank?
+
+    if user.last_whitelist_update&.enabled && [PublisherStatusUpdate::NO_GRANTS, PublisherStatusUpdate::SUSPENDED].include?(status)
+      raise CannotSuspendWhitelisted
+    end
+
+    status_update = PublisherStatusUpdate.create!(publisher: user, status: status)
+    PublisherNote.create!(note: note, publisher: user, created_by: admin)
+
+    # Email users who were put on hold via the API
+    PublisherMailer.email_user_on_hold(@publisher).deliver_later if status == PublisherStatusUpdate::HOLD
+
+    return status_update
+  end
+end

--- a/app/services/publisher_status_updater.rb
+++ b/app/services/publisher_status_updater.rb
@@ -2,7 +2,9 @@
 
 class PublisherStatusUpdater < BaseService
   class InvalidNote < StandardError; end
+
   class InvalidAdmin < StandardError; end
+
   class CannotSuspendWhitelisted < StandardError; end
 
   def perform(user:, admin:, status:, note:)
@@ -24,6 +26,6 @@ class PublisherStatusUpdater < BaseService
     # Email users who were put on hold via the API
     PublisherMailer.email_user_on_hold(@publisher).deliver_later if status == PublisherStatusUpdate::HOLD
 
-    return status_update
+    status_update
   end
 end

--- a/lib/tasks/update_publisher_statuses.rake
+++ b/lib/tasks/update_publisher_statuses.rake
@@ -1,0 +1,39 @@
+desc 'Update Publisher Statuses'
+namespace :update do
+  task :publisher_statuses, [:status_file, :status, :admin] => :environment do |t, args|
+    raise 'Need status file' unless args[:status_file]
+    raise 'Need status' unless args[:status]
+    raise 'Need admin' unless args[:admin]
+
+    if args[:status_file].present?
+      status_file = args[:status_file]
+    end
+    status = args[:status]
+    to_update_list = JSON.parse(File.read(status_file))
+    admin = Publisher.where(email: admin).first!
+
+    puts to_update_list.size
+    puts to_update_list.first
+    to_update_list.each do |channel_identifier, data|
+      judgement_note = data["judgements"]
+      channel = Channel.find_by_channel_identifier(channel_identifier)
+      if channel
+        begin
+          publisher = channel.publisher
+          next if publisher.last_status_update&.status == status
+          PublisherStatusUpdater.new.perform(
+            user: publisher,
+            admin: admin,
+            status: status,
+            note: judgement_note
+          )
+        rescue => e
+          puts "Error for channel #{channel_identifier}:: #{e.message}"
+          next
+        end
+      else
+        puts "Can't find channel #{channel_identifier}"
+      end
+    end
+  end
+end

--- a/lib/tasks/update_publisher_statuses.rake
+++ b/lib/tasks/update_publisher_statuses.rake
@@ -1,9 +1,11 @@
-desc 'Update Publisher Statuses'
+# To use
+# rake "update:publisher_statuses[judgements.json,active,only@notes.org]"
+desc "Update Publisher Statuses"
 namespace :update do
   task :publisher_statuses, [:status_file, :status, :admin] => :environment do |t, args|
-    raise 'Need status file' unless args[:status_file]
-    raise 'Need status' unless args[:status]
-    raise 'Need admin' unless args[:admin]
+    raise "Need status file" unless args[:status_file]
+    raise "Need status" unless args[:status]
+    raise "Need admin" unless args[:admin]
 
     if args[:status_file].present?
       status_file = args[:status_file]

--- a/test/services/publisher_status_updater_test.rb
+++ b/test/services/publisher_status_updater_test.rb
@@ -1,0 +1,40 @@
+# typed: false
+
+require "test_helper"
+
+class PublisherStatusUpdaterTest < ActiveJob::TestCase
+  describe "PublisherStatusUpdater" do
+    test "updates status" do
+      channel = channels(:default)
+      publisher = channel.publisher
+      assert !publisher.suspended?
+      admin = publishers(:admin)
+      status_update = PublisherStatusUpdater.new.perform(
+        user: channel.publisher,
+        admin: admin,
+        status: "suspended",
+        note: "looked fishy"
+      )
+
+      assert status_update["status"] == "suspended"
+      assert publisher.suspended?
+    end
+
+    test "does not suspend a whitelisted publisher" do
+      channel = channels(:default)
+      admin = publishers(:admin)
+      publisher = channel.publisher
+      PublisherWhitelistUpdate.create!(publisher: publisher, enabled: true, publisher_note: PublisherNote.create!(publisher: publisher, note: "test", created_by: admin))
+      assert !publisher.suspended?
+      admin = publishers(:admin)
+      assert_raises PublisherStatusUpdater::CannotSuspendWhitelisted do
+        PublisherStatusUpdater.new.perform(
+          user: channel.publisher,
+          admin: admin,
+          status: "suspended",
+          note: "looked fishy"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the ability to bulk update creators from a CLI script. Leverage the same code an API action uses, but break that out into a separate service for reuse.