### PR TITLE
Redis sessions & overmind

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rails", rails_version
 gem "rails-html-sanitizer", "1.5.0"
 gem "railties", rails_version
 
-gem "rack", "2.2.6.4"
+gem "rack"
 
 # All things countries
 gem "countries"
@@ -19,9 +19,6 @@ gem "active_model_serializers", "~> 0.10.0"
 
 # For bulk updates/imports
 gem "activerecord-import", "1.4.1"
-
-# ActiveRecord Session store for server side storage of session data
-gem "activerecord-session_store", "~> 2.0"
 
 gem "activerecord7-redshift-adapter", git: "https://github.com/pennylane-hq/activerecord7-redshift-adapter.git"
 
@@ -117,6 +114,7 @@ gem "recaptcha", "~> 5.12.3", require: "recaptcha/rails"
 
 # Cache with Redis
 gem "redis", "~> 5.0.6"
+gem 'redis-session-store'
 
 gem "render_async", "~> 2.1.8"
 
@@ -187,8 +185,6 @@ group :development do
 
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem "web-console"
-
-  gem "mailcatcher"
 
   # gem "spring"
   # gem "spring-watcher-listen", "~> 2.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ gem "recaptcha", "~> 5.12.3", require: "recaptcha/rails"
 
 # Cache with Redis
 gem "redis", "~> 5.0.6"
-gem 'redis-session-store'
+gem "redis-session-store"
 
 gem "render_async", "~> 2.1.8"
 

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "domain_name"
 gem "faraday", "~> 2.7.4"
 gem "faraday-retry"
 
-gem "ffi", github: "ffi/ffi", tag: "v1.15.5", submodules: true
+gem "ffi"
 
 gem "font-awesome-rails", "~> 4.7.0.4"
 
@@ -187,6 +187,9 @@ group :development do
 
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem "web-console"
+
+  gem "foreman"
+  gem "mailcatcher"
 
   # gem "spring"
   # gem "spring-watcher-listen", "~> 2.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -188,7 +188,6 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem "web-console"
 
-  gem "foreman"
   gem "mailcatcher"
 
   # gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,12 +106,6 @@ GEM
     activerecord-postgres_enum (2.0.1)
       activerecord (>= 5.2)
       pg
-    activerecord-session_store (2.0.0)
-      actionpack (>= 5.2.4.1)
-      activerecord (>= 5.2.4.1)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 2.0.8, < 3)
-      railties (>= 5.2.4.1)
     activestorage (7.0.4.3)
       actionpack (= 7.0.4.3)
       activejob (= 7.0.4.3)
@@ -124,7 +118,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     android_key_attestation (0.3.0)
     ast (2.4.2)
@@ -132,13 +126,13 @@ GEM
       execjs (~> 2)
     awrence (1.2.1)
     aws-eventstream (1.2.0)
-    aws-partitions (1.734.0)
-    aws-sdk-core (3.171.0)
+    aws-partitions (1.768.0)
+    aws-sdk-core (3.173.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.63.0)
+    aws-sdk-kms (1.64.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.119.2)
@@ -150,10 +144,10 @@ GEM
     backport (1.2.0)
     bcrypt (3.1.18)
     benchmark (0.2.1)
