### PR TITLE
Removes broken uphold url on channel card

### DIFF
--- a/app/views/publishers/_channel.html.slim
+++ b/app/views/publishers/_channel.html.slim
@@ -70,11 +70,6 @@
         .added-date.d-none.d-sm-block
           = t(".added", date: channel.created_at.to_date.iso8601)
           span.mx-2= ' | '
-        - if channel.uphold_connection.present? && !current_publisher.uphold_connection.japanese_account?
-          =image_tag 'uphold.svg', style: "width: 18px; height: 18px; margin-top: 3px;"
-          =link_to(t('.uphold'), "#{uphold_dashboard_url}/cards/#{channel.uphold_connection.card_id}", class: 'px-1', target: "_blank")
-          span.mx-2
-            = ' | '
         a.remove-channel href="#" data-channel-id=(channel.id)
           = t(".remove_verified")
         script type="text/html" data-js-channel-removal-confirmation-template=(channel.id)


### PR DESCRIPTION
Resolves https://github.com/brave-intl/creators-private-issues/issues/1639

Removes broken uphold link from Channel card

### Before
<img width="502" alt="Screenshot 2023-06-16 at 11 15 43 AM" src="https://github.com/brave-intl/publishers/assets/6961771/57b79153-ed0a-4bcf-9692-7279118cec56">

### After
<img width="385" alt="Screenshot 2023-06-16 at 11 15 32 AM" src="https://github.com/brave-intl/publishers/assets/6961771/5b3fd819-a8d1-49c7-901b-bfcca928794f">

