### PR TITLE
update config to fix change in rails 7.2 only showing model object id…

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -110,6 +110,9 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # allow display of full model in rails console
+  config.active_record.attributes_for_inspect = :all
+
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,9 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
+  # allow display of full model in rails console
+  config.active_record.attributes_for_inspect = :all
+
   config.after_initialize do
     # Enable this if rotating keys for encrypted fields
     # Util::AttrEncrypted.monkey_patch_old_key_fallback

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -103,6 +103,9 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
+  # allow display of full model in rails console
+  config.active_record.attributes_for_inspect = :all
+
   config.after_initialize do
     # Enable this if rotating keys for encrypted fields
     # Util::AttrEncrypted.monkey_patch_old_key_fallback


### PR DESCRIPTION
Addresses default behavior as of rails 7.2 in the rails console.  Only being able to view the ID of the queried model, and not its data, makes debugging slow and tedious.