### PR TITLE
Add Reject Transfer Cancel Success page

### DIFF
--- a/app/assets/stylesheets/theme/panels.scss
+++ b/app/assets/stylesheets/theme/panels.scss
@@ -57,6 +57,10 @@ $brave-panels-borderRadius: 8px;
     &--collapsed {
       min-height: auto;
     }
+    &--spaced {
+      padding-top: $spacer * 2;
+      padding-bottom: $spacer * 2;
+    }
   }
 
   &--content {

--- a/app/mailers/publisher_mailer.rb
+++ b/app/mailers/publisher_mailer.rb
@@ -185,7 +185,7 @@ class PublisherMailer < ApplicationMailer
     @publisher_name = @channel.publisher.name
     @email = @channel.publisher.email
 
-    @transfer_url = token_reject_transfer_url(@channel, @channel.contest_token)
+    @transfer_url = reject_transfer_success_publishers_url(channel_name: @channel_name)
 
     mail_if_destination_exists(
       to: @email,

--- a/app/views/publishers/reject_transfer_success.html.slim
+++ b/app/views/publishers/reject_transfer_success.html.slim
@@ -1,0 +1,10 @@
+.single-panel--wrapper
+  = render "panel_flash_messages"
+  .single-panel--content
+    .single-panel--padded-content
+      .col-small-centered
+        = render "icon_circled_check"
+        .single-panel--wrapper--spaced
+          h3.single-panel= t ".title", channel_name: params[:channel_name]
+          p= t ".body", channel_name: params[:channel_name]
+          = link_to(t(".button"), root_path, class: "btn btn-block btn-primary")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -526,7 +526,11 @@ en:
     ensure_email:
       ensure_email: Authentication Attempt
       ensure_email_html: |
-        Press <strong>Continue</strong> to login as <br/><strong>'%{login_email}'</strong>.  
+        Press <strong>Continue</strong> to login as <br/><strong>'%{login_email}'</strong>.
+    reject_transfer_success:
+      title: "The %{channel_name} channel transfer has been canceled"
+      body: "You have rejected the request to transfer the channel, %{channel_name} to another publisher."
+      button: Go to Brave Creators
     change_email:
       login_email: Login Email
       login_email_message: We need your valid email address for account access and recovery purposes.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -499,7 +499,10 @@ ja:
       ensure_email: 認証を試みます
       ensure_email_html: |
         <strong>'%{login_email}'</strong> としてログインするには<strong>「続ける」</strong>を押してください
-
+    reject_transfer_success:
+      title: "%{channel_name}チャンネル移管はキャンセルされました"
+      body: "チャンネル%{channel_name}を別のサイト運営者に移管するリクエストを却下しました。"
+      button: 続ける
     change_email:
       login_email: ログインメールアドレス
       login_email_message: アカウントへのアクセスと復旧のために有効なメールアドレスが必要です。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
       patch :complete_signup
       post :create_new_untethered_referral_code
       get :choose_new_channel_type
+      get :reject_transfer_success
       get :security, to: "publishers/security#index"
       get :prompt_security, to: "publishers/security#prompt"
       get :settings, to: "publishers/settings#index"


### PR DESCRIPTION
Resolves https://github.com/brave-intl/creators-private-issues/issues/1660

When a user clicks the "Reject Transfer" button in the corresponding email, they will now be taken to a static success page.

## Screenshot
<img width="850" alt="Screenshot 2023-07-17 at 4 50 07 PM" src="https://github.com/brave-intl/publishers/assets/6961771/b062f2e4-4d4d-4943-9af5-3200e9b6b432">
