### PR TITLE
fix: enforce 2FA step-up on Nextv1 API endpoints

### DIFF
--- a/app/controllers/api/nextv1/totp_authentications_controller.rb
+++ b/app/controllers/api/nextv1/totp_authentications_controller.rb
@@ -1,0 +1,42 @@
+# typed: ignore
+
+class Api::Nextv1::TotpAuthenticationsController < Api::Nextv1::BaseController
+  include PublishersHelper
+  include PendingActions
+
+  before_action :require_pending_action
+
+  # POST /api/nextv1/totp_authentications
+  # Verify TOTP code and execute pending step-up action
+  def create
+    pending_action = saved_pending_action
+    totp_registration = pending_action.publisher.totp_registration
+
+    unless totp_registration
+      render(json: {error: "totp_not_enabled"}, status: 400) && return
+    end
+
+    verified_at_timestamp = totp_registration.totp.verify(
+      params[:totp_password],
+      drift_ahead: 60,
+      drift_behind: 60,
+      after: totp_registration.last_logged_in_at,
+      at: Time.now - 30
+    )
+
+    if verified_at_timestamp
+      totp_registration.update!(last_logged_in_at: Time.at(verified_at_timestamp))
+      pending_action.execute! self
+    else
+      render(json: {error: "invalid_totp"}, status: 401)
+    end
+  end
+
+  private
+
+  def require_pending_action
+    unless session[:pending_action]
+      render(json: {error: "no_pending_action"}, status: 400)
+    end
+  end
+end

--- a/app/controllers/api/nextv1/two_factor_authentications_controller.rb
+++ b/app/controllers/api/nextv1/two_factor_authentications_controller.rb
@@ -1,0 +1,41 @@
+# typed: ignore
+
+class Api::Nextv1::TwoFactorAuthenticationsController < Api::Nextv1::BaseController
+  include PublishersHelper
+  include PendingActions
+
+  before_action :require_pending_action
+
+  # GET /api/nextv1/two_factor_authentications
+  # Returns 2FA challenge options (WebAuthn get options if U2F enabled)
+  def index
+    publisher = saved_pending_action.publisher
+
+    response_data = {
+      u2f_enabled: u2f_enabled?(publisher),
+      totp_enabled: totp_enabled?(publisher)
+    }
+
+    if u2f_enabled?(publisher)
+      get_options = WebAuthn::Credential.options_for_get(
+        allow: publisher.u2f_registrations.map(&:key_handle),
+        extensions: {appid: Rails.configuration.pub_secrets[:creators_full_host]}
+      )
+      session[:current_authentication] = {
+        challenge: get_options.challenge,
+        username: publisher.email
+      }
+      response_data[:webauthn_options] = get_options
+    end
+
+    render(json: response_data.to_json, status: 200)
+  end
+
+  private
+
+  def require_pending_action
+    unless session[:pending_action]
+      render(json: {error: "no_pending_action"}, status: 400)
+    end
+  end
+end

--- a/app/controllers/api/nextv1/u2f_authentications_controller.rb
+++ b/app/controllers/api/nextv1/u2f_authentications_controller.rb
@@ -1,0 +1,40 @@
+# typed: ignore
+
+class Api::Nextv1::U2fAuthenticationsController < Api::Nextv1::BaseController
+  include PublishersHelper
+  include PendingActions
+
+  before_action :require_pending_action
+
+  # POST /api/nextv1/u2f_authentications
+  # Verify WebAuthn/U2F assertion and execute pending step-up action
+  def create
+    pending_action = saved_pending_action
+    publisher = pending_action.publisher
+    domain = Rails.configuration.pub_secrets[:creators_full_host]
+
+    result = TwoFactorAuth::WebauthnVerifyService.build.call(
+      publisher: publisher,
+      webauthn_u2f_response: params[:webauthn_u2f_response],
+      domain: domain,
+      session: session
+    )
+
+    case result
+    when ::BSuccess
+      pending_action.execute! self
+    when ::BFailure
+      render(json: {error: "invalid_u2f"}, status: 401)
+    else
+      raise result
+    end
+  end
+
+  private
+
+  def require_pending_action
+    unless session[:pending_action]
+      render(json: {error: "no_pending_action"}, status: 400)
+    end
+  end
+end

--- a/app/services/pending_actions.rb
+++ b/app/services/pending_actions.rb
@@ -122,10 +122,11 @@ module PendingActions
       if context.two_factor_enabled?(current_publisher)
         save! context
         if context.class.name.include?("Nextv1")
-          execute! context
-          # context.render(json: {
-          #   error: '2fa_required'
-          # }, status: 200)
+          context.render(json: {
+            error: "2fa_required",
+            u2f_enabled: context.u2f_enabled?(current_publisher),
+            totp_enabled: context.totp_enabled?(current_publisher)
+          }, status: 200)
         else
           context.redirect_to context.two_factor_authentications_path
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,11 @@ Rails.application.routes.draw do
         delete :destroy
       end
 
+      # 2FA step-up verification endpoints for Nextv1 SPA
+      resources :two_factor_authentications, only: %i[index]
+      resources :totp_authentications, only: %i[create]
+      resources :u2f_authentications, only: %i[create]
+
       namespace :connection do
         resource :bitflyer_connection
         resource :uphold_connection, except: [:new]


### PR DESCRIPTION
## Summary
- **StepUpAction#step_up!** was calling `execute!` directly for Nextv1 controllers, bypassing 2FA entirely. The intended `2fa_required` JSON response was commented out since PR #4224 (Oct 2023).
- Uncomments the `2fa_required` response so Nextv1 step-up actions save to session and return a JSON challenge instead of executing immediately.
- Adds three new Nextv1 controllers mirroring the existing HTML 2FA verification flow:
  - `TwoFactorAuthenticationsController` — GET challenge options (WebAuthn get options if U2F enabled)
  - `TotpAuthenticationsController` — POST TOTP code verification
  - `U2fAuthenticationsController` — POST WebAuthn/U2F assertion verification
- Adds corresponding routes in the `nextv1` namespace.

## Affected routes
| Route | Action | Impact |
|-------|--------|--------|
| `DELETE /api/nextv1/publishers` | Account deletion | Now requires 2FA |
| `POST /api/nextv1/totp_registrations/create` | TOTP replacement | Now requires 2FA |
| `DELETE /api/nextv1/totp_registrations/destroy` | TOTP removal | Now requires 2FA |
| `POST /api/nextv1/u2f_registrations/create` | WebAuthn key add | Now requires 2FA |
| `DELETE /api/nextv1/u2f_registrations/destroy` | WebAuthn key remove | Now requires 2FA |

## Security
Fixes a 2FA bypass that allowed session-theft attackers to take over TOTP/U2F credentials without step-up verification on the Nextv1 (SPA) API.