### PR TITLE
remove use of asset_url method

### DIFF
--- a/app/helpers/publishers_helper.rb
+++ b/app/helpers/publishers_helper.rb
@@ -373,9 +373,9 @@ module PublishersHelper
   def channel_type_icon_url(channel)
     case channel&.details
     when SiteChannelDetails
-      asset_url("publishers-home/website-icon_32x32.png")
+      "publishers-home/website-icon_32x32.png"
     else
-      asset_url("publishers-home/#{channel.type_display.downcase}-icon_32x32.png")
+      "publishers-home/#{channel.type_display.downcase}-icon_32x32.png"
     end
   end
 

--- a/app/views/admin/publishers/_channel.html.slim
+++ b/app/views/admin/publishers/_channel.html.slim
@@ -9,7 +9,7 @@
         small.text-muted TITLE
         .d-flex
           h5.m-0.font-weight-bold
-            img src=(channel_type_icon_url(channel)) width=16 height=16 class="mr-3"
+            = image_tag(channel_type_icon_url(channel), class: "mr-3", height: 16, width: 16)
             = link_to(channel.publication_title, channel.details.url, target: '_blank')
 
           - if channel.details.is_a?(SiteChannelDetails)

--- a/app/views/publishers/_channel.html.slim
+++ b/app/views/publishers/_channel.html.slim
@@ -3,7 +3,7 @@
     div class=("channel-panel channel-#{channel_verification_status(channel)}")
       .channel-panel--intro.mb-1
         .channel-panel--intro-icon
-          img src=(channel_type_icon_url(channel)) height=25
+          = image_tag(channel_type_icon_url(channel), class: "", height: 25)
         .channel-panel--intro-body
           = channel_type(channel).upcase
 


### PR DESCRIPTION
using `asset_url` instead of `image_tag` tries to load assets from `web:3000` instead of `localhost:5001` when using the new UI.