### PR TITLE
replace eth gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -177,7 +177,10 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "sprockets-rails", "3.5.2"
 gem "sprockets", "4.4.1"
 
-gem "eth", "~> 0.5"
+# Keccak-256 for EIP-191 signature recovery in Util::CryptoUtils. Replaces the
+# eth gem, whose rbsecp256k1 dependency pins rubyzip to a 2.x line that carries
+# CVE-2026-85396; recovery is done directly with OpenSSL secp256k1 instead.
+gem "keccak", "~> 1.3"
 gem "rbnacl"
 gem "base58"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,9 +145,6 @@ GEM
     bindex (0.8.1)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
-    bls12-381 (0.3.1)
-      bigdecimal
-      h2c (>= 0.2.1, < 0.3)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
     brakeman (8.0.6)
@@ -219,22 +216,10 @@ GEM
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
-    ecdsa (1.2.0)
     erb (6.0.7)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    eth (0.5.17)
-      base64 (~> 0.1)
-      bigdecimal (~> 3.1)
-      bls12-381 (~> 0.3)
-      forwardable (~> 1.3)
-      httpx (~> 1.6)
-      keccak (~> 1.3)
-      konstructor (~> 1.0)
-      openssl (~> 3.3)
-      rbsecp256k1 (~> 6.0)
-      scrypt (~> 3.0)
     execjs (2.10.1)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
@@ -251,28 +236,19 @@ GEM
     ffi (1.17.4-arm-linux-gnu)
     ffi (1.17.4-arm-linux-musl)
     ffi (1.17.4-arm64-darwin)
-    ffi-compiler (1.4.2)
-      ffi (>= 1.15.5)
-      rake
     font-awesome-rails (4.7.0.9)
       railties (>= 3.2, < 9.0)
-    forwardable (1.4.0)
     fugit (1.13.0)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     globalid (1.4.0)
       activesupport (>= 6.1)
     google-protobuf (3.25.8)
-    h2c (0.2.1)
-      ecdsa (~> 1.2.0)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
     highline (3.0.1)
     htmlentities (4.4.2)
-    http-2 (1.2.1)
-    httpx (1.8.0)
-      http-2 (>= 1.2.0)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.1.2)
@@ -305,7 +281,6 @@ GEM
     jwt (3.2.0)
       base64
     keccak (1.3.3)
-    konstructor (1.0.2)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
@@ -439,7 +414,6 @@ GEM
       racc
     pg (1.6.3)
     pg (1.6.3-arm64-darwin)
-    pkg-config (1.6.5)
     popper_js (2.11.8)
     pp (0.6.4)
       prettyprint
@@ -535,10 +509,6 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
-    rbsecp256k1 (6.0.0)
-      mini_portile2 (~> 2.8)
-      pkg-config (~> 1.5)
-      rubyzip (~> 2.3)
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -598,7 +568,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     ruby_http_client (3.6.0)
-    rubyzip (2.4.1)
+    rubyzip (3.6.0)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
     safety_net_attestation (0.5.0)
@@ -613,9 +583,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scrypt (3.1.0)
-      ffi-compiler (>= 1.0, < 2.0)
-      rake (~> 13)
     securerandom (0.4.1)
     selenium-webdriver (4.48.0)
       base64 (~> 0.2)
@@ -816,7 +783,6 @@ DEPENDENCIES
   dnsruby (~> 1.70)
   domain_name
   dotenv-rails (= 3.2.0)
-  eth (~> 0.5)
   faraday (= 2.14.3)
   faraday-retry (= 2.4.0)
   fastimage (~> 2.4.0)
@@ -825,6 +791,7 @@ DEPENDENCIES
   google-protobuf (~> 3.25)
   i18n-tasks (~> 1.1.0)
   importmap-rails (~> 2.0)
+  keccak (~> 1.3)
   letter_opener
   letter_opener_web (~> 3.0)
   listen (~> 3.9)
