### PR TITLE
Use `word-wrap` sub-dependency alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,9 @@
     "@types/react": "16.4.7",
     "@types/styled-components": "5.1.0"
   },
+  "overrides": {
+    "optionator" : "0.9.3"
+  },  
   "browserslist": [
     "defaults"
   ]

--- a/package.json
+++ b/package.json
@@ -143,9 +143,6 @@
     "@types/react": "16.4.7",
     "@types/styled-components": "5.1.0"
   },
-  "overrides": {
-    "optionator" : "0.9.3"
-  },  
   "browserslist": [
     "defaults"
   ]

--- a/public/creators-landing/package.json
+++ b/public/creators-landing/package.json
@@ -39,6 +39,9 @@
       "last 1 safari version"
     ]
   },
+  "overrides": {
+    "optionator" : "0.9.3"
+  },  
   "resolutions": {
     "nth-check": "2.1.1"
   }

--- a/public/creators-landing/package.json
+++ b/public/creators-landing/package.json
@@ -39,10 +39,8 @@
       "last 1 safari version"
     ]
   },
-  "overrides": {
-    "optionator" : "0.9.3"
-  },  
   "resolutions": {
-    "nth-check": "2.1.1"
+    "nth-check": "2.1.1",
+    "word-wrap": "aashutoshrathi/word-wrap"
   }
 }

--- a/public/creators-landing/yarn.lock
+++ b/public/creators-landing/yarn.lock
@@ -2906,7 +2906,7 @@ bonjour-service@^1.0.11:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.5"
 
-boolbase@^1.0.0:
+boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
@@ -6394,7 +6394,14 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@2.1.1, nth-check@^1.0.2, nth-check@^2.0.1:
+nth-check@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
+nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
@@ -9043,10 +9050,9 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+word-wrap@^1.2.3, word-wrap@aashutoshrathi/word-wrap, word-wrap@~1.2.3:
+  version "1.2.6"
+  resolved "https://codeload.github.com/aashutoshrathi/word-wrap/tar.gz/84981421a9ff67bf7604a1183c719b9bfe053994"
 
 workbox-background-sync@6.5.4:
   version "6.5.4"


### PR DESCRIPTION
Audit was failing from the following vulnerability https://github.com/advisories/GHSA-j8xg-fqg3-53r7

`word-wrap` dependency was replaced with working fork
