### PR TITLE
Fix/bulk insert for attr encrypted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -657,6 +657,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-20
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -764,4 +765,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.3.18
+   2.4.9

--- a/lib/tasks/database_updates/migrate_old_encrypted_fields_to_rails_7.rake
+++ b/lib/tasks/database_updates/migrate_old_encrypted_fields_to_rails_7.rake
@@ -10,52 +10,6 @@ namespace :database_updates do
       UserAuthenticationToken: [:authentication_token]
     }
 
-
-
-
-    #
-    # # BULK CODE
-    #
-    # records_to_update = []
-    # UpholdConnection.where.not(encrypted_uphold_access_parameters: nil).order(id: :asc).find_each do |uphold_connection|
-    #   access_params = uphold_connection.uphold_access_parameters
-    #   if access_params
-    #     parsed_access_params = JSON.parse(access_params)
-    #     if access_token_to_refresh_token.include?(parsed_access_params["access_token"])
-    #       parsed_access_params["refresh_token"] = access_token_to_refresh_token[parsed_access_params["access_token"]]
-    #       parsed_access_params["expiration_time"] = expiration_time
-    #       uphold_connection.uphold_access_parameters = JSON.dump(parsed_access_params)
-    #       records_to_update << uphold_connection
-    #     end
-    #   end
-    # end
-    #
-    # UpholdConnection.import(records_to_update,
-    #                         on_duplicate_key_update: {
-    #                           conflict_target: [:id],
-    #                           columns: [:encrypted_uphold_access_parameters, :encrypted_uphold_access_parameters_iv]
-    #                         },
-    #                         validate: false,
-    #                         batch_size: 1000)
-    #
-    #
-    # # END BULK CODE
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     class_and_columns.each do |klass, columns|
       reload_model(klass)
       records_to_update = []

--- a/lib/tasks/database_updates/migrate_old_encrypted_fields_to_rails_7.rake
+++ b/lib/tasks/database_updates/migrate_old_encrypted_fields_to_rails_7.rake
@@ -29,12 +29,12 @@ namespace :database_updates do
       end
       puts "Bulk upserting #{records_to_update.size} #{klass} records"
       klass.to_s.constantize.import(records_to_update,
-                on_duplicate_key_update: {
-                  conflict_target: [:id],
-                  columns: columns
-                },
-                validate: false,
-                batch_size: 1000)
+        on_duplicate_key_update: {
+          conflict_target: [:id],
+          columns: columns
+        },
+        validate: false,
+        batch_size: 1000)
       reload_model(klass)
     end
     puts "Done!"
@@ -50,10 +50,3 @@ def reload_model(klass)
   load "app/models/#{klass.to_s.underscore}.rb"
   puts "Reloaded #{klass}"
 end
-
-
-
-
-
-
-

--- a/lib/tasks/database_updates/migrate_old_encrypted_fields_to_rails_7.rake
+++ b/lib/tasks/database_updates/migrate_old_encrypted_fields_to_rails_7.rake
@@ -74,7 +74,7 @@ namespace :database_updates do
         records_to_update << u
       end
       puts "Bulk upserting #{records_to_update.size} #{klass} records"