@@ -933,7 +900,6 @@ CHECKSUMS
   bindata (2.5.1) sha256=53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   binding_of_caller (2.0.0) sha256=e53eebf8428a85587aede7b43a83e7419eb85b8b690938a96aa330d03052d517
-  bls12-381 (0.3.1) sha256=d1525cd319c53f14178d54f355dfe1b4c572fbf5625965c1afccdc425b9896dc
   bootstrap (5.3.8) sha256=1c23b06df24ec28a0058ad90a0da93e260d2c0a5c453d7087f6bad428464742f
   brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   brotli (0.8.0) sha256=0c5a42046b3b603fb109656881147fd76064c034b7d19c1b4fcc32a093a4d55d
@@ -970,11 +936,9 @@ CHECKSUMS
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  ecdsa (1.2.0) sha256=b8f7c9541b6c587cbe37e705a1b76be6dc1e85336aa23ac3cf2f07b038bcec55
   erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
-  eth (0.5.17) sha256=5be9caa85b0643613010ae33c92e746a02ce376a35245e6eb5f491e80531f137
   execjs (2.10.1) sha256=abe0ae028467eb8e30c10814eb934d07876a691aae7e803d813b7ce5a75e73f1
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
@@ -985,19 +949,14 @@ CHECKSUMS
   ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
   ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
-  ffi-compiler (1.4.2) sha256=a9d69d5d9ced6f64776ddafa535867ad90e5740ad37bed7afb4de6e450da126e
   font-awesome-rails (4.7.0.9) sha256=b45044908fbf3178b8d84fbae415dae4b9bf847612bcb1170d88ed13842c8732
-  forwardable (1.4.0) sha256=f1cd40cc9812937980e1c76f1aa053660990a7c9b6a98fc37d945468afcce838
   fugit (1.13.0) sha256=a4f093fce740da52f216740a5041e2a594ea763cdb89e8b2754ca4399634ab18
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   google-protobuf (3.25.8) sha256=102c8500502e224a5daa7447bdd2c458a25a6c7b0bf5d8496a559ada131952b7
-  h2c (0.2.1) sha256=a53b7dfeb95660c97b615235ea1b29ec8e1856edc571845685682d94b6e8e227
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   highline (3.0.1) sha256=ca18b218fd581b1fae832f89bfeaf2b34d3a93429c44fd4411042ffce286f009
   htmlentities (4.4.2) sha256=bbafbdf69f2eca9262be4efef7e43e6a1de54c95eb600f26984f71d2fe96c5c3
-  http-2 (1.2.1) sha256=d290f3b7daa70b8be8cd2260306c01243c73ec4df9d598feadaf0ed26e00b9b7
-  httpx (1.8.0) sha256=10b300875be99cbc3497397278cf99632262567886f3582ee25ce492bdadbe2a
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   i18n-tasks (1.1.2) sha256=4dcfba49e52a623f30661cb316cb80d84fbba5cb8c6d88ef5e02545fffa3637a
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -1010,7 +969,6 @@ CHECKSUMS
   jsonapi-renderer (0.2.2) sha256=b5c44b033d61b4abdb6500fa4ab84807ca0b36ea0e59e47a2c3ca7095a6e447b
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   keccak (1.3.3) sha256=970dcb1e78b8c3129ba2baff8a5baa5cebf391136db1f4018e8ccc9130794557
-  konstructor (1.0.2) sha256=fd6ac9eb1dadc1e520e06042aa2ef0122d6a070e06cde86db5a54c0c7bfe2e31
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
@@ -1069,7 +1027,6 @@ CHECKSUMS
   parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
   pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
-  pkg-config (1.6.5) sha256=33f9f81c5322983d22b439b8b672f27777b406fea23bfec74ff14bbeb42ec733
   popper_js (2.11.8) sha256=f4b0be717fc0d50bdb3dbbc55788525a9e0e8f640b76c9971fc34ee609eadbd2
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   premailer (1.29.0) sha256=015f30c520701f3d47fd898886a3eaf4e5171efcc5fd239b872efd1ba61d3da0
@@ -1103,7 +1060,6 @@ CHECKSUMS
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbnacl (7.1.2) sha256=c58433e93b390a7b8c03a9da9e54f2de67e6cc3d6731553265299c6aac889a60
   rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
