### PR TITLE
Fix logo out of place on small screens

### DIFF
--- a/app/assets/stylesheets/theme/nav.scss
+++ b/app/assets/stylesheets/theme/nav.scss
@@ -6,7 +6,7 @@
   @media screen and (max-width: 460px) {
     .brave-logo {
       position: absolute;
-      top: 28px;
+      top: 0px;
     }
 
     .brave-logo img {


### PR DESCRIPTION
Closes https://github.com/brave-intl/creators-private-issues/issues/1605

The logo was too low on small screens, removed the top padding fixed it.

![Screenshot 2023-03-29 at 8 31 28 AM](https://user-images.githubusercontent.com/81187695/228590536-cb8d868d-8201-4f35-827a-be85c97c4299.png)