-    better_errors (2.9.1)
-      coderay (>= 1.0.0)
+    better_errors (2.10.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+      rouge (>= 1.0.0)
     better_html (2.0.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -180,7 +174,7 @@ GEM
       thor (~> 1.0)
     byebug (11.1.3)
     cancancan (3.4.0)
-    capybara (3.38.0)
+    capybara (3.39.1)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -199,14 +193,13 @@ GEM
     cose (1.3.0)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
-    countries (5.3.1)
+    countries (5.4.0)
       unaccent (~> 0.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
-    daemons (1.4.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -235,9 +228,8 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
-    eventmachine (1.2.7)
     execjs (2.8.1)
-    faraday (2.7.4)
+    faraday (2.7.5)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-multipart (1.0.4)
@@ -254,18 +246,12 @@ GEM
       raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-protobuf (3.21.12)
     google-protobuf (3.21.12-x86_64-darwin)
-    google-protobuf (3.21.12-x86_64-linux)
-    haml (6.1.1)
-      temple (>= 0.8.2)
-      thor
-      tilt
     hashdiff (1.0.1)
     hashie (5.0.0)
     highline (2.1.0)
     htmlentities (4.3.4)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.12)
       activesupport (>= 4.0.2)
@@ -278,11 +264,11 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
-    importmap-rails (1.1.5)
+    importmap-rails (1.1.6)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     inflection (1.0.0)
-    jaro_winkler (1.5.4)
+    jaro_winkler (1.5.5)
     jmespath (1.6.2)
     json (2.6.3)
     jsonapi-renderer (0.2.2)
@@ -292,6 +278,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
+    lint_roller (1.0.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -300,24 +287,14 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.19.1)
+    loofah (2.21.3)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
-    mailcatcher (0.2.4)
-      eventmachine
-      haml
-      i18n
-      json
-      mail
-      sinatra
-      skinny (>= 0.1.2)
-      sqlite3-ruby
-      thin
     marcel (1.0.2)
     matrix (0.4.2)
     meta-tags (2.18.0)
@@ -332,11 +309,8 @@ GEM
       minitest (>= 5.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
-    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
-    mustermann (3.0.0)
-      ruby2_keywords (~> 0.0.1)
     net-imap (0.3.4)
       date
       net-protocol
@@ -347,14 +321,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     newrelic_rpm (8.16.0)
-    nio4r (2.5.8)
-    nokogiri (1.14.3-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.14.3-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-linux)
+    nio4r (2.5.9)
+    nokogiri (1.15.1-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -393,10 +361,10 @@ GEM
     paper_trail (14.0.0)
       activerecord (>= 6.0)
       request_store (~> 1.4)
-    parallel (1.22.1)
-    parser (3.2.1.1)
+    parallel (1.23.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
-    pg (1.4.6)
+    pg (1.5.3)
     popper_js (1.16.1)
     premailer (1.21.0)
       addressable
@@ -420,10 +388,10 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.6.2)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
-    rack-protection (3.0.5)
+    rack-protection (3.0.6)
       rack
     rack-proxy (0.7.6)
       rack
@@ -452,7 +420,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
-    rails-i18n (7.0.6)
+    rails-i18n (7.0.7)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     railties (7.0.4.3)
@@ -467,13 +435,17 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbs (2.8.4)
     recaptcha (5.12.3)
       json
     redis (5.0.6)
       redis-client (>= 0.9.0)
-    redis-client (0.14.0)
+    redis-client (0.14.1)
       connection_pool
-    regexp_parser (2.7.0)
+    redis-session-store (0.11.5)
+      actionpack (>= 6, < 8)
+      redis (>= 3, < 6)
+    regexp_parser (2.8.0)
     render_async (2.1.11)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -484,21 +456,22 @@ GEM
       nokogiri
     rexml (3.2.5)
     rotp (6.2.2)
+    rouge (4.1.1)
     rqrcode (2.1.2)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
     rqrcode_core (1.2.0)
-    rubocop (1.48.1)
+    rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.26.0, < 2.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
     rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
@@ -521,7 +494,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.8.2)
+    selenium-webdriver (4.8.6)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -545,17 +518,9 @@ GEM
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    sinatra (3.0.5)
-      mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.0.5)
-      tilt (~> 2.0)
-    skinny (0.2.2)
-      eventmachine (~> 1.0)
-      thin
-    slim (5.1.0)
+    slim (5.1.1)
       temple (~> 0.10.0)
-      tilt (>= 2.0.6, < 2.2)
+      tilt (>= 2.1.0)
     slim-rails (3.6.2)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -564,18 +529,19 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    solargraph (0.48.0)
+    solargraph (0.49.0)
       backport (~> 1.2)
       benchmark
-      bundler (>= 1.17.2)
+      bundler (~> 2.0)
       diff-lcs (~> 1.4)
       e2mmap
       jaro_winkler (~> 1.5)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.1)
       parser (~> 3.0)
-      reverse_markdown (>= 1.0.5, < 3)
-      rubocop (>= 0.52)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
@@ -586,29 +552,27 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.1-arm64-darwin)
-    sqlite3 (1.6.1-x86_64-darwin)
-    sqlite3 (1.6.1-x86_64-linux)
-    sqlite3-ruby (1.3.3)
-      sqlite3 (>= 1.3.3)
     ssrf_filter (1.0.7)
-    standard (1.25.3)
+    standard (1.28.2)
       language_server-protocol (~> 3.17.0.2)
-      rubocop (~> 1.48.1)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50.2)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.0.1)
+    standard-custom (1.0.0)
+      lint_roller (~> 1.0)
+    standard-performance (1.0.1)
+      lint_roller (~> 1.0)
       rubocop-performance (~> 1.16.0)
     strong_migrations (1.4.4)
       activerecord (>= 5.2)
     temping (4.0.0)
       activerecord (>= 5.2, < 7.1)
       activesupport (>= 5.2, < 7.1)