-  rbsecp256k1 (6.0.0) sha256=d38f563bfc6bcf3ce20c336a4798cc6990427f291e74c6817360363a72f11669
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   recaptcha (5.21.2) sha256=8f7bb6cc9f04c523fff3f38126b7c5f1314c35fcb3691fc8e70d2b464533c12a
   redis (6.0.0) sha256=de71c10edd106986b759ec7ecdd08b63b9c0ee7414a0d0c1da73d31ba2bccda6
@@ -1129,13 +1085,12 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   ruby_http_client (3.6.0) sha256=9308505d3a0421810d2dc012d79d986f7d360d5b02178641190849a22fd279f2
-  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
+  rubyzip (3.6.0) sha256=268994d44d62282d1cfd99bf10eae48d7267199158ad7ea3e1fee2da9458b695
   rufus-scheduler (3.9.2) sha256=55fa9e4db0ff69d7f38c804f17baba0c9bce5cba39984ae3c5cf6c039d1323b9
   safety_net_attestation (0.5.0) sha256=c8cd01dd550dbe8553862918af6355a04672db11d218ec96104ce3955293f2aa
   sass-rails (6.0.0) sha256=e0b6448ea1c7929fd5929fc7a8eb2d78045e44cc82fc0765a249d3fa1c5810d3
   sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e
   sassc-rails (2.1.2) sha256=5f4fdf3881fc9bdc8e856ffbd9850d70a2878866feae8114aa45996179952db5
-  scrypt (3.1.0) sha256=67fde35bc7e3b7fe906c5be9c242acf95fe4a886c89572f405f6b11df30aa6af
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.48.0) sha256=0c8376ebc8a0a4879343fe6fe6eccdcea76748611cd25de370b33eded2077a94
   semantic_range (3.1.1) sha256=508333196ef0c7ba33e79579d4df7eb0a41080595e6a655c2515b03d634ec4a9

--- a/app/controllers/api/nextv1/crypto_address_for_channels_controller.rb
+++ b/app/controllers/api/nextv1/crypto_address_for_channels_controller.rb
@@ -1,6 +1,5 @@
 class Api::Nextv1::CryptoAddressForChannelsController < Api::Nextv1::BaseController
   include PublishersHelper
-  include Eth
 
   def index
     current_channel = current_publisher.channels.find(params[:channel_id])

--- a/app/services/util/crypto_utils.rb
+++ b/app/services/util/crypto_utils.rb
@@ -1,9 +1,26 @@
-require "eth"
+require "openssl"
+require "digest/keccak"
 require "rbnacl"
 require "base58"
 
 class Util::CryptoUtils
-  include Eth
+  class SignatureError < StandardError; end
+
+  # Ethereum signs with secp256k1 and hashes with Keccak-256 -- the
+  # pre-standardisation padding, which is *not* the SHA3-256 that OpenSSL
+  # exposes, so the digest has to come from the keccak gem.
+  SECP256K1_GROUP = OpenSSL::PKey::EC::Group.new("secp256k1")
+  SECP256K1_ORDER = SECP256K1_GROUP.order
+
+  # r (32) + s (32) + v (1)
+  SIGNATURE_BYTES = 65
+
+  # 0x04 tag + x (32) + y (32)
+  PUBLIC_KEY_BYTES = 65
+
+  # EIP-191 personal_sign envelope. Binary so that it can be concatenated with
+  # a message of any encoding.
+  PERSONAL_PREFIX = "\x19Ethereum Signed Message:\n".b.freeze
 
   def self.verify_solana_address(signature, address, message, current_publisher)
     verify_key = RbNaCl::VerifyKey.new(Base58.base58_to_binary(address, :bitcoin))
