### PR TITLE
store new email as pending and re-enable the confirmation flow

### DIFF
--- a/app/controllers/api/nextv1/publishers_controller.rb
+++ b/app/controllers/api/nextv1/publishers_controller.rb
@@ -24,12 +24,13 @@ class Api::Nextv1::PublishersController < Api::Nextv1::BaseController
 
   def update
     # If user enters current email address delete the pending email attribute
-    # update_params[:pending_email] = update_params[:pending_email]&.downcase
-    # update_params[:pending_email] = nil if update_params[:pending_email] == current_publisher.email
-    update_params_except_email = update_params.except(:pending_email)
-    success = current_publisher.update(update_params_except_email)
+    pending_email = update_params[:email]&.downcase
+    pending_email = nil if update_params[:email] == current_publisher.email
 
-    if success && update_params[:pending_email]
+    update_params_except_email = update_params.except(:email)
+    success = current_publisher.update(**update_params_except_email.merge(pending_email: pending_email))
+
+    if success && pending_email
       MailerServices::ConfirmEmailChangeEmailer.new(publisher: current_publisher).perform
     end
 

--- a/nextjs/src/app/[locale]/publishers/settings/page.tsx
+++ b/nextjs/src/app/[locale]/publishers/settings/page.tsx
@@ -175,7 +175,6 @@ export default function SettingsPage() {
                       value={settings.email}
                       onInput={(e) => handleInputChange(e, 'email')}
                       name='email'
-                      disabled={true}
                     />
                   ) : (
                     user.email


### PR DESCRIPTION
Resolves: https://github.com/brave-intl/creators-private-issues/issues/1905