### PR TITLE
Update payout wording for referrers

### DIFF
--- a/app/views/publishers/_home_balances.html.slim
+++ b/app/views/publishers/_home_balances.html.slim
@@ -20,6 +20,9 @@
           .next_deposit_date.small.mt-2
             span = t(".next_deposit_date")
             span = next_deposit_date
+        - if @publisher.may_create_referrals?
+          .next_deposit_date.small.mt-2
+            span = t(".referral_payout_date")
   - if @publisher.no_grants?
     .d-none.d-xl-block
       .line

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -433,6 +433,7 @@ en:
       held_funds_description: |
         These funds have been flagged for irregular activity. Appeal this action by <a href="/publishers/case/new">following these steps.</a>
       next_deposit_date: "Next Deposit Date: "
+      referral_payout_date: "Referrals are paid out every 2 weeks. If you also have contributions, those will be paid out per the date above."
       open_case_description:
         <a href="/publishers/case">Your appeal case </a> has been opened. Check back regularly for any updates.
       payout_in_progress: "Payout In Progress"

--- a/test/features/payout_in_progress_test.rb
+++ b/test/features/payout_in_progress_test.rb
@@ -21,13 +21,25 @@ class PayoutInProgressTest < Capybara::Rails::TestCase
 
   test "Gemini generating in progress" do
     publisher = publishers(:gemini_completed)
-
     sign_in publisher
 
     PublishersController.view_context_class.any_instance.stubs(:has_balance?).returns(true)
     visit home_publishers_path
 
     assert_content page, I18n.t("publishers.home_balances.payout_in_progress")
+  end
+
+  test "Gemini generating in progress, referrer sees referrer message" do
+    publisher = publishers(:gemini_completed)
+    publisher.feature_flags[UserFeatureFlags::REFERRAL_ENABLED_OVERRIDE] = true
+    publisher.save!
+    sign_in publisher
+
+    PublishersController.view_context_class.any_instance.stubs(:has_balance?).returns(true)
+    visit home_publishers_path
+
+    assert_content page, I18n.t("publishers.home_balances.payout_in_progress")
+    assert_content page, I18n.t("publishers.home_balances.referral_payout_date")
   end
 
   test "Gemini generating in progress but no BAT so no payouts in progress" do


### PR DESCRIPTION
Referrers will now see this on their home page to better explain their payouts.

![Screenshot 2022-11-23 at 4 07 10 PM](https://user-images.githubusercontent.com/81187695/203666962-d27a4ece-a952-4b89-877d-238193fea084.png)

Closes https://github.com/brave-intl/creators-private-issues/issues/133
