### PR TITLE
feat: allow user to delete account

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,10 @@
         "app/javascript/locale",
         "nextjs/src/messages",
         "public/creators-landing/src/locale"
-    ]
+    ],
+      "workbench.colorCustomizations": {
+      "activityBar.background": "#340e05",
+      "titleBar.activeBackground": "#FB542B",
+      "titleBar.activeForeground": "#FDFBF6"
+  },
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Rails.application.routes.draw do
       namespace :publishers do
         get :me
         post :update
+        delete :destroy
       end
     end
 

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit --incremental false"
   },
   "dependencies": {
-    "@brave/leo": "github:brave/leo#51a2b99bd8939658c1195e9ee83450911eb3b889",
+    "@brave/leo": "github:brave/leo#86be9379ea55a7e32b56beee05a4e57caa1c0da2",
     "axios": "^1.5.0",
     "clsx": "^2.0.0",
     "next": "^13.4.12",
@@ -45,6 +45,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-unused-imports": "^3.0.0",
+    "http-proxy": "^1.18.1",
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^29.6.1",
     "lint-staged": "^13.2.3",

--- a/nextjs/src/app/[locale]/publishers/settings/page.tsx
+++ b/nextjs/src/app/[locale]/publishers/settings/page.tsx
@@ -3,8 +3,10 @@
 import Button from '@brave/leo/react/button';
 import Checkbox from '@brave/leo/react/checkbox';
 import Dialog from '@brave/leo/react/dialog';
+import Input from '@brave/leo/react/input';
 import Toggle from '@brave/leo/react/toggle';
 import Head from 'next/head';
+import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useContext, useState } from 'react';
 import * as React from 'react';
@@ -21,6 +23,7 @@ export default function SettingsPage() {
   const [isModalOpen, setModalIsOpen] = useState(false);
   const [settings, setSettings] = useState<Partial<UserType>>(user);
   const [isEditMode, setIsEditMode] = useState(false);
+  const { push } = useRouter();
   const t = useTranslations();
 
   function updateAccountSettings(newSettings?) {
@@ -41,7 +44,8 @@ export default function SettingsPage() {
   }
 
   function deleteAccount() {
-    apiRequest('publishers', null, 'DELETE');
+    apiRequest('publishers/destroy', null, 'DELETE');
+    push('/');
   }
 
   function handleToggleChange(e: CustomEvent, name: string) {
@@ -115,9 +119,9 @@ export default function SettingsPage() {
               <label className='font-semibold'>
                 {t('Settings.index.contact.name')}
               </label>
-              <div className='mb-2'>
+              <div className='mb-2 sm:w-[400px]'>
                 {isEditMode ? (
-                  <input
+                  <Input
                     value={settings.name}
                     onChange={handleInputChange}
                     name='name'
@@ -131,9 +135,9 @@ export default function SettingsPage() {
               <label className='font-semibold'>
                 {t('Settings.index.contact.email')}
               </label>
-              <div>
+              <div className='sm:w-[400px]'>
                 {isEditMode ? (
-                  <input
+                  <Input
                     value={settings.email}
                     onChange={handleInputChange}
                     name='email'


### PR DESCRIPTION
Resolves https://github.com/brave-intl/creators-private-issues/issues/1698

## Summary
Allow users to delete their account via the settings page

* Also adds back in the .vscode directory
* Adds the (broken) Nala Input component 