### PR TITLE
fix(feat): channel input allows an attacker arbitrary code

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -204,7 +204,16 @@ class Channel < ApplicationRecord
     if name == "twitch"
       Channel.twitch_channels.verified.where("twitch_channel_details.name": value).first
     elsif PROPERTIES.include?(name)
-      public_send(:"#{name}_channels").verified.where("#{name}_channel_details.#{name}_channel_id": value).first
+      method_mapping = {
+        "youtube" => :youtube_channels,
+        "twitch" => :twitch_channels,
+        "follower" => :follower_channels,
+        "video" => :video_channels,
+        "subscriber" => :subscriber_channels
+      }
+      method = method_mapping[name]
+      return nil unless method
+      send(method).verified.where("#{name}_channel_details.#{name}_channel_id": value).first
     else
       visible_site_channels_fully_verified.where("site_channel_details.brave_publisher_id": identifier).first
     end


### PR DESCRIPTION
https://github.com/brave-intl/publishers/blob/6f40d255b6bf1dee30e8c0921cec943763fbf35e/app/models/channel.rb#L207-L207

Fix the issue need to eliminate the dynamic invocation of methods using `public_send` with user-provided input. Instead, we can use a safer approach by mapping the `name` parameter to a predefined set of methods explicitly. This ensures that only expected methods are invoked, and user input cannot influence the method name dynamically.

Steps to implement the fix:
1. Replace the `public_send` call with a lookup in a predefined hash or case statement that maps valid `name` values to corresponding methods.
2. Ensure that the mapping is strictly controlled and immutable, preventing any unintended method invocation.
3. Update the `find_fully_verified_by_channel_identifier` method in `app/models/channel.rb` to use this safer approach.

Directly evaluating user input (an HTTP request parameter) as code without first sanitizing the input allows an attacker arbitrary code execution. This can occur when user input is passed to code that interprets it as an expression to be evaluated, using methods such as `Kernel.eval` or `Kernel.send`.






#### Pull Request Checklist

- [x] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [x] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [x] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [x] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [ ] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [x] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)