@@ -14,12 +31,109 @@ class Util::CryptoUtils
   end
 
   def self.verify_ethereum_address(signature, address, message, current_publisher)
-    signature_pubkey = Eth::Signature.personal_recover message, signature
-    signature_address = Eth::Util.public_key_to_address signature_pubkey
+    signature_address = personal_recover_address(message, signature)
     # Eth addresses are case insensitive
-    signature_address.address.downcase == address.downcase
+    signature_address == address.to_s.downcase
   rescue => e
     LogException.perform(e, publisher: current_publisher)
     false
   end
+
+  # Recovers the address that produced an EIP-191 personal_sign signature.
+  # Returns a lowercase 0x-prefixed address; raises SignatureError if the
+  # signature is malformed or does not recover to a point on the curve.
+  def self.personal_recover_address(message, signature)
+    public_key_to_address(personal_recover(message, signature))
+  end
+
+  # Returns the 65-byte uncompressed public key that signed +message+.
+  def self.personal_recover(message, signature)
+    blob = hex_to_bin(signature)
+    unless blob.bytesize == SIGNATURE_BYTES
+      raise SignatureError, "signature must be #{SIGNATURE_BYTES} bytes, got #{blob.bytesize}"
+    end
+
+    r = decode_scalar(blob[0, 32], "r")
+    s = decode_scalar(blob[32, 32], "s")
+    recover_public_key(keccak256(prefixed_message(message)), r, s, recovery_id(blob.getbyte(64)))
+  end
+
+  # Keccak-256 of the public key minus its 0x04 tag; the address is the low 20
+  # bytes of that digest.
+  def self.public_key_to_address(public_key)
+    unless public_key.bytesize == PUBLIC_KEY_BYTES && public_key.getbyte(0) == 0x04
+      raise SignatureError, "expected a 65-byte uncompressed public key"
+    end
+
+    "0x#{keccak256(public_key[1, 64])[-20..].unpack1("H*")}"
+  end
+
+  # ECDSA public key recovery: Q = r^-1 (sR - eG), where R is the curve point
+  # whose x coordinate is r (offset by the group order when the recovery id
+  # says the x coordinate overflowed) and whose y parity is the low bit of the
+  # recovery id.
+  def self.recover_public_key(message_hash, r, s, recovery_id)
+    e = OpenSSL::BN.new(message_hash.unpack1("H*"), 16)
+    x = r + OpenSSL::BN.new((recovery_id / 2).to_s) * SECP256K1_ORDER
+    y_parity = (recovery_id & 1).zero? ? "02" : "03"
+
+    # Point.new validates that x is in the field and lands on the curve.
+    point = begin
+      OpenSSL::PKey::EC::Point.new(
+        SECP256K1_GROUP,
+        OpenSSL::BN.new(y_parity + x.to_s(16).rjust(64, "0"), 16)
+      )
+    rescue OpenSSL::PKey::EC::Point::Error, OpenSSL::BNError => error
+      raise SignatureError, "signature does not describe a curve point: #{error.message}"
+    end
+
+    r_inv = r.mod_inverse(SECP256K1_ORDER)
+    # mul(a, b) == a * point + b * generator
+    public_key = point.mul((s * r_inv) % SECP256K1_ORDER,
+      ((SECP256K1_ORDER - (e % SECP256K1_ORDER)) * r_inv) % SECP256K1_ORDER)
+    raise SignatureError, "recovered the point at infinity" if public_key.infinity?
+
+    public_key.to_octet_string(:uncompressed)
+  end
+
+  def self.prefixed_message(message)
+    body = message.to_s.b
+    PERSONAL_PREFIX + body.bytesize.to_s + body
+  end
+
+  def self.keccak256(data)
+    Digest::Keccak.digest(data, 256)
+  end
+
+  # Accepts 27/28 (the personal_sign convention), 0/1 (raw), and EIP-155
+  # chain-encoded values.
+  def self.recovery_id(v)
+    id = if v >= 35
+      (v - 35) % 2
+    elsif v >= 27
+      v - 27
+    else
+      v
+    end
+    raise SignatureError, "invalid recovery id from v=#{v}" unless (0..3).cover?(id)
+    id
+  end
+
+  def self.decode_scalar(bytes, name)
+    scalar = OpenSSL::BN.new(bytes.unpack1("H*"), 16)
+    if scalar.zero? || scalar >= SECP256K1_ORDER
+      raise SignatureError, "signature #{name} is outside the group order"
+    end
+    scalar
+  end
+
+  def self.hex_to_bin(hex)
+    hex = hex.to_s.strip
+    hex = hex[2..] if hex.start_with?("0x", "0X")
+    raise SignatureError, "signature is not valid hex" unless hex.match?(/\A\h*\z/) && hex.length.even?
+    [hex].pack("H*")
+  end
+
+  private_class_method :recover_public_key, :prefixed_message, :keccak256,
+    :recovery_id, :decode_scalar, :hex_to_bin
 end

