### PR TITLE
Use WHATWG URL API rather than deprecated url.parse

### DIFF
--- a/nextjs/scripts/create-local-server.js
+++ b/nextjs/scripts/create-local-server.js
@@ -1,13 +1,11 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 const httpProxy = require('http-proxy');
 const chalk = require('chalk');
-const { parse } = require('url');
 const next = require('next');
 const path = require('path');
 const fs = require('fs');
 const express = require('express');
 const { createServer } = require('https');
-var url = require('url');
 const PORT = 5001;
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -37,8 +35,8 @@ app
       return handle(req, res);
     });
 
-    const pubHost = `https://${process.env.PUBLISHERS_HOST}`;
-    const nextHost = `https://${process.env.NEXT_HOST}`
+    const pubHost = new URL(`https://${process.env.PUBLISHERS_HOST}`);
+    const nextHost = `https://${process.env.NEXT_HOST}`;
 
     // Proxy over to Rails
     expressApp.use(
@@ -54,12 +52,14 @@ app
         onProxyRes: (proxyRes, request, response) => {
           const redir = proxyRes.headers['location'];
           if (redir) {
-            const host = parse(redir).host;
-            if (`https://${host}` == pubHost) {
-              const newRedirUrlToProxy = `${nextHost}${
-                parse(redir).pathname
-              }`;
-              proxyRes.headers['location'] = newRedirUrlToProxy;
+            try {
+              const redirUrl = new URL(redir);
+              if (redirUrl.protocol === pubHost.protocol && redirUrl.host === pubHost.host) {
+                const newRedirUrlToProxy = `${nextHost}${redirUrl.pathname}`;
+                proxyRes.headers['location'] = newRedirUrlToProxy;
+              }
+            } catch (e) {
+              if (!e.code || e.code != "ERR_INVALID_URL") throw e;
             }
           }
         },


### PR DESCRIPTION
## Avoid url parse

#### Features

https://github.com/brave-intl/creators-private-issues/issues/1695

url.parse uses a lenient, non-standard algorithm for parsing URL strings.
It is prone to security issues such as host name spoofing and incorrect handling of usernames and passwords

This change maintains the previous behaviour of stripping the querystring
and hash from the URL before redirecting (just using the path).

#### How To Test

not sure

#### Pull Request Checklist

- [ ] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [ ] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [ ] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [ ] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [ ] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
