### PR TITLE
Replaces static count with verified channels count to landing page

### DIFF
--- a/app/controllers/api/v3/public/channels_controller.rb
+++ b/app/controllers/api/v3/public/channels_controller.rb
@@ -1,19 +1,8 @@
 # typed: ignore
 
 class Api::V3::Public::ChannelsController < Api::V3::Public::BaseController
-  include BrowserChannelsDynoCaching
-  @@cached_payload = nil
-  REDIS_KEY = "browser_channels_json_v3".freeze
-  REDIS_THUNDERING_HERD_KEY = "browser_channels_json_v3_th".freeze
-
-  def totals
-    statistical_totals_json = Rails.cache.fetch(CacheBrowserChannelsJsonJobV3::TOTALS_CACHE_KEY, race_condition_ttl: 30)
-    render(json: statistical_totals_json, status: 200)
-  end
-
-  private
-
-  def dyno_expiration_key
-    "browser_v3_channels_expiration:#{ENV["DYNO"]}"
+  def total_verified
+    total_verified_json = Channel.verified.count
+    render(json: total_verified_json, status: 200)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,7 @@ Rails.application.routes.draw do
     member do
       get :verification_status
       get :cancel_add
+      get :total_verified_count
       delete :destroy
       resources :tokens, only: %() do
         get :reject_transfer, to: "channel_transfer#reject_transfer"
@@ -217,7 +218,7 @@ Rails.application.routes.draw do
       namespace :public, defaults: {format: :json} do
         get "channels", controller: "channels"
         namespace :channels, defaults: {format: :json} do
-          get "totals"
+          get "total_verified"
         end
       end
       namespace :channels, defaults: {format: :json} do

--- a/public/creators-landing/src/sections/signoff/index.js
+++ b/public/creators-landing/src/sections/signoff/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Box, Heading, Image, ResponsiveContext } from 'grommet'
 import { Container, PrimaryButton } from '../../components'
 import CreatorsWide_webp from '../../components/img/creator-logos-wide.webp'
@@ -10,13 +10,30 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 export const Signoff = () => {
   const intl = useIntl();
+  const [channelsCount, SetChannelsCount] = useState(1000000); // defaults to 1mil
+
+  useEffect(() => {
+    fetchTotalVerifiedChannels();
+  }, []);
+
+  const fetchTotalVerifiedChannels = async () => {
+    try {
+      const response = await fetch("/api/v3/public/channels/total_verified");
+      const result = await response.json();
+
+      SetChannelsCount(result);
+    } catch(err) {
+      console.error(err)
+    }
+  }
+
   return (
     <Box align='center'>
       <Container align='center' pad='large'>
         <Box pad={{ horizontal: 'large' }}>
           <Heading alignSelf='center' level='4' textAlign='center'>
             <FormattedMessage id="signoff.headline" values={{
-              count: <strong>{intl.formatNumber(1000000)}</strong>
+              count: <strong>{intl.formatNumber(channelsCount)}</strong>
             }} />
           </Heading>
           <ResponsiveContext.Consumer>

--- a/test/controllers/api/v3/public/channels_controller_test.rb
+++ b/test/controllers/api/v3/public/channels_controller_test.rb
@@ -1,0 +1,18 @@
+# typed: false
+
+require "test_helper"
+
+class Api::V3::Public::ChannelsControllerTest < ActionDispatch::IntegrationTest
+  include MockRewardsResponses
+
+  before do
+    stub_rewards_parameters
+  end
+
+  test "/api/v3/public/channels/total_verified returns json count of verified channels" do
+    get "/api/v3/public/channels/total_verified", headers: {"HTTP_AUTHORIZATION" => "Token token=fake_api_auth_token"}
+
+    assert_equal(200, response.status)
+    assert_equal(55, JSON.parse(response.body))
+  end
+end


### PR DESCRIPTION
## Summary 
Replace's the static `1,000,000` count in the sign-off section of the landing page with a count of verified channels from the database

Removes original code  for the PublicChannelsController since it is missing the associated file to work correctly

**Note:** The test DB only has 54 verified channels
<img width="975" alt="Screenshot 2023-06-21 at 1 14 24 PM" src="https://github.com/brave-intl/publishers/assets/6961771/fcd86e4e-713b-478e-8f9e-3e78b498356b">