--- a/test/controllers/api/nextv1/crypto_address_for_channels_controller_test.rb
+++ b/test/controllers/api/nextv1/crypto_address_for_channels_controller_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 require "shared/mailer_test_helper"
 require "webmock/minitest"
-require "eth"
 require "test_helpers/csrf_getter"
 
 class Api::Nextv1::CryptoAddressForChannelsControllerTest < ActionDispatch::IntegrationTest
@@ -139,10 +138,31 @@ class Api::Nextv1::CryptoAddressForChannelsControllerTest < ActionDispatch::Inte
     address = "0x3430E11a53fE270C0ce3997AfFf1Ba6F9B48b59F"
     message = "1686284137397"
 
-    Eth::Signature.expects(:personal_recover).with(message, signature).returns(address)
-    Eth::Util.expects(:public_key_to_address).with(address).returns(Eth::Address.new(address))
-
     assert_equal true, Util::CryptoUtils.verify_ethereum_address(signature, address, message, @publisher)
+  end
+
+  test "should reject an Ethereum signature from a different address" do
+    signature = "0xc6ed3f93f3ca79fc3ebd7548d4adb79ef70a5fbea35ed088ffe265389be4f65f4980e056316bedb515ffafe1dda3889f7e753c78d26dd16146e39ee7e62382021b"
+    other_address = "0x000000000000000000000000000000000000dEaD"
+    message = "1686284137397"
+
+    assert_equal false, Util::CryptoUtils.verify_ethereum_address(signature, other_address, message, @publisher)
+  end
+
+  test "should reject an Ethereum signature over a different message" do
+    signature = "0xc6ed3f93f3ca79fc3ebd7548d4adb79ef70a5fbea35ed088ffe265389be4f65f4980e056316bedb515ffafe1dda3889f7e753c78d26dd16146e39ee7e62382021b"
+    address = "0x3430E11a53fE270C0ce3997AfFf1Ba6F9B48b59F"
+
+    assert_equal false, Util::CryptoUtils.verify_ethereum_address(signature, address, "1686284137398", @publisher)
+  end
+
+  test "should reject a malformed Ethereum signature without raising" do
+    address = "0x3430E11a53fE270C0ce3997AfFf1Ba6F9B48b59F"
+    message = "1686284137397"
+
+    ["", "0xdeadbeef", "0x" + "00" * 65, "not-hex-at-all", nil].each do |signature|
+      assert_equal false, Util::CryptoUtils.verify_ethereum_address(signature, address, message, @publisher)
+    end
   end
 
   # -------------------------------------------------------------------


### PR DESCRIPTION
Eth has a transitive dependency on a vulnerable version of rubyzip (https://nvd.nist.gov/vuln/detail/cve-2026-85396).  It's not a frequently updated library so it's best to try and remove it entirely.