### PR TITLE
fix: have docker correctly update node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,10 @@ services:
     build: nextjs/.
     command: npm run dev
     volumes:
+      - /app/node_modules # <-- try adding this!
       - type: bind
         source: ./nextjs
         target: /app
-      - /app/node_modules # <-- try adding this!
       - ./ssl:/ssl
     ports:
       - "5001:5001"


### PR DESCRIPTION
## Summary

We were having an issue where the node_modules directory was not effectively cached or shared between ours host system and the container. 

It looks like the issue was due to excluding node_modules too late in the process.