### PR TITLE
Prod release: Block public API from serving unverified channels

### DIFF
--- a/app/controllers/api/nextv1/contribution_page_controller.rb
+++ b/app/controllers/api/nextv1/contribution_page_controller.rb
@@ -29,6 +29,10 @@ class Api::Nextv1::ContributionPageController < Api::Nextv1::BaseController
       return render json: {}, status: 404
     end
 
+    unless current_channel.verified?
+      return render json: {errors: "channel must be verified before customizing the contribution page"}, status: :unprocessable_entity
+    end
+
     permitted_params = params.permit(
       :contribution_page,
       :publicName,

--- a/app/controllers/api/nextv1/crypto_address_for_channels_controller.rb
+++ b/app/controllers/api/nextv1/crypto_address_for_channels_controller.rb
@@ -22,6 +22,10 @@ class Api::Nextv1::CryptoAddressForChannelsController < Api::Nextv1::BaseControl
     current_channel = current_publisher.channels.find(params[:channel_id])
     @errors = []
 
+    unless current_channel.verified?
+      return render(json: {errors: ["channel must be verified before attaching a wallet"]}, status: :unprocessable_entity)
+    end
+
     # check that the message is a valid nonce and delete after use
     valid_message = if Rails.cache.read(message) == current_publisher.id
       !!Rails.cache.delete(message)

--- a/app/controllers/api/nextv1/public_channel_controller.rb
+++ b/app/controllers/api/nextv1/public_channel_controller.rb
@@ -7,8 +7,11 @@ class Api::Nextv1::PublicChannelController < Api::Nextv1::BaseController
     channel_title = channel&.publication_title
     crypto_addresses = channel&.crypto_addresses&.pluck(:address, :chain)
 
-    # Handle the case when the resource is not found
-    if channel.nil? || crypto_addresses&.empty?
+    # Handle the case when the resource is not found or not yet verified.
+    # Returning data for unverified channels would allow any publisher to
+    # publish a spoofed contribution page (with an attacker-controlled wallet)
+    # for a domain they do not yet own.
+    if channel.nil? || !channel.verified? || crypto_addresses&.empty?
       return render json: {}, status: 404
     end
 

--- a/test/controllers/api/nextv1/crypto_address_for_channels_controller_test.rb
+++ b/test/controllers/api/nextv1/crypto_address_for_channels_controller_test.rb
@@ -144,4 +144,37 @@ class Api::Nextv1::CryptoAddressForChannelsControllerTest < ActionDispatch::Inte
 
     assert_equal true, Util::CryptoUtils.verify_ethereum_address(signature, address, message, @publisher)
   end
+
+  # -------------------------------------------------------------------
+  # Security regression: attaching a wallet to an unverified channel must
+  # be rejected so that the public contribution page cannot be spoofed.
+  # -------------------------------------------------------------------
+
+  test "should reject wallet attachment to an unverified channel" do
+    unverified_publisher = publishers(:default)
+    unverified_channel = channels(:default)
+    sign_out @publisher
+    sign_in unverified_publisher
+
+    assert_equal false, unverified_channel.verified?, "precondition: fixture channel must be unverified"
+
+    nonce = "test-nonce-#{SecureRandom.uuid}"
+    Rails.cache.write(nonce, unverified_publisher.id)
+    csrf_token = get_csrf_token
+
+    Util::CryptoUtils.stubs(:verify_ethereum_address).returns(true)
+
+    post "/api/nextv1/channels/#{unverified_channel.id}/crypto_address_for_channels",
+      params: {
+        chain: "ETH",
+        account_address: "0xE35fF99536f3B122aa1B9cDed8E090232831C93f",
+        message: nonce,
+        transaction_signature: "0x00"
+      },
+      headers: {"HTTP_ACCEPT" => "application/json", "X-CSRF-Token" => csrf_token}
+
+    assert_response :unprocessable_entity,
+      "Wallet attachment must be rejected for unverified channels (got #{response.status})"
+    assert_includes JSON.parse(response.body)["errors"].to_s, "verified"
+  end
 end

--- a/test/controllers/api/nextv1/public_channel_controller_test.rb
+++ b/test/controllers/api/nextv1/public_channel_controller_test.rb
@@ -1,0 +1,53 @@
+# typed: false
+
+require "test_helper"
+
+# Security regression tests for the unverified-channel public page vulnerability.
+#
+# Attack chain: a publisher registers any domain (e.g. mozilla.org), attaches a
+# wallet to the unverified channel, and the public contribution page is served
+# immediately — routing contributions to an attacker-controlled address and
+# displaying attacker-controlled branding before any domain ownership is proven.
+class Api::Nextv1::PublicChannelControllerTest < ActionDispatch::IntegrationTest
+  # -----------------------------------------------------------------------
+  # RED tests — document the vulnerability.  These assert the SECURE behavior
+  # that the fix must produce; they FAIL on the buggy controller and PASS after.
+  # -----------------------------------------------------------------------
+
+  test "public endpoint does NOT expose an unverified channel even when it has a wallet attached" do
+    unverified = channels(:default)
+    assert_equal false, unverified.verified?, "precondition: fixture must be unverified"
+    assert unverified.crypto_addresses.any?, "precondition: fixture must have a wallet to trigger the bug"
+
+    get "/api/nextv1/public_channel/#{unverified.public_identifier}"
+
+    assert_response :not_found,
+      "Unverified channel must not be served publicly (got #{response.status})"
+    body = JSON.parse(response.body)
+    assert body["crypto_addresses"].nil?,
+      "Response must not include wallet addresses for unverified channels"
+  end
+
+  test "public endpoint serves a verified channel normally" do
+    verified = channels(:verified)
+    assert_equal true, verified.verified?, "precondition: fixture must be verified"
+
+    get "/api/nextv1/public_channel/#{verified.public_identifier}"
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body["url"].present?, "Verified channel response must include url"
+  end
+
+  test "public endpoint returns 404 for an unverified channel looked up by public_name" do
+    unverified = channels(:default)
+    unverified.update_column(:public_name, "unverified_brand_test")
+
+    get "/api/nextv1/public_channel/unverified_brand_test"
+
+    assert_response :not_found,
+      "Unverified channel must not be found by public_name (got #{response.status})"
+  ensure
+    unverified.update_column(:public_name, nil)
+  end
+end


### PR DESCRIPTION
#### Features

Any publisher could register an arbitrary domain, attach a wallet, and get a live contribution page before completing domain verification. The public channel endpoint was missing a verified? check, letting it serve wallet addresses for domains the publisher does not yet own.

Primary fix: return 404 from PublicChannelController when channel is unverified. Defense-in-depth: block wallet attachment and banner customization for unverified channels at the write endpoints too.

#### How To Test

Adds regression tests for all three surfaces

#### Pull Request Checklist

- [X] Adequate test coverage exists to prevent regressions -- [Guide to Testing](https://guides.rubyonrails.org/testing.html)
- [X] XSS is mitigated -- [Guide to XSS Prevention](https://guides.rubyonrails.org/security.html#cross-site-scripting-xss)
- [X] No raw SQL -- [Guide to SQL Injection Prevention](https://guides.rubyonrails.org/security.html#sql-injection)
- [X] UI/UX is responsive -- [Guide to Responsive UI/UX](https://developers.google.com/web/fundamentals/design-and-ux/responsive/)
- [X] Integrated Matomo for new UI elements -- [Guide to Matomo](https://developer.matomo.org/guides/integrate-introduction)
- [X] Passes checklist for Progressive Web App -- [Guide to PWAs](https://developers.google.com/web/progressive-web-apps/checklist)


release of https://github.com/brave-intl/publishers/pull/5408
resolves https://github.com/brave-intl/creators-private-issues/issues/1954