### PR TITLE
Fix/missing address

### DIFF
--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -133,7 +133,7 @@ class Oauth2Controller < ApplicationController
   end
 
   def record_error(result)
-    LogException.perform(result)
+    LogException.perform(result, expected: true)
   end
 
   def allow_debug?

--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -43,8 +43,8 @@ class Cache::BrowserChannels::ResponsesForPrefix
             uphold_address = site_banner_lookup.channel&.uphold_connection&.address || ""
             uphold_wallet.address = uphold_address
           else
-            uphold_wallet.address = ""
-            LogException.perform("Setting an empty address for connection #{connection.id} and publisher #{site_banner_lookup.publisher.id}", expected: true)
+            LogException.perform("Wallet outside of allowed. Country: #{connection.country} Id: #{connection.id} Publisher: #{site_banner_lookup.publisher.id}", expected: true)
+            next
           end
 
           wallet.uphold_wallet = uphold_wallet

--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -43,8 +43,8 @@ class Cache::BrowserChannels::ResponsesForPrefix
             uphold_address = site_banner_lookup.channel&.uphold_connection&.address || ""
             uphold_wallet.address = uphold_address
           else
-            LogException.perform("Wallet outside of allowed. Country: #{connection.country} Id: #{connection.id} Publisher: #{site_banner_lookup.publisher.id}", expected: true)
-            next
+            uphold_wallet.address = ""
+            LogException.perform("Wallet outside of allowed. Country: #{connection.country} Id: #{connection.id} Publisher #{site_banner_lookup.publisher.id}", expected: true)
           end
 
           wallet.uphold_wallet = uphold_wallet

--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -44,6 +44,7 @@ class Cache::BrowserChannels::ResponsesForPrefix
             uphold_wallet.address = uphold_address
           else
             uphold_wallet.address = ""
+            LogException.perform("Setting an empty address for connection #{connection.id} and publisher #{site_banner_lookup.publisher.id}", expected: true)
           end
 
           wallet.uphold_wallet = uphold_wallet

--- a/app/jobs/cache/browser_channels/responses_for_prefix.rb
+++ b/app/jobs/cache/browser_channels/responses_for_prefix.rb
@@ -42,6 +42,8 @@ class Cache::BrowserChannels::ResponsesForPrefix
           if connection.country && allowed_regions[:uphold][:allow].include?(connection.country.upcase)
             uphold_address = site_banner_lookup.channel&.uphold_connection&.address || ""
             uphold_wallet.address = uphold_address
+          else
+            uphold_wallet.address = ""
           end
 
           wallet.uphold_wallet = uphold_wallet


### PR DESCRIPTION
Also mark errors passed from Uphold/Gemini during connection as expected. If Uphold says "your account is restricted b/c XYZ", that's not an exception we care about.