### PR TITLE
add redirect for 2fa prompt on signup

### DIFF
--- a/nextjs/src/lib/api.ts
+++ b/nextjs/src/lib/api.ts
@@ -22,6 +22,8 @@ export async function apiRequest(
       err.response.status === 422
     ) {
       window.location.replace('/log-in');
+    } else if ( err.response && err.response.status === 302 ){
+      err.response.data && err.response.data.location && window.location.replace(err.response.data.location);
     } else {
       console.log(err);
     }


### PR DESCRIPTION
Fixes issue noticed here: https://bravesoftware.slack.com/archives/C0KHGGEUW/p1727879448793799

We weren't redirecting to the 2fa prompt when a new user navigated to the homepage.  I added that back in.  

While next.js allows redirects on the front end, there doesn't seem to be any particularly good way of having the server redirect the front-end.  This may be necessary from time to time in reaction to information that exists on the server but doesn't exist on the front end (either because it would require an unnecessary api request to get the information, or because it's information we don't want exposed to the client.) I added a step to our API logic that allows for 302 redirects, in the same way we allow 400s requests to redirect the user to the login page.