### PR TITLE
Create Uphold cards for those who should have them

### DIFF
--- a/app/jobs/create_uphold_cards_where_missing_job.rb
+++ b/app/jobs/create_uphold_cards_where_missing_job.rb
@@ -1,0 +1,14 @@
+# typed: false
+
+# Creates the Uphold Cards for recently-logged-in publishers that don't have one but should
+class CreateUpholdCardsWhereMissingJob < ApplicationJob
+  queue_as :default
+
+  def perform(publishers:)
+    if publishers.blank?
+      publishers = Publisher.uphold_selected_provider.with_verified_channel.not_suspended.logged_in_recently
+    end
+
+    publishers.each { |publisher| CreateUpholdCardsJob.perform_later(uphold_connection_id: publisher.selected_wallet_provider_id) }
+  end
+end

--- a/app/jobs/create_uphold_cards_where_missing_job.rb
+++ b/app/jobs/create_uphold_cards_where_missing_job.rb
@@ -6,7 +6,7 @@ class CreateUpholdCardsWhereMissingJob < ApplicationJob
 
   def perform(publishers:)
     if publishers.blank?
-      publishers = Publisher.uphold_selected_provider.with_verified_channel.not_suspended.logged_in_recently
+      publishers = Publisher.uphold_selected_provider_updated_recently.with_verified_channel.not_suspended
     end
 
     publishers.each { |publisher| CreateUpholdCardsJob.perform_later(uphold_connection_id: publisher.selected_wallet_provider_id) }

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -140,6 +140,11 @@ class Publisher < ApplicationRecord
            AND publishers.selected_wallet_provider_type = '#{UpholdConnection}'")
   }
 
+  scope :uphold_selected_provider_updated_recently, -> {
+    uphold_selected_provider
+      .where("uphold_connections.updated_at > :start_date", start_date: 1.week.ago)
+  }
+
   # We could remove the `country is null` if we change all affected creators to an
   # unknown country. This applies exclusively to Uphold and not Gemini
   scope :valid_payable_uphold_creators, -> {

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -103,6 +103,7 @@ class Publisher < ApplicationRecord
                                        }
 
   scope :created_recently, -> { where("created_at > :start_date", start_date: 1.week.ago) }
+  scope :logged_in_recently, -> { where("last_sign_in_at > :start_date", start_date: 1.week.ago) }
 
   scope :email_verified, -> { where.not(email: nil) }
   scope :admin, -> { where(role: ADMIN) }

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -33,6 +33,9 @@
   CleanAbandonedSiteChannelsJob:
     cron: "0 3 * * *"
     description: "Remove abandoned site channels."
+  CreateUpholdCardsWhereMissingJob:
+    cron: "0 1 * * *"
+    description: "Ensure anonymous cards are created for those who need them."
   Channels::TransferChannelsJob:
     cron: "0 8 * * *"
     description: "Complete transfer of channels that have exceeded their timeout time without being rejected"


### PR DESCRIPTION
In the case that creating the Uphold Cards fails, due to a flake on the part of the Uphold API, we should ensure that these are created in a timely manner. This job runs nightly and checks for those who have verified channels and Uphold connections, but who don't have cards. It then launches a job to create them.

Closes https://github.com/brave-intl/creators-private-issues/issues/126