### PR TITLE
Refactor Gemini payable scope to not include hardcoded country

### DIFF
--- a/app/models/gemini_connection.rb
+++ b/app/models/gemini_connection.rb
@@ -24,10 +24,15 @@ class GeminiConnection < Oauth2::AuthorizationCodeBase
   # this will be all payable connections, minus connections that are payable because the publisher
   # has the 'blocked_country_exception' flag.
   scope :payable, -> {
-    where(is_verified: true)
+    joins(:publisher)
+      .where(is_verified: true)
       .where(status: "Active")
       .where.not(recipient_id: nil)
-      .where(country: allowed_countries)
+      .merge(in_supported_country)
+  }
+
+  scope :in_supported_country, -> {
+    where(country: allowed_countries).or(Publisher.where(blocked_country_exception: true))
   }
 
   scope :with_expired_tokens, -> {

--- a/app/models/publisher.rb
+++ b/app/models/publisher.rb
@@ -185,9 +185,7 @@ class Publisher < ApplicationRecord
 
   scope :valid_payable_gemini_creators, -> {
     gemini_selected_provider
-      .where(gemini_connections: {is_verified: true})
-      .where.not(gemini_connections: {recipient_id: nil})
-      .where(gemini_connections: {country: "US"})
+      .merge(GeminiConnection.payable)
   }
 
   store_accessor :feature_flags, VALID_FEATURE_FLAGS

--- a/test/fixtures/gemini_connections.yml
+++ b/test/fixtures/gemini_connections.yml
@@ -31,7 +31,8 @@ connection_with_token:
   ) %>"
   encrypted_refresh_token_iv: "<%= Base64.encode64(salt) %>"
   recipient_id: <%= SecureRandom.uuid %>
-  country: 'US'
+  country: 'BE'
+  status: 'Active'
 
 connection_not_verified:
   publisher: gemini_not_completed
@@ -56,6 +57,7 @@ top_referrer_gemini_connected:
   recipient_id: <%= SecureRandom.uuid %>
   country: 'US'
   is_verified: true
+  status: 'Active'
 
 gemini_blocked_country_connection:
   publisher: verified_blocked_country_gemini


### PR DESCRIPTION
A referrer was not being included in `PotentialPayout` generation due to a lack of a `blocked_country_exception` check.
We had 2 separate scopes for similar checks, this combines them. We also move away from hard-coding for the country check. 