### PR TITLE
fix: make reserved public name lookup case-insensitive

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -543,7 +543,7 @@ class Channel < ApplicationRecord
       errors.add(:public_name, "must only contain letters, numbers, dashes, and underscores")
     end
 
-    reserved = ReservedPublicName.find_by(public_name: public_name)
+    reserved = ReservedPublicName.find_by("LOWER(public_name) = ?", public_name.downcase)
     # names previously in use are released after 1 year
     if reserved && (reserved.permanent || reserved.created_at >= 1.year.ago)
       errors.add(:public_name, "already under use")

--- a/test/models/reserved_public_name_case_test.rb
+++ b/test/models/reserved_public_name_case_test.rb
@@ -1,0 +1,31 @@
+# typed: false
+
+require "test_helper"
+
+class ReservedPublicNameCaseTest < ActionDispatch::IntegrationTest
+  test "a reserved public name cannot be taken back by changing the case" do
+    channel = channels(:google_verified)
+    reserved = reserved_public_names(:temporary)
+
+    assert_equal "Slartybartfast", reserved.public_name
+    assert reserved.created_at >= 1.year.ago, "the reservation must still be active"
+
+    # same case, the reservation holds
+    channel.public_name = reserved.public_name
+    assert_not channel.valid?
+    assert_includes channel.errors[:public_name], "already under use"
+
+    # same name, one letter with another case — must also be blocked
+    channel.public_name = reserved.public_name.downcase
+    assert_not channel.valid?
+    assert_includes channel.errors[:public_name], "already under use"
+
+    # the public page downcase the query, so both cases resolve to the same channel
+    # (query copied from Api::Nextv1::PublicChannelController#show)
+    found = Channel.where(
+      "LOWER(public_name) = :query OR LOWER(public_identifier) = :query",
+      query: "Slartybartfast".downcase
+    ).first
+    assert_nil found
+  end
+end


### PR DESCRIPTION
Closes https://github.com/brave-intl/creators-private-issues/issues/1958

## Summary

`Channel#validate_public_url_unique` checked the `reserved_public_names` table with a case-sensitive `find_by(public_name:)` (`app/models/channel.rb:546`), while every other check uses `LOWER()`.

This mismatch let a verified creator bypass a reservation by flipping one letter's cases leading to redirecting tips to a different wallet address.

## Fix

Use `LOWER()` in the `find_by`, matching the case-insensitive behavior of the rest of the method. This handles both existing mixed-case rows and new ones without a data migration.

## Test

Adds `test/models/reserved_public_name_case_test.rb` asserting that both the exact-case and case-flipped forms of a reserved name are rejected. All 86 existing model tests continue to pass.

## Checklist

- [x] Production code fix (logic correction, not defense-in-depth)
- [x] Test added covering the bypass
- [x] Existing tests pass
- [ ] No migration required (lookup fix handles existing data)