-      klass.import(records_to_update,
+      klass.to_s.constantize.import(records_to_update,
                 on_duplicate_key_update: {
                   conflict_target: [:id],
                   columns: columns

--- a/test/fixtures/bitflyer_connections.yml
+++ b/test/fixtures/bitflyer_connections.yml
@@ -1,8 +1,8 @@
 enabled_bitflyer_connection:
   publisher: bitflyer_pub
   recipient_id: 'bitflyer_pub_connectionABC'
-  access_token:  '<%= BitflyerConnection.attribute_types["access_token"].serialize('access_token') %>'
-  refresh_token:  '<%= BitflyerConnection.attribute_types["refresh_token"].serialize('refresh_token') %>'
+  access_token:  "{\"p\":\"e/ENo7bAk4vGIUww\",\"h\":{\"iv\":\"OhYVbo8G5pOiKCeU\",\"at\":\"3XkxH1Pscfb1ZIhRhbFd/A==\"}}"
+  refresh_token:  "{\"p\":\"Ko/s19tu5aFATtNnNw==\",\"h\":{\"iv\":\"g+1aQdVgFvzZ0ZEQ\",\"at\":\"CwSB50ZQmgKTYUMRmmmrmA==\"}}"
   display_name: 123
   access_expiration_time: "<%= 2.days.ago %>"
 

--- a/test/fixtures/gemini_connections.yml
+++ b/test/fixtures/gemini_connections.yml
@@ -17,8 +17,8 @@ connection_with_token:
   publisher: gemini_completed
   is_verified: true
   recipient_id: <%= SecureRandom.uuid %>
-  access_token:  '<%= GeminiConnection.attribute_types["access_token"].serialize('access_token') %>'
-  refresh_token:  '<%= GeminiConnection.attribute_types["refresh_token"].serialize('refresh_token') %>'
+  access_token:  "{\"p\":\"jAbpCZWg+WEt+Pd2\",\"h\":{\"iv\":\"ge8wrBvKjf37XCuL\",\"at\":\"khms5mVUubgSt1Kn3pqk7g==\"}}"
+  refresh_token: "{\"p\":\"NGzY2xXThfjkicba/A==\",\"h\":{\"iv\":\"f3ZKcZla2PcQ9INT\",\"at\":\"wEYWCO8FQpO1JLQCdwHB7g==\"}}"
   country: 'BE'
   status: 'Active'
 

--- a/test/fixtures/totp_registrations.yml
+++ b/test/fixtures/totp_registrations.yml
@@ -1,14 +1,14 @@
 default:
   publisher: verified
   last_logged_in_at: <%= 2.days.ago %>
-  secret: '<%= TotpRegistration.attribute_types["secret"].serialize("secret") %>'
+  secret: "{\"p\":\"wGaRMQ3Q\",\"h\":{\"iv\":\"uJJLsghya2K1vGDG\",\"at\":\"JKGd7ZFGmlugdpxztPM4ew==\"}}"
 
 verified_totp:
   publisher: verified_totp_only
   last_logged_in_at: <%= 2.days.ago %>
-  secret: '<%= TotpRegistration.attribute_types["secret"].serialize("secret") %>'
+  secret: "{\"p\":\"wGaRMQ3Q\",\"h\":{\"iv\":\"uJJLsghya2K1vGDG\",\"at\":\"JKGd7ZFGmlugdpxztPM4ew==\"}}"
 
 admin:
   publisher: admin
   last_logged_in_at: <%= 2.days.ago %>
-  secret: '<%= TotpRegistration.attribute_types["secret"].serialize("secret") %>'
+  secret: "{\"p\":\"wGaRMQ3Q\",\"h\":{\"iv\":\"uJJLsghya2K1vGDG\",\"at\":\"JKGd7ZFGmlugdpxztPM4ew==\"}}"

--- a/test/fixtures/user_authentication_tokens.yml
+++ b/test/fixtures/user_authentication_tokens.yml
@@ -1,6 +1,8 @@
 default_user_authentication_token: &default_user_authentication_token
   authentication_token_expires_at: "<%= DateTime.now + PublisherTokenGenerator::TOKEN_TTL %>"
-  authentication_token: '<%= UserAuthenticationToken.attribute_types["authentication_token"].serialize("authentication_token") %>'
+  # authenticity_token run through console with
+  # UserAuthenticationToken.attribute_types["authentication_token"].serialize("authentication_token")
+  authentication_token: "{\"p\":\"0td0A3BTMy9uWB70qMpg2gDcW8A=\",\"h\":{\"iv\":\"+Y/xIQHuaf5RB3ZZ\",\"at\":\"7Na/C3xVwKZVxB+1s9eltw==\"}}"
   user: default
 
 completed_user_authentication_token:


### PR DESCRIPTION
Loading the new columns should go much faster with bulk inserting. We will rerun this on staging to confirm that the values are correct when updated.

I discovered that the fixture loading was not working properly for simple strings that needed to be encrypted, so I just ran the `serialize` command in the console to simplify