-    temple (0.10.0)
+    temple (0.10.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thin (1.8.1)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
-    thor (1.2.1)
+    thor (1.2.2)
     tilt (2.1.0)
     timeout (0.3.2)
     tpm-key_attestation (0.12.0)
@@ -657,7 +621,6 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    webrick (1.7.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -665,11 +628,10 @@ GEM
     will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
+    yard (0.9.34)
     yt (0.33.4)
       activesupport
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
     zendesk_api (1.38.0.rc1)
       faraday (> 2.0.0)
       faraday-multipart
@@ -679,18 +641,13 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
-  aarch64-linux
-  arm64-darwin-21
-  x86_64-darwin-20
   x86_64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   activerecord-import (= 1.4.1)
   activerecord-nulldb-adapter (= 0.8.0)
   activerecord-postgres_enum
-  activerecord-session_store (~> 2.0)
   activerecord7-redshift-adapter!
   addressable (~> 2.8)
   aws-sdk-s3 (~> 1.119.0)
@@ -721,7 +678,6 @@ DEPENDENCIES
   importmap-rails (~> 1.1)
   listen (~> 3.5)
   lograge (~> 0.4)
-  mailcatcher
   meta-tags (~> 2.18.0)
   minitest
   minitest-rails
@@ -744,7 +700,7 @@ DEPENDENCIES
   pry-stack_explorer (~> 0.6.1)
   public_suffix (~> 5.0.1)
   puma (~> 6.0.2)
-  rack (= 2.2.6.4)
+  rack
   rack-attack (~> 6.6.1)
   rails (= 7.0.4.3)
   rails-controller-testing
@@ -753,6 +709,7 @@ DEPENDENCIES
   railties (= 7.0.4.3)
   recaptcha (~> 5.12.3)
   redis (~> 5.0.6)
+  redis-session-store
   render_async (~> 2.1.8)
   rexml
   rotp (~> 6.2.0)
@@ -791,4 +748,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.4.9
+   2.4.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,14 +24,6 @@ GIT
       wasmer (~> 1.0)
 
 GIT
-  remote: https://github.com/ffi/ffi.git
-  revision: c0c7d68dea59c792438aa76e65290a44524a3c1c
-  tag: v1.15.5
-  submodules: true
-  specs:
-    ffi (1.15.5)
-
-GIT
   remote: https://github.com/pennylane-hq/activerecord7-redshift-adapter.git
   revision: 8051862711488efb99b68992ea00541973527123
   specs:
@@ -140,8 +132,8 @@ GEM
       execjs (~> 2)
     awrence (1.2.1)
     aws-eventstream (1.2.0)
-    aws-partitions (1.727.0)
-    aws-sdk-core (3.170.0)
+    aws-partitions (1.734.0)
+    aws-sdk-core (3.171.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -149,7 +141,7 @@ GEM
     aws-sdk-kms (1.63.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.119.1)
+    aws-sdk-s3 (1.119.2)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
@@ -214,6 +206,7 @@ GEM
     crass (1.0.6)
     css_parser (1.14.0)
       addressable
+    daemons (1.4.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -242,6 +235,7 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
+    eventmachine (1.2.7)
     execjs (2.8.1)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
@@ -252,8 +246,10 @@ GEM
     faraday-retry (2.1.0)
       faraday (~> 2.0)
     fastimage (2.2.6)
+    ffi (1.15.5)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
+    foreman (0.87.2)
     fugit (1.8.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
@@ -262,6 +258,10 @@ GEM
     google-protobuf (3.21.12)
     google-protobuf (3.21.12-x86_64-darwin)
     google-protobuf (3.21.12-x86_64-linux)
+    haml (6.1.1)
+      temple (>= 0.8.2)
+      thor
+      tilt
     hashdiff (1.0.1)
     hashie (5.0.0)
     highline (2.1.0)
@@ -309,6 +309,16 @@ GEM
       net-imap
       net-pop
       net-smtp
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     marcel (1.0.2)
     matrix (0.4.2)
     meta-tags (2.18.0)
@@ -326,6 +336,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
     net-imap (0.3.4)
       date
       net-protocol
@@ -387,7 +399,7 @@ GEM
       ast (~> 2.4.1)
     pg (1.4.6)
     popper_js (1.16.1)
-    premailer (1.20.0)
+    premailer (1.21.0)
       addressable
       css_parser (>= 1.12.0)
       htmlentities (>= 4.0.0)
@@ -477,19 +489,19 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
     rqrcode_core (1.2.0)
-    rubocop (1.44.1)
+    rubocop (1.48.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.27.0)
+    rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
-    rubocop-performance (1.15.2)
+    rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
@@ -510,7 +522,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.8.1)
+    selenium-webdriver (4.8.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -534,6 +546,14 @@ GEM
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
+    sinatra (3.0.5)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.5)
+      tilt (~> 2.0)
+    skinny (0.2.2)
+      eventmachine (~> 1.0)
+      thin
     slim (5.1.0)
       temple (~> 0.10.0)
       tilt (>= 2.0.6, < 2.2)
@@ -567,11 +587,16 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.1-arm64-darwin)
+    sqlite3 (1.6.1-x86_64-darwin)
+    sqlite3 (1.6.1-x86_64-linux)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
     ssrf_filter (1.0.7)
-    standard (1.24.3)
+    standard (1.25.3)
       language_server-protocol (~> 3.17.0.2)
-      rubocop (= 1.44.1)
-      rubocop-performance (= 1.15.2)
+      rubocop (~> 1.48.1)
+      rubocop-performance (~> 1.16.0)
     strong_migrations (1.4.4)
       activerecord (>= 5.2)
     temping (4.0.0)
@@ -580,6 +605,10 @@ GEM
     temple (0.10.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    thin (1.8.1)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -599,7 +628,7 @@ GEM
     unicode-display_width (2.4.2)
     uniform_notifier (1.16.0)
     vcr (6.1.0)
-    version_gem (1.1.1)
+    version_gem (1.1.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -686,13 +715,15 @@ DEPENDENCIES
   faraday (~> 2.7.4)
   faraday-retry
   fastimage (~> 2.2.5)
-  ffi!
+  ffi
   font-awesome-rails (~> 4.7.0.4)
+  foreman
   google-protobuf (~> 3.21.12)
   i18n-tasks (~> 1.0.12)
   importmap-rails (~> 1.1)
   listen (~> 3.5)
   lograge (~> 0.4)
+  mailcatcher
   meta-tags (~> 2.18.0)
   minitest
   minitest-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,6 @@ GEM
     ffi (1.15.5)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
-    foreman (0.87.2)
     fugit (1.8.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
@@ -717,7 +716,6 @@ DEPENDENCIES
   fastimage (~> 2.2.5)
   ffi
   font-awesome-rails (~> 4.7.0.4)
-  foreman
   google-protobuf (~> 3.21.12)
   i18n-tasks (~> 1.0.12)
   importmap-rails (~> 1.1)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+redis: redis-server
+worker: bundle exec sidekiq -C config/sidekiq.yml
+web: bundle exec rails s
+mailcatcher: bundle exec mailcatcher

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 redis: redis-server
 worker: bundle exec sidekiq -C config/sidekiq.yml
-web: bundle exec rails s
+web: bundle exec rails s -p 3000
 mailcatcher: bundle exec mailcatcher

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 redis: redis-server
 worker: bundle exec sidekiq -C config/sidekiq.yml
-web: bundle exec rails s -p 3000
+web: bundle exec rails s
 mailcatcher: bundle exec mailcatcher

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,5 @@
 redis: redis-server
 worker: bundle exec sidekiq -C config/sidekiq.yml
 web: bundle exec rails s
-mailcatcher: bundle exec mailcatcher
+# Can't run mailcatcher with bundle since it's deps are so old. Have to install it separately
+mailcatcher: mailcatcher -f

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Creators is powered by Ruby on Rails and React.
 
 Development with Docker and `docker-compose` is recommended for anyone just getting started.  If for any reason you wish to run the stack locally see [Local Installation Instructions](docs/LOCAL.md). Creators has a complex set of interactions however and has another application ([Eyeshade](https://github.com/brave-intl/bat-ledger)) as a core integration/service dependency that is most readily accessed via `docker-compose`.
 
+## Running locally with Foreman
+
+If you don't want to use docker, and want to develop locally, you can use foreman:
+
+`bundle exec foreman start`
+
 ## Running locally with docker-compose
 
 1. [install docker and docker compose](https://docs.docker.com/compose/install/).

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Creators is powered by Ruby on Rails and React.
 
 Development with Docker and `docker-compose` is recommended for anyone just getting started.  If for any reason you wish to run the stack locally see [Local Installation Instructions](docs/LOCAL.md). Creators has a complex set of interactions however and has another application ([Eyeshade](https://github.com/brave-intl/bat-ledger)) as a core integration/service dependency that is most readily accessed via `docker-compose`.
 
-## Running locally with Foreman
+## Running locally with Overmind
 
-If you don't want to use docker, and want to develop locally, you can use foreman:
+If you don't want to use docker, and want to develop locally, you can use [overmind](https://github.com/DarthSim/overmind):
 
-`bundle exec foreman start`
+Make sure to install it and then run:
+`overmind start -N -f Procfile.dev`
 
 ## Running locally with docker-compose
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,6 +22,15 @@ Rails.application.configure do
   require "connection_pool"
   REDIS = ConnectionPool.new(size: 5) { Redis.new }
 
+  # SESSION STORE
+  config.session_store :redis_session_store,
+    key:  "_publishers_session",
+    redis: {
+    client: Redis.new(url: Rails.application.secrets[:redis_url]),
+    expire_after: 120.minutes,
+    key_prefix: 'publishers:session:'
+  }
+
   config.middleware.use(Rack::Attack)
   config.action_mailer.default_url_options = { host: "localhost", port: 3000, protocol: "https" }
   # Mailcatcher

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,6 +38,15 @@ Rails.application.configure do
   require "connection_pool"
   REDIS = ConnectionPool.new(size: 5) { Redis.new }
 
+  # SESSION STORE
+  config.session_store :redis_session_store,
+                       key:  "_publishers_session",
+                       redis: {
+                         client: Redis.new(url: Rails.application.secrets[:redis_url]),
+                         expire_after: 120.minutes,
+                         key_prefix: 'publishers:session:'
+                       }
+
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "publishers_#{Rails.env}"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,6 +38,16 @@ Rails.application.configure do
   require "connection_pool"
   REDIS = ConnectionPool.new(size: 5) { Redis.new }
 
+
+  # SESSION STORE
+  config.session_store :redis_session_store,
+                       key:  "_publishers_session",
+                       redis: {
+                         client: Redis.new(url: Rails.application.secrets[:redis_url]),
+                         expire_after: 120.minutes,
+                         key_prefix: 'publishers:session:'
+                       }
+
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "publishers_#{Rails.env}"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -72,6 +72,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  config.session_store :cache_store, key: "_publishers_session"
+
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,7 +1,0 @@
-# typed: strict
-
-# Be sure to restart your server when you modify this file.
-
-# Underlying setup found in https://github.com/rails/activerecord-session_store/blob/master/lib/tasks/database.rake
-ENV["SESSION_DAYS_TRIM_THRESHOLD"] = "1"
-Rails.application.config.session_store :active_record_store, key: "_publishers_session"


### PR DESCRIPTION
Closes https://github.com/brave-intl/creators-private-issues/issues/1638

Use overmind for running locally without Docker. This boots all services with one command. 

This required a switch to redis for sessions since the activerecord module is no longer receiving updates, it seems.

This is in draft since we need the encrypted columns change to go to production first.