### PR TITLE
specify rp_id

### DIFF
--- a/app/services/two_factor_auth/webauthn_verify_service.rb
+++ b/app/services/two_factor_auth/webauthn_verify_service.rb
@@ -26,22 +26,13 @@ module TwoFactorAuth
       )
 
       begin
-        if registration.u2f? # old registration format
-          assertion_response.verify(
-            Base64.urlsafe_decode64(session[:current_authentication][:challenge]),
-            domain,
-            public_key: Base64.urlsafe_decode64(registration.public_key),
-            sign_count: registration.counter,
-            rp_id: domain
-          )
-        else
-          assertion_response.verify(
-            Base64.urlsafe_decode64(session[:current_authentication][:challenge]),
-            domain,
-            public_key: Base64.urlsafe_decode64(registration.public_key),
-            sign_count: registration.counter
-          )
-        end
+        assertion_response.verify(
+          Base64.urlsafe_decode64(session[:current_authentication][:challenge]),
+          domain,
+          public_key: Base64.urlsafe_decode64(registration.public_key),
+          sign_count: registration.counter,
+          rp_id: URI.parse(domain).host
+        )
       rescue WebAuthn::VerificationError => e
         Rails.logger.debug("WebAuthn::Error! #{e}")
         return problem(e.message)


### PR DESCRIPTION
Resolves https://github.com/brave-intl/creators-private-issues/issues/1914

Fixes a bug introduced in https://github.com/brave-intl/publishers/pull/4753.  Reading through the webauthn code, we shouldn't need to specify an rp_id (it should read it from the `domain` variable we are already supplying), but apparently it's necessary.  Also removing the u2f check, since there's no longer a difference in the verify methods.