### PR TITLE
Not all connections are refreshing due to this limit

### DIFF
--- a/app/jobs/uphold_refresh_job.rb
+++ b/app/jobs/uphold_refresh_job.rb
@@ -4,8 +4,4 @@ class UpholdRefreshJob < Oauth2BatchRefreshJob
   def set_klass
     UpholdConnection
   end
-
-  def set_limit
-    20000
-  end
 end


### PR DESCRIPTION
We previously discovered not all Uphold wallets were regularly refreshing because of this limit. For now, remove it.