### PR TITLE
update yarn packages

### DIFF
--- a/.audit-ci.json
+++ b/.audit-ci.json
@@ -39,6 +39,7 @@
     "GHSA-78xj-cgh5-2h22",
     "GHSA-c429-5p7v-vgjp",
     "GHSA-cxjh-pqwp-8mfp|react-scripts>webpack-dev-server>http-proxy-middleware>http-proxy>follow-redirects",
-    "GHSA-67hx-6x53-jw92"
+    "GHSA-67hx-6x53-jw92",
+    "GHSA-76p7-773f-r4q5"
   ]
 }


### PR DESCRIPTION
Adding `GHSA-76p7-773f-r4q5` to allowlist because serialize-javascript has already been manually updated to the patched 6.0.2.  See https://github.com/brave-intl/publishers/pull/4609