### PR TITLE
Updates expired auth token copy to correct time

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -599,7 +599,7 @@ en:
       expired_authentication_token:
         expired_error: Your login link has expired. Please send yourself another one.
         heading: Login Link Expired
-        body: Login link access expires after 30 minutes and can only be used once
+        body: Login link access expires after 3 hours and can only be used once
         button: Send me a new link
       require_verified_email:
         email_verification_required: To continue please confirm your email address.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -561,7 +561,7 @@ ja:
       expired_authentication_token:
         expired_error: ログインリンクの有効期限が切れています。 新しいメールを送信してください。
         heading: ログインリンクが期限切れです
-        body: ログインリンクアクセスは30分で有効期限が切れ、1回しか使用できません
+        body: ログインリンクアクセスは3時間で有効期限が切れ、1回しか使用できません
         button: 新しいリンクを送ってください
       require_verified_email:
         email_verification_required: 続行するには、メールアドレスを承認してください。


### PR DESCRIPTION
Resolves https://github.com/brave-intl/creators-private-issues/issues/481

## Summary
Updates expired auth token copy to now say 3 hours instead of 30 minutes

Verified that 3 hours in the correct time [here](https://github.com/brave-intl/publishers/blob/63c93f82a26029006f968fa572e5f46d10df3bc5/app/services/publisher_token_generator.rb#L4-L5/) 

Changed the Japanese Kanji from `30分` (30 minutes) to `3時間` (3 hours)
## Screenshot
<img width="727" alt="Screenshot 2023-06-20 at 11 12 01 AM" src="https://github.com/brave-intl/publishers/assets/6961771/a42d2ce8-1a66-4d2e-b41b-206a015a7acd">


