### PR TITLE
Handle for missing promo registration elements 

### DIFF
--- a/app/javascript/admin/dashboard/unattached_promo_registration.js
+++ b/app/javascript/admin/dashboard/unattached_promo_registration.js
@@ -1,25 +1,25 @@
 document.addEventListener('DOMContentLoaded', function() {
   var unattachedReferralCodeForm = document.getElementById('unattached-referral-code-form');
 
-  let assignToCampaignButton = document.getElementById('assign-to-campaign')
-  assignToCampaignButton.addEventListener('click', function(event){
-    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/assign_campaign'
-  })
+  function addListener(id, callback) {
+    let element = document.getElementById(id);
+    if (element) {
+      element.addEventListener('click', callback);
+    }
+  }
 
-  let assignInstallerTypeToCodesButton = document.getElementById('assign-installer-type')
-  assignInstallerTypeToCodesButton.addEventListener('click', function(event){
-    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/assign_installer_type'
-    document.getElementsByName("_method")[0].value = 'put'
-  })
-
-  let downloadReferralReportButton = document.getElementById('download-referral-reports')
-  downloadReferralReportButton.addEventListener('click', function(event){
-    unattachedReferralCodeForm.method = 'get'
-    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/report'
-  })
-
-  let updateReferralCodeStatusesButton = document.getElementById('update-referral-code-statuses')
-  updateReferralCodeStatusesButton.addEventListener('click', function(event){
-    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/update_statuses'
-  })
+  addListener('assign-to-campaign', () => {
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/assign_campaign';
+  });
+  addListener('assign-installer-type', () => {
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/assign_installer_type';
+    document.getElementsByName("_method")[0].value = 'put';
+  });
+  addListener('download-referral-reports', () => {
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/report';
+    unattachedReferralCodeForm.method = 'get';
+  });
+  addListener('update-referral-code-statuses', () => {
+    unattachedReferralCodeForm.action = '/admin/unattached_promo_registrations/update_statuses';
+  });
 })


### PR DESCRIPTION
Not sure this code is relevant anymore, but this prevents an errors being throw if the elements don't exist on the page.

Closes [Issue #391](https://github.com/brave-intl/creators-private-issues/issues/391)